### PR TITLE
Fix faulty project pattern in eslint-config-backend

### DIFF
--- a/packages/eslint-config-backend/index.js
+++ b/packages/eslint-config-backend/index.js
@@ -9,7 +9,7 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       parserOptions: {
         tsconfigRootDir: __dirname,
-        project: ['./tsconfig.json'],
+        project: ['./packages/*/tsconfig.json'],
       },
       plugins: ['@typescript-eslint'],
       extends: [


### PR DESCRIPTION
## Description

A faulty configuration inside the backend eslint-configuration caused the tsconfig of the individual packages to not be resolved correctly.

## Showcase


https://user-images.githubusercontent.com/30313631/155778764-07746447-0f2f-4fbd-a01a-b039c1264633.mp4

### Method to test if it works

1. Add this line to backend-modules/auth/index.ts
```ts
declare const loggedInUsername: string;
 
const users = [
  { name: "Oby", age: 12 },
  { name: "Heera", age: 32 },
];
 
const loggedInUser = users.find((u) => u.name === loggedInUsername);
console.log(loggedInUser.age);
```
You should see that `loggedInUser.age` is highlighted since it might be null.
 2. Update the backend tsconfig to `"strictNullChecks": false` (as in the video)
 3. You should now no longer see the above mentioned error being highlighted


### Used tools 

WebStorm: 2021.3.2
VSCode: V1.64.2
VSCode Eslint Plugin: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint V2.2.2