### PR TITLE
Fix Series Meta Data Issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.exclude": {
+    "**/.next": true
+  }
+}

--- a/apps/www/lib/apollo/apolloClient.ts
+++ b/apps/www/lib/apollo/apolloClient.ts
@@ -25,13 +25,6 @@ type Options = {
   onResponse?: any
 }
 
-function mergeNullableData(existing, incoming) {
-  // only merge truthy objects
-  if (!existing || !incoming) return incoming
-
-  return { ...existing, ...incoming }
-}
-
 function createApolloClient(
   options: Options = {},
 ): ApolloClient<NormalizedCacheObject> {
@@ -40,21 +33,15 @@ function createApolloClient(
     ssrMode: !process.browser,
     cache: new InMemoryCache({
       typePolicies: {
-        Document: {
-          fields: {
-            // Since Meta doesn't have a key-field, update cached data
-            // Source: https://www.apollographql.com/docs/react/caching/cache-field-behavior/#merging-non-normalized-objects
-            meta: {
-              merge: (existing, incoming) => {
-                return deepMerge({}, existing, incoming)
-              },
-            },
-          },
+        // Since Meta doesn't have a key-field, update cached data
+        // Source: https://www.apollographql.com/docs/react/caching/cache-field-behavior/#merging-non-normalized-objects
+        Meta: {
+          merge: true,
         },
         Discussion: {
           fields: {
             userPreference: {
-              merge: mergeNullableData,
+              merge: true,
             },
           },
         },


### PR DESCRIPTION
After navigating around a series it would sometimes not properly load more than the two public episodes:

https://user-images.githubusercontent.com/410211/153433798-e222b322-a39f-47ad-a407-296a378e9e91.mp4

After a lot of debugging I errored it in that meta objects where not properly merged. While the exact reason our custom merged caused issues remains unclear to me using the build in merge hints seem to work like a charm:

https://user-images.githubusercontent.com/410211/153434371-292abdff-8e2e-4811-b27d-58cecaac43c4.mp4

> [Configuring merge functions for types rather than fields](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#configuring-merge-functions-for-types-rather-than-fields)
> Beginning with Apollo Client 3.3, you can avoid having to configure merge functions for lots of different fields that might hold an Author object, and instead put the merge configuration in the Author type policy:

Merging a whole type where ever used seems to also be a very nice new feature in apollo.