### PR TITLE
www: fix notification settings section-titles

### DIFF
--- a/apps/www/components/Notifications/SubscribedDocuments.js
+++ b/apps/www/components/Notifications/SubscribedDocuments.js
@@ -7,7 +7,7 @@ import {
   plainButtonRule,
   A,
   Interaction,
-  useColorContext
+  useColorContext,
 } from '@project-r/styleguide'
 import { css } from 'glamor'
 import SubscribeCheckbox from './SubscribeCheckbox'
@@ -17,8 +17,8 @@ import { withMembership } from '../Auth/checkRoles'
 
 const styles = {
   checkboxes: css({
-    margin: '8px 0 16px'
-  })
+    margin: '8px 0 16px',
+  }),
 }
 
 const SECTIONS_ALWAYS_SHOWN = ONBOARDING_SECTIONS_REPO_IDS
@@ -41,7 +41,7 @@ const getVisibleSections = (sections, prevShown = []) =>
     section =>
       prevShown.find(s => s.id === section.id) ||
       getSubscriptionCount(section) ||
-      SECTIONS_ALWAYS_SHOWN.find(repoId => repoId === section.repoId)
+      SECTIONS_ALWAYS_SHOWN.find(repoId => repoId === section.repoId),
   )
 
 const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
@@ -55,12 +55,12 @@ const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
   }, [sectionNodes])
 
   const [visibleSections, setVisibleSections] = useState(
-    getVisibleSections(sectionsWithFormat || [])
+    getVisibleSections(sectionsWithFormat || []),
   )
 
   useEffect(() => {
     setVisibleSections(prevShown =>
-      getVisibleSections(sectionsWithFormat, prevShown)
+      getVisibleSections(sectionsWithFormat, prevShown),
     )
   }, [sectionsWithFormat])
 
@@ -68,7 +68,7 @@ const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
     sectionsWithFormat &&
     sectionsWithFormat.reduce(
       (reducer, section) => reducer + getSubscriptionCount(section),
-      0
+      0,
     )
 
   if (!sectionsWithFormat || !sectionsWithFormat.length) return null
@@ -77,12 +77,16 @@ const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
     <>
       <Interaction.P style={{ marginBottom: 16 }}>
         {t.pluralize('Notifications/settings/formats/summary', {
-          count: totalSubs
+          count: totalSubs,
         })}
       </Interaction.P>
       {(showAll ? sectionsWithFormat : visibleSections).map(section => (
         <div
-          {...colorScheme.set('color', section.meta?.color || 'textSoft')}
+          {...colorScheme.set(
+            'color',
+            section.meta?.color || 'textSoft',
+            'format',
+          )}
           key={section.id}
         >
           <TeaserSectionTitle small>{section.meta.title}</TeaserSectionTitle>
@@ -109,5 +113,5 @@ const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
 export default compose(
   withT,
   withMembership,
-  graphql(possibleSubscriptions)
+  graphql(possibleSubscriptions),
 )(SubscribedDocuments)


### PR DESCRIPTION
Related issue https://github.com/republik/plattform/issues/7

# Description

Fix a color-error in the notification-settings section-titles, by using the format mapping that can be enabled in the `colorscheme.set` method.

### Defined Format Mapping
<img width="715" alt="image" src="https://user-images.githubusercontent.com/30313631/152325081-a16e9611-65b6-4d17-b789-4d0405252586.png">

# Screenshots

## After

<img width="715" alt="image" src="https://user-images.githubusercontent.com/30313631/152324523-0fcba5b4-4c07-4f89-8bc4-749aace22a07.png">

## Before

<img width="715" alt="image" src="https://user-images.githubusercontent.com/30313631/152324738-ac43f49d-3269-429b-9240-0f765db485e1.png">

