### PR TITLE
fix: remove margin between subsequential article carousels

### DIFF
--- a/packages/styleguide/src/components/TeaserCarousel/Carousel.js
+++ b/packages/styleguide/src/components/TeaserCarousel/Carousel.js
@@ -11,6 +11,12 @@ const styles = {
   carousel: css({
     padding: `30px ${PADDING}px ${30 - PADDING}px`,
   }),
+  articleMargin: css({
+    margin: '20px 0',
+    '& ~ &': {
+      marginTop: -20,
+    },
+  }),
 }
 
 export const Carousel = ({
@@ -51,8 +57,8 @@ export const Carousel = ({
         {...styles.carousel}
         {...colorScheme.set('backgroundColor', bgColor)}
         {...colorScheme.set('color', color || 'inherit')}
+        {...(article ? styles.articleMargin : undefined)}
         style={{
-          margin: article ? '20px 0' : undefined,
           ...(isSeriesNav
             ? {
                 paddingTop: 0,


### PR DESCRIPTION
because it came up in Slack, maybe better?

| before | after |
|---|---|
| ![screencapture-republik-ch-audio-2022-02-23-11_08_59](https://user-images.githubusercontent.com/410211/155299121-882483a5-b4c0-4f22-b020-09eb2547d47f.png) | ![screencapture-localhost-3010-audio-2022-02-23-11_08_04](https://user-images.githubusercontent.com/410211/155299318-9a99e126-3ade-4234-8f18-66122cf3e78c.png) |
| | ![screencapture-localhost-3010-audio-2022-02-23-11_08_31](https://user-images.githubusercontent.com/410211/155299366-01ab455f-7984-41e5-a025-09f9580728be.png) |
