### PR TITLE
Styleguide emit type declarations

### DIFF
--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "dist/lib.js",
   "module": "src/lib.ts",
+  "types": "dist/lib.d.ts",
   "engines": {
     "node": "^14.4.0"
   },
@@ -108,7 +109,7 @@
     "build:docs": "react-scripts build",
     "start": "serve -s build",
     "dev": "concurrently yarn:dev:lib yarn:dev:docs",
-    "dev:lib": "tsc -w --project tsconfig.dist.json",
+    "dev:lib": "tsc -w --project tsconfig.json",
     "dev:docs": "BROWSER=none PORT=3003 react-scripts start",
     "test": "CI=true react-scripts test",
     "test:dev": "react-scripts test",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -109,7 +109,7 @@
     "build:docs": "react-scripts build",
     "start": "serve -s build",
     "dev": "concurrently yarn:dev:lib yarn:dev:docs",
-    "dev:lib": "tsc -w --project tsconfig.json",
+    "dev:lib": "tsc -w --project tsconfig.dist.json",
     "dev:docs": "BROWSER=none PORT=3003 react-scripts start",
     "test": "CI=true react-scripts test",
     "test:dev": "react-scripts test",

--- a/packages/styleguide/tsconfig.dist.json
+++ b/packages/styleguide/tsconfig.dist.json
@@ -1,9 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "module": "commonjs",
-    "sourceMap": false,
-    "declarationMap": false
+    "noEmit": false,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "declarationMap": true
   },
   "include": [
     "src"

--- a/packages/styleguide/tsconfig.dist.json
+++ b/packages/styleguide/tsconfig.dist.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
     "module": "commonjs",
-    "noEmit": false
+    "sourceMap": false,
+    "declarationMap": false
   },
   "include": [
     "src"

--- a/packages/styleguide/tsconfig.json
+++ b/packages/styleguide/tsconfig.json
@@ -1,29 +1,24 @@
 {
   "name": "tsconfig",
   "compilerOptions": {
-    "outDir": "./dist",
     "target": "es5",
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
-    "sourceMap": true,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "declarationDir": "./dist/types",
-    "declarationMap": true,
-    "noEmit": true
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "src"

--- a/packages/styleguide/tsconfig.json
+++ b/packages/styleguide/tsconfig.json
@@ -1,24 +1,28 @@
 {
   "name": "tsconfig",
   "compilerOptions": {
+    "outDir": "./dist",
     "target": "es5",
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
+    "sourceMap": true,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "declarationMap": true,
   },
   "include": [
     "src"

--- a/packages/styleguide/tsconfig.json
+++ b/packages/styleguide/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": false,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
-    "module": "CommonJS",
+    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -23,6 +23,7 @@
     "declaration": true,
     "declarationDir": "./dist/types",
     "declarationMap": true,
+    "noEmit": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## Description

Back when we used rollup, a plugin handled the generation of the type declarations.
Due to the removal of rollup, types were no longer emitted. 

With this PR the config was updated to emit type declarations again. 
Also source-maps for both the JS and the TS declaration will now be generated when running dev:lib.