### PR TITLE
feat(documents): prepend format external base url if external base url differs

### DIFF
--- a/packages/backend-modules/search/lib/Documents.js
+++ b/packages/backend-modules/search/lib/Documents.js
@@ -413,6 +413,16 @@ const addRelatedDocs = async ({
 
   relatedDocs = relatedDocs.concat(variousRelatedDocs)
 
+  // resolve formats for all related docs
+  const { docs: relatedFormatDocs } = await loadLinkedMetaData({
+    context,
+    repoIds: relatedDocs.map((d) => getRepoId(d.meta.format).repoId),
+    scheduledAt,
+    ignorePrepublished,
+  })
+
+  relatedDocs = relatedDocs.concat(relatedFormatDocs)
+
   debug({
     numDocs: docs.length,
     numUserIds: userIds.length,


### PR DESCRIPTION
Prepends a given format `externalBaseUrl` on all links if `externalBaseUrl` in requested document differs.