### PR TITLE
Update userCanComment resolver to return false if the discussion has been closed.

### DIFF
--- a/apps/www/components/Discussion/CommentContainers/CommentContainer.tsx
+++ b/apps/www/components/Discussion/CommentContainers/CommentContainer.tsx
@@ -3,12 +3,12 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useState
+  useState,
 } from 'react'
 import {
   CommentNode,
   CommentProps,
-  readDiscussionCommentDraft
+  readDiscussionCommentDraft,
 } from '@project-r/styleguide'
 import { useTranslation } from '../../../lib/withT'
 import CommentLink, { getFocusHref } from '../shared/CommentLink'
@@ -35,7 +35,7 @@ const CommentContainer = ({
   comment,
   isLast,
   isBoard,
-  inRootCommentOverlay
+  inRootCommentOverlay,
 }: Props): ReactElement => {
   const { t } = useTranslation()
   const { me } = useMe()
@@ -44,7 +44,7 @@ const CommentContainer = ({
     id: discussionId,
     discussion,
     fetchMore,
-    overlays: { shareOverlay, featureOverlay }
+    overlays: { shareOverlay, featureOverlay },
   } = useDiscussion()
 
   const parentId = comment.id
@@ -72,8 +72,8 @@ const CommentContainer = ({
         actions: {
           reportCommentHandler,
           unpublishCommentHandler,
-          featureCommentHandler: featureOverlay.handleOpen
-        }
+          featureCommentHandler: featureOverlay.handleOpen,
+        },
       }),
     [
       t,
@@ -82,8 +82,8 @@ const CommentContainer = ({
       me?.roles,
       reportCommentHandler,
       unpublishCommentHandler,
-      featureOverlay.handleOpen
-    ]
+      featureOverlay.handleOpen,
+    ],
   )
 
   const loadRemainingAfter = discussion?.comments?.pageInfo?.endCursor
@@ -98,7 +98,7 @@ const CommentContainer = ({
     return fetchMore({
       discussionId,
       parentId,
-      after: loadRemainingAfter
+      after: loadRemainingAfter,
     })
   }, [discussionId, parentId, loadRemainingAfter, fetchMore, isBoard])
 
@@ -108,11 +108,12 @@ const CommentContainer = ({
       comment={comment}
       CommentLink={CommentLink}
       actions={{
-        handleReply: discussion.userCanComment
-          ? () => setIsReplying(true)
-          : undefined,
+        handleReply:
+          !discussion.closed && discussion.userCanComment
+            ? () => setIsReplying(true)
+            : undefined,
         handleLoadReplies: loadRemainingReplies,
-        handleShare: shareOverlay.shareHandler
+        handleShare: shareOverlay.shareHandler,
       }}
       voteActions={{
         handleUpVote: voteHandlers.upVoteCommentHandler,

--- a/apps/www/components/Discussion/CommentContainers/CommentContainer.tsx
+++ b/apps/www/components/Discussion/CommentContainers/CommentContainer.tsx
@@ -3,12 +3,12 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useState,
+  useState
 } from 'react'
 import {
   CommentNode,
   CommentProps,
-  readDiscussionCommentDraft,
+  readDiscussionCommentDraft
 } from '@project-r/styleguide'
 import { useTranslation } from '../../../lib/withT'
 import CommentLink, { getFocusHref } from '../shared/CommentLink'
@@ -35,7 +35,7 @@ const CommentContainer = ({
   comment,
   isLast,
   isBoard,
-  inRootCommentOverlay,
+  inRootCommentOverlay
 }: Props): ReactElement => {
   const { t } = useTranslation()
   const { me } = useMe()
@@ -44,7 +44,7 @@ const CommentContainer = ({
     id: discussionId,
     discussion,
     fetchMore,
-    overlays: { shareOverlay, featureOverlay },
+    overlays: { shareOverlay, featureOverlay }
   } = useDiscussion()
 
   const parentId = comment.id
@@ -72,8 +72,8 @@ const CommentContainer = ({
         actions: {
           reportCommentHandler,
           unpublishCommentHandler,
-          featureCommentHandler: featureOverlay.handleOpen,
-        },
+          featureCommentHandler: featureOverlay.handleOpen
+        }
       }),
     [
       t,
@@ -82,8 +82,8 @@ const CommentContainer = ({
       me?.roles,
       reportCommentHandler,
       unpublishCommentHandler,
-      featureOverlay.handleOpen,
-    ],
+      featureOverlay.handleOpen
+    ]
   )
 
   const loadRemainingAfter = discussion?.comments?.pageInfo?.endCursor
@@ -98,7 +98,7 @@ const CommentContainer = ({
     return fetchMore({
       discussionId,
       parentId,
-      after: loadRemainingAfter,
+      after: loadRemainingAfter
     })
   }, [discussionId, parentId, loadRemainingAfter, fetchMore, isBoard])
 
@@ -108,12 +108,11 @@ const CommentContainer = ({
       comment={comment}
       CommentLink={CommentLink}
       actions={{
-        handleReply:
-          !discussion.closed && discussion.userCanComment
-            ? () => setIsReplying(true)
-            : undefined,
+        handleReply: discussion.userCanComment
+          ? () => setIsReplying(true)
+          : undefined,
         handleLoadReplies: loadRemainingReplies,
-        handleShare: shareOverlay.shareHandler,
+        handleShare: shareOverlay.shareHandler
       }}
       voteActions={{
         handleUpVote: voteHandlers.upVoteCommentHandler,

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -1,13 +1,22 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
-module.exports = async ({ minInterval, id }, _, context) => {
+module.exports = async (discussion, _, context) => {
+  const { closed } = discussion
   const { user, pgdb } = context
 
+  if (closed) {
+    return false
+  }
+
   const isMember = Roles.userIsInRoles(user, ['member'])
+  if (!isMember) {
+    return false
+  }
+
   const isDebater = Roles.userIsInRoles(user, ['debater'])
   const hasActiveMembership =
     !!user && (await hasUserActiveMembership(user, pgdb))
 
-  return isMember && (hasActiveMembership || isDebater)
+  return hasActiveMembership || isDebater
 }


### PR DESCRIPTION
Closes #5 

# Description

Don't pass the reply-handler to the CommentNode if the discussion is closed. (Line 112)