### PR TITLE
feat(documents): process IF hasAccess in document.content

### DIFF
--- a/packages/backend-modules/documents/graphql/resolvers/Document.js
+++ b/packages/backend-modules/documents/graphql/resolvers/Document.js
@@ -7,6 +7,7 @@ const {
   processRepoImageUrlsInMeta,
   processEmbedImageUrlsInContent,
   processNodeModifiersInContent,
+  processIfHasAccess,
 } = require('../../lib/process')
 const { getMeta } = require('../../lib/meta')
 
@@ -78,6 +79,7 @@ module.exports = {
 
       processMembersOnlyZonesInContent(doc.content, context.user)
       processNodeModifiersInContent(doc.content, context.user)
+      processIfHasAccess(doc.content, context.user)
     }
     return doc.content
   },
@@ -158,6 +160,7 @@ module.exports = {
 
         processMembersOnlyZonesInContent(node, context.user)
         processNodeModifiersInContent(node, context.user)
+        processIfHasAccess(node, context.user)
 
         return extractIdsFromNode(node, doc.meta.repoId)
       })

--- a/packages/backend-modules/documents/lib/process.js
+++ b/packages/backend-modules/documents/lib/process.js
@@ -167,6 +167,35 @@ const processNodeModifiersInContent = (mdast, user) => {
   })
 }
 
+const processIfHasAccess = (mdast, user) => {
+  visit(mdast, 'zone', (node, index, parent) => {
+    if (node.identifier === 'IF' && node.data.present === 'hasAccess') {
+      let children = [...node.children]
+
+      const elseIndex = node.children.findIndex(
+        (child) => child.identifier === 'ELSE',
+      )
+
+      if (elseIndex >= 0) {
+        if (userIsInRoles(user, documentsRestrictToRoles)) {
+          children = [
+            ...children.slice(0, elseIndex),
+            ...children.slice(elseIndex + 1),
+          ]
+        } else {
+          children = node.children?.[elseIndex]?.children
+        }
+      }
+
+      parent.children = [
+        ...parent.children.slice(0, index),
+        ...children,
+        ...parent.children.slice(index + 1),
+      ]
+    }
+  })
+}
+
 module.exports = {
   processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
@@ -174,4 +203,5 @@ module.exports = {
   processEmbedImageUrlsInContent,
   processEmbedsInContent,
   processNodeModifiersInContent,
+  processIfHasAccess,
 }


### PR DESCRIPTION
Unwraps zone identifier `"IF"` when `data.present` is set to `hasAccess`.

**Example**

```json
{
  "identifier": "IF",
  "data": {
    "present": "hasAccess"
  },
  "children": [
    {
      "children": [
        {
          "type": "text",
          "value": "(Mitglied.)"
        }
      ],
      "type": "paragraph"
    },
    {
      "identifier": "ELSE",
      "data": {},
      "children": [
        {
          "children": [
            {
              "type": "text",
              "value": "(Kein Mitglied)"
            }
          ],
          "type": "paragraph"
        }
      ],
      "type": "zone"
    }
  ],
  "type": "zone"
}
```

When a user role has unrestricted access, zone identifier `"IF"` `children` is unwrapped. In `children` contain a zone identifier `"ELSE"`, entire zone is omitted.

```json
{
  "children": [
    {
      "type": "text",
      "value": "(Mitglied.)"
    }
  ],
  "type": "paragraph"
}
```

If user has no access, zone identifier `"ELSE"` `children` maybe be returned.

```json
{
  "children": [
    {
      "type": "text",
      "value": "(Kein Mitglied)"
    }
  ],
  "type": "paragraph"
}
```