### PR TITLE
fix(ActionBar): flexWrap in seriesEpisode

### DIFF
--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -447,7 +447,8 @@ const ActionBar = ({
     <>
       <div
         {...styles.topRow}
-        {...(mode === 'articleOverlay' && { ...styles.overlay })}
+        {...(mode === 'articleOverlay' && styles.overlay)}
+        {...(mode === 'seriesEpisode' && styles.flexWrap)}
         {...(!!centered && { ...styles.centered })}
       >
         {ActionItems.filter(
@@ -520,6 +521,10 @@ const ActionBar = ({
 const styles = {
   topRow: css({
     display: 'flex',
+  }),
+  flexWrap: css({
+    flexWrap: 'wrap',
+    rowGap: 16,
   }),
   bottomRow: css({
     display: 'flex',


### PR DESCRIPTION
Fixes overlong ActionBar when audio and reading position are both present. Scopes the fix to only concern SeriesEpisode-ActionBar
Result:
<img width="692" alt="Screenshot 2022-02-28 at 12 17 06" src="https://user-images.githubusercontent.com/20746301/155974482-631a8d7d-ec2b-4728-b876-d02a9c49e0d4.png">