### PR TITLE
chore(commitlint): ignore node-version requirements when running commitlint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+yarn --ignore-engines commitlint --edit $1


### PR DESCRIPTION
@patrickvenetz could you please check if this also fixes the issues that you experienced?