### PR TITLE
fix(Discussion): unsafe localStorage.getItem

### DIFF
--- a/packages/styleguide/src/components/Discussion/Composer/CommentComposer.js
+++ b/packages/styleguide/src/components/Discussion/Composer/CommentComposer.js
@@ -154,11 +154,7 @@ export const CommentComposer = ({
     if (initialText) {
       return initialText
     } else if (!isEditing) {
-      try {
-        return readDraft(discussionId, parentId) ?? ''
-      } catch (e) {
-        return ''
-      }
+      return readDraft(discussionId, parentId) || ''
     } else {
       return ''
     }
@@ -219,16 +215,12 @@ export const CommentComposer = ({
 
   textRef.current = text
 
-  const onChangeText = ev => {
+  const onChangeText = (ev) => {
     const nextText = ev.target.value
     setText(nextText)
-    setHints(hintValidators.map(fn => fn(nextText)).filter(Boolean))
+    setHints(hintValidators.map((fn) => fn(nextText)).filter(Boolean))
     if (!isEditing) {
-      try {
-        writeDraft(discussionId, parentId, ev.target.value)
-      } catch (e) {
-        /* Ignore errors */
-      }
+      writeDraft(discussionId, parentId, ev.target.value)
     }
   }
 
@@ -258,11 +250,7 @@ export const CommentComposer = ({
 
           if (ok) {
             if (!isEditing) {
-              try {
-                deleteDraft(discussionId, parentId)
-              } catch (e) {
-                /* Ignore */
-              }
+              deleteDraft(discussionId, parentId)
             }
             onClose()
 

--- a/packages/styleguide/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/packages/styleguide/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -1,8 +1,8 @@
 /**
  * The key in localStorage under which we store the drafts. Keyed by the discussion id.
  */
- export const commentComposerStorageKey = discussionId =>
- `commentComposerText:${discussionId}`
+export const commentComposerStorageKey = (discussionId) =>
+  `commentComposerText:${discussionId}`
 
 /**
  * Load a stored draft an validate the schema.
@@ -10,8 +10,10 @@
  * @returns {{replies}|{text}|any|undefined}
  */
 function loadStoredDraftsObject(key) {
-  if (typeof localStorage === 'undefined') return undefined
-  const storedValue = localStorage.getItem(key)
+  let storedValue
+  try {
+    storedValue = localStorage.getItem(key)
+  } catch (e) {}
   if (!storedValue) return undefined
 
   try {
@@ -30,7 +32,9 @@ function loadStoredDraftsObject(key) {
     const newValue = createDraftsObject()
     // assume the legacy-draft is a comment-draft -> save in text property
     newValue.text = storedValue
-    localStorage.setItem(key, JSON.stringify(newValue))
+    try {
+      localStorage.setItem(key, JSON.stringify(newValue))
+    } catch (e) {}
     return newValue
   }
 }
@@ -39,7 +43,7 @@ function loadStoredDraftsObject(key) {
 function createDraftsObject() {
   return {
     text: null,
-    replies: {}
+    replies: {},
   }
 }
 
@@ -50,7 +54,7 @@ function createDraftsObject() {
  */
 export function readDraft(discussionID, commentID) {
   const storedDrafts = loadStoredDraftsObject(
-    commentComposerStorageKey(discussionID)
+    commentComposerStorageKey(discussionID),
   )
   if (!storedDrafts) return undefined
 
@@ -83,7 +87,9 @@ export function writeDraft(discussionID, commentID, value) {
     drafts.text = value
   }
 
-  localStorage.setItem(storageKey, JSON.stringify(drafts))
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(drafts))
+  } catch (e) {}
 }
 
 /**
@@ -106,9 +112,13 @@ export function deleteDraft(discussionID, commentID) {
 
   // If the drafts-object is empty delete it all together
   if (!drafts.text && Object.keys(drafts.replies).length === 0) {
-    localStorage.removeItem(storageKey)
+    try {
+      localStorage.removeItem(storageKey)
+    } catch (e) {}
   } else {
     // If the drafts-object is not empty update it
-    localStorage.setItem(storageKey, JSON.stringify(drafts))
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(drafts))
+    } catch (e) {}
   }
 }


### PR DESCRIPTION
Some versions of safari have a `localStorage` object but no `getItem` function.

While some `readDraft` were wrapped in a try block, a `readDiscussionCommentDraft` was not (my fault). However I think in code paths we ignore broken local storage we should do the try catch everywhere we interact with it instead of assuming that our function is wrapped in a silent try catch as a whole. Wrapping the whole function also hides coding errors that are unrelated to local storage being available.  

<img width="1438" alt="Screenshot 2022-02-04 at 12 32 52" src="https://user-images.githubusercontent.com/410211/152522272-3b840815-e65f-464f-8107-de2e819947a8.png">
<img width="1438" alt="Screenshot 2022-02-04 at 12 33 11" src="https://user-images.githubusercontent.com/410211/152522282-ddbabbab-405c-4763-a31c-451278fa7925.png">

