### PR TITLE
Improve Share Chart

### DIFF
--- a/apps/www/components/Access/Campaigns/ShareChart.js
+++ b/apps/www/components/Access/Campaigns/ShareChart.js
@@ -186,7 +186,7 @@ const ShareChart = ({ data, t }) => {
                       label: t('Share/chart/annotation/lastBucket'),
                     },
                   ].filter(Boolean),
-                  colorLegendValues: [t('Share/chart/labels/converted')],
+                  colorLegendValues: [],
                   colorMap: {
                     [t('Share/chart/labels/activeUnconverted')]: '#256900',
                     [t('Share/chart/labels/converted')]: '#3CAD00',

--- a/apps/www/components/Access/Campaigns/ShareChart.js
+++ b/apps/www/components/Access/Campaigns/ShareChart.js
@@ -142,7 +142,7 @@ const ShareChart = ({ data, t }) => {
             <>
               <ChartTitle>
                 {t('Share/chart/title', {
-                  currentActiveAccessGrants: lastBucket.active,
+                  currentActiveAccessGrants: lastBucket.activeUnconverted,
                 })}
               </ChartTitle>
               <ChartLead>
@@ -182,7 +182,7 @@ const ShareChart = ({ data, t }) => {
                     {
                       x1: lastBucket.date,
                       x2: lastBucket.date,
-                      value: lastBucket.active,
+                      value: lastBucket.activeUnconverted,
                       label: t('Share/chart/annotation/lastBucket'),
                     },
                   ].filter(Boolean),

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3658,7 +3658,7 @@
     },
     {
       "key": "Share/chart/lead",
-      "value": "In den letzten {days} Tagen haben sich nach dem Probezugriff rund {averagePercent} für die Republik entschieden."
+      "value": "Anzahl geteilte Zugriffe über die letzten {days} Tage."
     },
     {
       "key": "Share/chart/labels/activeUnconverted",
@@ -3670,7 +3670,7 @@
     },
     {
       "key": "Share/chart/legend",
-      "value": "Als Konversion gilt wenn spätestens 30 Tage nach Ablauf des Probezugriff man Verlegerin wird, etwas spendet oder verschenkt. Datenstand: {formattedDateTime}"
+      "value": "Der Konversionsrate rechnen wir an, wer 30 Tage nach Ablauf des Probezugriff Verlegerin wird, etwas spendet oder verschenkt. Datenstand: {formattedDateTime}"
     },
     {
       "key": "Share/chart/annotation/averageRate",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3662,11 +3662,11 @@
     },
     {
       "key": "Share/chart/after",
-      "value": "Seit dem {startDate} wurde insgesamt {invites} mal das Abo geteilt, {claims} Probezugriffe eingelöst und {pledges} mal konnten wir, dank Ihrem Engagement, eine Verlegerin dazu gewinnen."
+      "value": "Seit dem {startDate} wurden {invites} Personen eingeladen, die Republik kennen zu lernen. {claims} haben den Probezugriff eingelöst, und {pledges} durften wir in der Verlagsetage begrüssen – dank Ihrem Engagement."
     },
     {
       "key": "Share/chart/legend",
-      "value": "Mitgliedschaften, Abos und Spenden die spätestens 30 Tage nach Ablauf des Probezugriffs erfolgen zählen. Datenstand: {formattedDateTime}"
+      "value": "Es zählen Mitgliedschaften, Abos und Spenden innerhalb von 30 Tagen nach Probezugriff. Datenstand: {formattedDateTime}"
     },
     {
       "key": "Share/chart/annotation/lastBucket",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3658,7 +3658,7 @@
     },
     {
       "key": "Share/chart/lead",
-      "value": "Anzahl geteilte Zugriffe über die letzten {days} Tage."
+      "value": "Anzahl geteilter Zugriffe während der letzten {days} Tage"
     },
     {
       "key": "Share/chart/labels/activeUnconverted",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3661,20 +3661,12 @@
       "value": "Anzahl geteilter Zugriffe während der letzten {days} Tage"
     },
     {
-      "key": "Share/chart/labels/activeUnconverted",
-      "value": "Hat bisher nicht unterstützt"
-    },
-    {
-      "key": "Share/chart/labels/converted",
-      "value": "Inzwischen als Unterstützerin gewonnen"
+      "key": "Share/chart/after",
+      "value": "Seit dem {startDate} wurde insgesamt {invites} mal das Abo geteilt, {claims} Probezugriffe eingelöst und {pledges} mal konnten wir, dank Ihrem Engagement, eine Verlegerin dazu gewinnen."
     },
     {
       "key": "Share/chart/legend",
-      "value": "Der Konversionsrate rechnen wir an, wer 30 Tage nach Ablauf des Probezugriff Verlegerin wird, etwas spendet oder verschenkt. Datenstand: {formattedDateTime}"
-    },
-    {
-      "key": "Share/chart/annotation/averageRate",
-      "value": "rund {percent} Konversionsrate"
+      "value": "Mitgliedschaften, Abos und Spenden die spätestens 30 Tage nach Ablauf des Probezugriffs erfolgen zählen. Datenstand: {formattedDateTime}"
     },
     {
       "key": "Share/chart/annotation/lastBucket",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3658,15 +3658,19 @@
     },
     {
       "key": "Share/chart/lead",
-      "value": "In den letzten vier Wochen haben sich nach dem Probelesen {soldMembership} Personen für die Republik entschieden."
+      "value": "In den letzten {days} Tagen haben sich nach dem Probezugriff bis zu {maxRate}, Total {nPledges} Personen, für die Republik entschieden."
     },
     {
       "key": "Share/chart/labels/activeUnconverted",
-      "value": "Geteilte, aktive Probelesen"
+      "value": "Hat bisher nicht unterstützt"
     },
     {
       "key": "Share/chart/labels/converted",
-      "value": "Gewonnene Verlegerinnen"
+      "value": "Inzwischen als Unterstützerin gewonnen"
+    },
+    {
+      "key": "Share/chart/legend",
+      "value": "Als Unterstützer gelten alle die spätestens 30 Tage nach Ablauf des Probezugriffs ein Abo lösen, etwas verschenken oder spenden. Datenstand: {formattedDateTime}"
     },
     {
       "key": "notifications/pageTitle",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3658,7 +3658,7 @@
     },
     {
       "key": "Share/chart/lead",
-      "value": "In den letzten {days} Tagen haben sich nach dem Probezugriff bis zu {maxRate}, Total {nPledges} Personen, für die Republik entschieden."
+      "value": "In den letzten {days} Tagen haben sich nach dem Probezugriff rund {averagePercent} für die Republik entschieden."
     },
     {
       "key": "Share/chart/labels/activeUnconverted",
@@ -3671,6 +3671,14 @@
     {
       "key": "Share/chart/legend",
       "value": "Als Unterstützer gelten alle die spätestens 30 Tage nach Ablauf des Probezugriffs ein Abo lösen, etwas verschenken oder spenden. Datenstand: {formattedDateTime}"
+    },
+    {
+      "key": "Share/chart/annotation/averageRate",
+      "value": "rund {percent} Unterstützung"
+    },
+    {
+      "key": "Share/chart/annotation/lastBucket",
+      "value": "Aktuell"
     },
     {
       "key": "notifications/pageTitle",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3662,7 +3662,7 @@
     },
     {
       "key": "Share/chart/after",
-      "value": "Seit dem {startDate} wurden {invites} Personen eingeladen, die Republik kennen zu lernen. {claims} haben den Probezugriff eingelöst, und {pledges} durften wir in der Verlagsetage begrüssen – dank Ihrem Engagement."
+      "value": "Seit dem {startDate} wurden {invites} Personen eingeladen, die Republik kennenzulernen. {claims} haben den Probezugriff eingelöst, und {pledges} durften wir in der Verlagsetage begrüssen – dank Ihrem Engagement."
     },
     {
       "key": "Share/chart/legend",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3670,11 +3670,11 @@
     },
     {
       "key": "Share/chart/legend",
-      "value": "Als Unterstützer gelten alle die spätestens 30 Tage nach Ablauf des Probezugriffs ein Abo lösen, etwas verschenken oder spenden. Datenstand: {formattedDateTime}"
+      "value": "Als Konversion gilt wenn spätestens 30 Tage nach Ablauf des Probezugriff man Verlegerin wird, etwas spendet oder verschenkt. Datenstand: {formattedDateTime}"
     },
     {
       "key": "Share/chart/annotation/averageRate",
-      "value": "rund {percent} Unterstützung"
+      "value": "rund {percent} Konversionsrate"
     },
     {
       "key": "Share/chart/annotation/lastBucket",

--- a/apps/www/lib/utils/format.js
+++ b/apps/www/lib/utils/format.js
@@ -8,6 +8,8 @@ export const swissNumbers = formatLocale({
   thousands: thousandSeparator,
   grouping: [3],
   currency: ['CHF\u00a0', ''],
+  minus: '\u2212',
+  percent: '\u2009%',
 })
 const chf4Format = swissNumbers.format('$.0f')
 const chf5Format = swissNumbers.format('$,.0f')

--- a/apps/www/pages/cockpit.js
+++ b/apps/www/pages/cockpit.js
@@ -542,9 +542,9 @@ Die Grundlage dafür ist ein Geschäftsmodell für werbefreien, unabhängigen, l
                   und&nbsp;Abonnentinnen
                 </ChartTitle>
                 <ChartLead>
-                  Entwicklung vom Crowdfunding im April 2017 bis heute.{' '}
+                  Entwicklung vom Crowdfunding im April 2017 bis heute
                   {missingCount > 0 &&
-                    `Es fehlen ${countFormat(missingCount)} Mitglieder.`}
+                    `. Es fehlen ${countFormat(missingCount)} Mitglieder.`}
                 </ChartLead>
                 <Chart
                   config={{
@@ -556,7 +556,13 @@ Die Grundlage dafür ist ein Geschäftsmodell für werbefreien, unabhängigen, l
                     timeParse: '%Y-%m',
                     timeFormat: '%Y',
                     xInterval: 'month',
-                    xTicks: ['2018-01', '2019-01', '2020-01', '2021-01'],
+                    xTicks: [
+                      '2018-01',
+                      '2019-01',
+                      '2020-01',
+                      '2021-01',
+                      '2022-01',
+                    ],
                     height: 300,
                     domain: [minValue, maxValue + 2000],
                     yTicks: [-5000, 0, 5000, 10000, 15000, 20000, 25000, 30000],
@@ -582,7 +588,7 @@ Die Grundlage dafür ist ein Geschäftsmodell für werbefreien, unabhängigen, l
                   anstehende Verläng&shy;erungen in den nächsten&nbsp;Monaten
                 </ChartTitle>
                 <ChartLead>
-                  Anzahl Mitgliedschaften und Abos per Monatsende.
+                  Anzahl Mitgliedschaften und Abos per Monatsende
                 </ChartLead>
                 <Chart
                   config={{
@@ -633,7 +639,7 @@ Mit ${countFormat(
 
 Diese Zahl leitet sich aus dem aktuellen Budget 2021/22 ab. [Erfahren Sie, wofür wir das Geld ausgeben und wie sich das Budget über die Zeit entwickelt hat](/2021/10/08/werfen-sie-einen-blick-in-unsere-geschaeftsbuecher).
 
-## ${countFormat(lastSeen)} Mitglieder sind monatlich&nbsp;aktiv
+## ${countFormat(lastSeen)} Verlegerinnen sind monatlich&nbsp;aktiv
 
 Der beste Journalismus nützt nichts, wenn ihn niemand sieht. Für ein gesundes Unternehmen braucht es eine aktive und interessierte Verlegerschaft.
 
@@ -644,7 +650,7 @@ Der beste Journalismus nützt nichts, wenn ihn niemand sieht. Für ein gesundes 
                   Wie beliebt sind Dialog, Lesezeichen und Leseposition?
                 </ChartTitle>
                 <ChartLead>
-                  Anzahl Mitglieder, welche pro Monat eine Funktion benutzen.
+                  Anzahl Verleger, welche pro Monat eine Funktion benutzen.
                 </ChartLead>
                 <Chart
                   config={{
@@ -661,6 +667,7 @@ Der beste Journalismus nützt nichts, wenn ihn niemand sieht. Für ein gesundes 
                       '2019-01',
                       '2020-01',
                       '2021-01',
+                      '2022-01',
                       // lastSeenBucket.key
                     ],
                     yNice: 0,


### PR DESCRIPTION
Before and after:
<img width="1780" alt="Screenshot 2022-02-24 at 17 28 03" src="https://user-images.githubusercontent.com/410211/155567358-21887625-2615-4e3e-ac22-2da28f9dc5ea.png">



The current version has following problem:
- «Gewonnene Verlegerinnen» is inaccurate because donations and gifts count too
- it says «letzten vier Wochen» but displays 31 days
- «25 Personen für die Republik entschieden» those 25 pledge events are often from access grants that are not visible on the chart
- no foot note with data date and time, no explanation what counts as «Gewonnene»

Not 100% sure about the wording, especially the denglisch «Konversionsrate».

For the record and to understand how I got to the new chart, here a few wip intermediate screenshots:
| action | screenshot |
|---|---|
| calculate max rate in the last 60 days | <img width="868" alt="Screenshot 2022-02-23 at 18 50 14" src="https://user-images.githubusercontent.com/410211/155389040-51271dbf-3e7c-4e04-bdb4-a5918cf0b4a4.png"> |
| remove random 25 people | <img width="863" alt="Screenshot 2022-02-23 at 18 51 22" src="https://user-images.githubusercontent.com/410211/155389070-d220fa80-3b7e-433c-bffc-4920f7ef73cb.png"> |
| annotate and switch average over first 30 days | <img width="861" alt="Screenshot 2022-02-23 at 19 26 25" src="https://user-images.githubusercontent.com/410211/155389354-75cec904-18f2-472b-a8b7-27638a9c1666.png"> |
| change wording to eliminate ominous «Unterstützung» | <img width="846" alt="Screenshot 2022-02-23 at 19 51 34" src="https://user-images.githubusercontent.com/410211/155389487-7d21545b-98dd-4183-b5fd-667e75a75ce1.png"> |

