### PR TITLE
Fix Statement Focus

### DIFF
--- a/apps/www/components/Testimonial/List.js
+++ b/apps/www/components/Testimonial/List.js
@@ -29,6 +29,7 @@ import {
   useColorContext,
 } from '@project-r/styleguide'
 import { withRouter } from 'next/router'
+import ErrorMessage from '../ErrorMessage'
 
 const { P } = Interaction
 
@@ -242,7 +243,7 @@ export class List extends Component {
         this.setState(() => ({
           columns,
           open: {
-            0: this.props.focus && this.props.statements[0].id,
+            0: this.props.focus,
           },
         }))
       }
@@ -330,6 +331,7 @@ export class List extends Component {
       minColumns,
       showCredentials,
       share,
+      serverContext,
     } = this.props
     const { columns, open } = this.state
 
@@ -347,7 +349,12 @@ export class List extends Component {
         render={() => {
           const items = []
           const lastIndex = statements.length - 1
-          const focusItem = focus && statements[0]
+          const focusItem = statements[0]?.id === focus ? statements[0] : null
+
+          const hasNotFoundFocus = focus && !focusItem
+          if (hasNotFoundFocus && serverContext) {
+            serverContext.res.statusCode = 404
+          }
 
           const singleRowOpenItem =
             singleRow &&
@@ -453,6 +460,7 @@ export class List extends Component {
 
           return (
             <Fragment>
+              {hasNotFoundFocus && <ErrorMessage error={t('statement/404')} />}
               <div {...gridStyles} ref={this.ref}>
                 {!!isPage && <Meta data={metaData} />}
                 {items}
@@ -586,7 +594,7 @@ class Container extends Component {
     this.state = {}
   }
   render() {
-    const { t, id, isPage, router } = this.props
+    const { t, id, isPage, router, serverContext } = this.props
     const { query } = this.state
 
     const seed = this.state.seed || this.props.seed
@@ -611,6 +619,16 @@ class Container extends Component {
               this.setState(() => ({
                 seed: generateSeed(),
               }))
+              if (isPage && (id || this.state.clearedFocus)) {
+                this.setState(
+                  {
+                    clearedFocus: undefined,
+                  },
+                  () => {
+                    router.replace('/community', undefined, { shallow: true })
+                  },
+                )
+              }
             }}
           >
             {t('testimonial/search/seed')}
@@ -625,10 +643,10 @@ class Container extends Component {
               return
             }
             this.setState(
-              () => ({
+              {
                 // keep it around for the query
                 clearedFocus: id,
-              }),
+              },
               () => {
                 router.push('/community', undefined, { shallow: true })
               },
@@ -636,6 +654,7 @@ class Container extends Component {
           }}
           search={query}
           seed={seed}
+          serverContext={serverContext}
         />
       </div>
     )

--- a/apps/www/components/Testimonial/List.js
+++ b/apps/www/components/Testimonial/List.js
@@ -349,7 +349,7 @@ export class List extends Component {
         render={() => {
           const items = []
           const lastIndex = statements.length - 1
-          const focusItem = statements[0]?.id === focus ? statements[0] : null
+          const focusItem = statements[0]?.id === focus && statements[0]
 
           const hasNotFoundFocus = focus && !focusItem
           if (hasNotFoundFocus && serverContext) {

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -4569,6 +4569,10 @@
       "value": "ansehen"
     },
     {
+      "key": "statement/404",
+      "value": "Das gewünschte Statement ist zurzeit nicht verfügbar."
+    },
+    {
       "key": "statement/share/overlayTitle",
       "value": "Statement von {name}"
     },

--- a/apps/www/pages/community.js
+++ b/apps/www/pages/community.js
@@ -18,6 +18,7 @@ class CommunityPage extends Component {
     const {
       router: { query },
       seed,
+      serverContext,
     } = this.props
 
     if (query.share) {
@@ -43,7 +44,7 @@ class CommunityPage extends Component {
 
     return (
       <Frame>
-        <List seed={seed} id={query.id} isPage />
+        <List seed={seed} id={query.id} isPage serverContext={serverContext} />
       </Frame>
     )
   }

--- a/packages/backend-modules/republik/graphql/resolvers/_queries/statements.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_queries/statements.js
@@ -30,6 +30,7 @@ module.exports = async (_, args, { pgdb, t }) => {
       {
         testimonialId: focus,
         isListed: true,
+        'roles @>': '["member"]',
       },
       'id',
     )


### PR DESCRIPTION
This introduces a 404 status code and error message if a community focus id is not returned.

Additionally focus are no longer returned from the backend if the user no longer has an active member role. This matches the behaviour in the list where past members are already filtered out.

<img width="1239" alt="Screenshot 2022-02-17 at 13 36 46" src="https://user-images.githubusercontent.com/410211/154485508-9adce6d8-e2c8-443c-bb27-8fb33a942465.png">
