### PR TITLE
Add eslint fix to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [
+      "eslint --fix",
       "prettier --write"
     ]
   },


### PR DESCRIPTION
# Description

Surprisingly this works even though ESLint isn't actually installed inside the the root-package.
(Small fix to get ESlint running again before unifying the configurations)