### PR TITLE
fix: Active Debate section - DisucssionIcon

### DIFF
--- a/apps/www/pages/dialog.js
+++ b/apps/www/pages/dialog.js
@@ -7,7 +7,8 @@ import {
   Editorial,
   inQuotes,
   Interaction,
-  mediaQueries
+  mediaQueries,
+  useColorContext
 } from '@project-r/styleguide'
 import {
   CDN_FRONTEND_BASE_URL,
@@ -75,6 +76,7 @@ const SUPPORTED_TABS = ['general', 'article']
 const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
   const { t } = useTranslation()
   const { query } = useRouter()
+  const [colorScheme] = useColorContext()
 
   const discussionContext = useDiscussion()
 
@@ -200,7 +202,10 @@ const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
                     >
                       {t('feedback/activeDiscussions/label')}
                       <span style={{ position: 'absolute', right: 0, top: -1 }}>
-                        <DiscussionIcon size={24} fill='primary' />
+                        <DiscussionIcon
+                          size={24}
+                          {...colorScheme.set('fill', 'primary')}
+                        />
                       </span>
                     </H3>
                     <ActiveDiscussions first={5} />

--- a/apps/www/pages/dialog.js
+++ b/apps/www/pages/dialog.js
@@ -3,7 +3,6 @@ import { css } from 'glamor'
 import {
   A,
   Center,
-  DiscussionIcon,
   Editorial,
   inQuotes,
   Interaction,
@@ -199,9 +198,6 @@ const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
                       }}
                     >
                       {t('feedback/activeDiscussions/label')}
-                      <span style={{ position: 'absolute', right: 0, top: -1 }}>
-                        <DiscussionIcon size={24} fill='primary' />
-                      </span>
                     </H3>
                     <ActiveDiscussions first={5} />
                   </Fragment>

--- a/apps/www/pages/dialog.js
+++ b/apps/www/pages/dialog.js
@@ -3,6 +3,7 @@ import { css } from 'glamor'
 import {
   A,
   Center,
+  DiscussionIcon,
   Editorial,
   inQuotes,
   Interaction,
@@ -198,6 +199,9 @@ const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
                       }}
                     >
                       {t('feedback/activeDiscussions/label')}
+                      <span style={{ position: 'absolute', right: 0, top: -1 }}>
+                        <DiscussionIcon size={24} fill='primary' />
+                      </span>
                     </H3>
                     <ActiveDiscussions first={5} />
                   </Fragment>


### PR DESCRIPTION
# Description

Remove the discussion-icon next to the "Aktive Debatten" heading. It is removed for two reasons:
1. Consistent headings on the page
2. The Icon had faulty styling when using darkmode (see screenshot below)
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30313631/152130230-74565f0e-78ba-41fb-8a72-d79a1137862e.png">

Instead of removing the icon completely, it might an option to add it next to the green numbers for each active debate. That way it would be consistent compared to how the amount of comments are displayed, for example, on the front. (See screenshot below for a comparison) 
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30313631/152130502-e48298fd-3b95-4ab1-a580-6610f1b93227.png">


# Screenshot

## Before

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30313631/152129763-bab5ee96-2ee6-490d-ba25-4c731ccfc497.png">

## After

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30313631/152129954-70751e4b-1ab6-4bc6-a018-6412500f2e9a.png">
