### PR TITLE
Send tag value when requesting comment preview

### DIFF
--- a/apps/www/components/Discussion/DiscussionComposer/DiscussionComposer.tsx
+++ b/apps/www/components/Discussion/DiscussionComposer/DiscussionComposer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import {
   CommentComposer,
   CommentComposerPlaceholder,
-  readDiscussionCommentDraft
+  readDiscussionCommentDraft,
 } from '@project-r/styleguide'
 import PropTypes from 'prop-types'
 import { useDiscussion } from '../context/DiscussionContext'
@@ -24,7 +24,7 @@ const propTypes = {
   initialText: PropTypes.string,
   initialTagValue: PropTypes.string,
   initialActiveState: PropTypes.bool,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 }
 
 const DiscussionComposer = ({
@@ -37,7 +37,7 @@ const DiscussionComposer = ({
   initialText,
   initialTagValue,
   initialActiveState,
-  placeholder
+  placeholder,
 }: PropTypes.InferProps<typeof propTypes>) => {
   const { t } = useTranslation()
 
@@ -47,7 +47,7 @@ const DiscussionComposer = ({
 
   const {
     preferences,
-    updateDiscussionPreferencesHandler
+    updateDiscussionPreferencesHandler,
   } = useDiscussionPreferences(discussionId)
 
   const submitCommentHandler = useSubmitCommentHandler()
@@ -82,24 +82,24 @@ const DiscussionComposer = ({
       if (automaticCredential) {
         await updateDiscussionPreferencesHandler(
           false,
-          automaticCredential.description
+          automaticCredential.description,
         )
       }
 
       let response
 
       if (!commentId && !parentId) {
-        // New root comment or a reply to a comment
+        // New root comment
         response = await submitCommentHandler(value, tags, {
           discussionId,
-          parentId
+          parentId,
         })
       } else if (!commentId && parentId) {
-        // New root comment or a reply to a comment
+        // Reply to a comment
         // No tags are passed since responses should not have tags!
         response = await submitCommentHandler(value, [], {
           discussionId,
-          parentId
+          parentId,
         })
       } else {
         // Edit a comment
@@ -107,11 +107,11 @@ const DiscussionComposer = ({
       }
 
       return {
-        ok: response
+        ok: response,
       }
     } catch (err) {
       return {
-        error: err
+        error: err,
       }
     }
   }
@@ -147,14 +147,17 @@ const DiscussionComposer = ({
           secondaryActions={<SecondaryActions isReply={!!parentId} />}
           displayAuthor={{
             ...displayAuthor,
-            credential: displayAuthor?.credential || automaticCredential
+            credential: displayAuthor?.credential || automaticCredential,
           }}
           placeholder={placeholder}
           maxLength={rules?.maxLength}
           tags={tags}
           initialText={initialText}
           initialTagValue={
-            tags?.length > 0 ? initialTagValue ?? activeTag : undefined
+            // In case a reply is being composed, no tag-values should be passed
+            !parentId && tags?.length > 0
+              ? initialTagValue ?? activeTag
+              : undefined
           }
         />
       ) : (

--- a/apps/www/components/Discussion/graphql/queries/PreviewCommentQuery.graphql.ts
+++ b/apps/www/components/Discussion/graphql/queries/PreviewCommentQuery.graphql.ts
@@ -7,6 +7,7 @@ export type PreviewCommentQueryVariables = {
   content: string
   parentId?: string
   id?: string
+  tags?: string[]
 }
 
 export type PreviewCommentQuery = {
@@ -21,16 +22,19 @@ export const PREVIEW_COMMENT_QUERY = gql`
     $content: String!
     $parentId: ID
     $id: ID
+    $tags: [String!]
   ) {
     commentPreview(
       content: $content
       discussionId: $discussionId
       parentId: $parentId
       id: $id
+      tags: $tags
     ) {
       id
       content
       contentLength
+      tags
       updatedAt
       createdAt
       embed {

--- a/apps/www/components/Discussion/helpers/usePreviewCommentHandler.ts
+++ b/apps/www/components/Discussion/helpers/usePreviewCommentHandler.ts
@@ -3,13 +3,13 @@ import { useApolloClient } from '@apollo/client'
 import {
   PREVIEW_COMMENT_QUERY,
   PreviewCommentQuery,
-  PreviewCommentQueryVariables
+  PreviewCommentQueryVariables,
 } from '../graphql/queries/PreviewCommentQuery.graphql'
 import { errorToString } from '../../../lib/utils/errors'
 import { useDiscussion } from '../context/DiscussionContext'
 
 export type PreviewCommentHandler = (
-  variables: PreviewCommentQueryVariables
+  variables: PreviewCommentQueryVariables,
 ) => Promise<PreviewCommentQuery['commentPreview']>
 
 function usePreviewCommentHandler(): PreviewCommentHandler {
@@ -17,14 +17,14 @@ function usePreviewCommentHandler(): PreviewCommentHandler {
   const { query } = useApolloClient()
 
   return async (
-    variables: Omit<PreviewCommentQueryVariables, 'id'>
+    variables: Omit<PreviewCommentQueryVariables, 'id'>,
   ): Promise<PreviewCommentQuery['commentPreview']> => {
     return await query<PreviewCommentQuery, PreviewCommentQueryVariables>({
       query: PREVIEW_COMMENT_QUERY,
       variables: {
         ...variables,
-        discussionId: id
-      }
+        discussionId: id,
+      },
     })
       .then(result => result?.data?.commentPreview)
       .catch(errorToString)

--- a/packages/styleguide/src/components/Discussion/Composer/CommentComposer.js
+++ b/packages/styleguide/src/components/Discussion/Composer/CommentComposer.js
@@ -18,7 +18,7 @@ import { fontStyles } from '../../Typography'
 const styles = {
   root: css({}),
   background: css({
-    position: 'relative'
+    position: 'relative',
   }),
   textArea: css({
     display: 'block',
@@ -31,33 +31,33 @@ const styles = {
     border: 'none',
     outline: 'none',
     boxSizing: 'border-box',
-    ...convertStyleToRem(serifRegular16)
+    ...convertStyleToRem(serifRegular16),
   }),
   textAreaLimit: css({
-    paddingBottom: '28px'
+    paddingBottom: '28px',
   }),
   maxLengthIndicator: css({
     ...convertStyleToRem(sansSerifRegular12),
     lineHeight: 1,
     position: 'absolute',
     bottom: 6,
-    left: 8
+    left: 8,
   }),
   withBorderBottom: css({
     borderBottomWidth: 1,
-    borderBottomStyle: 'solid'
+    borderBottomStyle: 'solid',
   }),
   hints: css({
-    marginTop: 6
+    marginTop: 6,
   }),
   previewWrapper: css({
-    padding: '8px'
+    padding: '8px',
   }),
   previewLabel: css({
     ...fontStyles.sansSerifMedium18,
     display: 'block',
-    marginBottom: '16px'
-  })
+    marginBottom: '16px',
+  }),
 }
 
 const propTypes = {
@@ -88,7 +88,7 @@ const propTypes = {
 
   isBoard: PropTypes.bool,
   autoFocus: PropTypes.bool,
-  hideHeader: PropTypes.bool
+  hideHeader: PropTypes.bool,
 }
 
 export const CommentComposer = ({
@@ -139,14 +139,14 @@ export const CommentComposer = ({
   const [preview, setPreview] = useState({
     loading: false,
     error: null,
-    comment: null
+    comment: null,
   })
 
   /*
    * Synchronize the text with localStorage, and restore it from there if not otherwise
    * provided through props. This way the user won't lose their text if the browser
    * crashes or if they inadvertently close the composer.
-   * 
+   *
    * This is only done when not editing. Edits are currently not supported by the store.
    */
   const isEditing = !!commentId
@@ -177,25 +177,26 @@ export const CommentComposer = ({
     setPreview({
       loading: true,
       error: null,
-      comment: null
+      comment: null,
     })
     try {
       const result = await onPreviewComment({
         discussionId,
         parentId,
         content: text,
-        id: commentId
+        id: commentId,
+        tags: tagValue ? [tagValue] : undefined,
       })
       setPreview({
         loading: false,
         error: null,
-        comment: result
+        comment: result,
       })
     } catch (e) {
       setPreview({
         loading: false,
         error: e,
-        comment: null
+        comment: null,
       })
     }
   }
@@ -239,7 +240,7 @@ export const CommentComposer = ({
    */
   const [{ loading, error }, setSubmit] = React.useState({
     loading: false,
-    error: undefined
+    error: undefined,
   })
   const submitHandler = () => {
     if (root.current) {
@@ -273,7 +274,7 @@ export const CommentComposer = ({
               setSubmit({ loading: false, error })
             }
           }
-        }
+        },
       )
     }
   }
@@ -283,10 +284,10 @@ export const CommentComposer = ({
       css({
         color: colorScheme.getCSSColor('textSoft'),
         '::-webkit-input-placeholder': {
-          color: colorScheme.getCSSColor('textSoft')
-        }
+          color: colorScheme.getCSSColor('textSoft'),
+        },
       }),
-    [colorScheme]
+    [colorScheme],
   )
 
   return (
@@ -312,7 +313,11 @@ export const CommentComposer = ({
                 {...styles.withBorderBottom}
                 {...colorScheme.set('borderColor', 'default')}
               >
-                <Tags tags={tags} onChange={setSelectedTagValue} value={tagValue} />
+                <Tags
+                  tags={tags}
+                  onChange={setSelectedTagValue}
+                  value={tagValue}
+                />
               </div>
             )}
             <>
@@ -353,8 +358,7 @@ export const CommentComposer = ({
                   t={t}
                   comment={{
                     ...preview.comment,
-                    tags: tags ? [tagValue] : undefined,
-                    displayAuthor
+                    displayAuthor,
                   }}
                   isExpanded
                   isPreview
@@ -416,7 +420,7 @@ const MaxLengthIndicator = ({ maxLength, length }) => {
       {...styles.maxLengthIndicator}
       {...colorScheme.set(
         'color',
-        remaining < 0 ? 'error' : remaining < 21 ? 'text' : 'textSoft'
+        remaining < 0 ? 'error' : remaining < 21 ? 'text' : 'textSoft',
       )}
     >
       {remaining}


### PR DESCRIPTION
Fixes #6 

## Description

The tag value is now passed to the preview-handler and no initial tag-value is set, if a composer is opened to compose a reply.