### PR TITLE
Fix focused comment not loading if it's not inside the initial comment query result

### DIFF
--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
@@ -335,16 +335,25 @@ module.exports = async (discussion, args, context, info) => {
   if (focusId) {
     focusComment = comments.find((c) => c.id === focusId)
 
-    if (!focusComment) {
+    if (focusComment) {
+      // topValue used for sorting
+      // we assign it here, because focusComment might be a node without
+      // children, which deepSortTree doesn't calculate a topValue for
+      focusComment.topValue = topValue
+
+      // Set comment (and its parents as topIds), used later for sorting tree and
+      // ensuring comment-tree bubbles to the very top.
+      topIds = _([focusComment.id])
+        .concat(focusComment.parentIds)
+        .compact()
+        .value()
+    } else {
       // In case the focused comment was not in the initial query result
       // we fetch the comment as well as it's parents if there are any.
 
-      const focusCommentQuery = [
-        'SELECT c.* FROM comments c',
-        'WHERE c.id = :focusId',
-      ]
-        .filter(Boolean)
-        .join(' ')
+      const focusCommentQuery = `
+        SELECT c.* FROM comments c
+        WHERE c.id = :focusId`
 
       const focusCommentResult = await pgdb
         .query(focusCommentQuery, {
@@ -361,47 +370,27 @@ module.exports = async (discussion, args, context, info) => {
         focusComment = focusCommentResult
         comments.push(focusCommentResult)
       }
-
-      // in case parent comments exists load them as well.
-      if (focusCommentResult && focusComment.parentIds?.length > 0) {
-        const focusCommentParentQuery = [
-          'SELECT c.* FROM comments c',
-          'WHERE c.id IN (:parentIds)',
-        ]
-          .filter(Boolean)
-          .join(' ')
-
-        const focusCommentParentResults = await pgdb
-          .query(focusCommentParentQuery, {
-            parentIds: focusComment.parentIds
-              .filter((parentId) => !comments.find((c) => c.id === parentId)) // Filter parents that might already be in the comments array
-              .join(','),
-          })
-          .then((c) => ({
-            // precompute
-            ...c,
-            score: c.upVotes - c.downVotes,
-            isPublished: c.published && !c.adminUnpublished,
-          }))
-
-        if (focusCommentParentResults) {
-          comments.push(...focusCommentParentResults)
-        }
-      }
     }
 
-    if (focusComment) {
-      // topValue used for sorting
-      // we assign it here, because focusComment might be a node without
-      // children, which deepSortTree doesn't calculate a topValue for
-      focusComment.topValue = topValue
+    if (focusComment && focusComment.parentIds?.length > 0) {
+      const focusCommentParentQuery = `
+      SELECT c.* FROM comments c
+      WHERE c.id IN (:parentIds)`
 
-      // Set comment (and its parents as topIds), used later for sorting tree and
-      // ensuring comment-tree bubbles to the very top.
-      topIds = _([focusComment.id])
-        .concat(focusComment.parentIds)
-        .compact()
-        .value()
+      const focusCommentParentResults = await pgdb
+        .query(focusCommentParentQuery, {
+          parentIds: focusComment.parentIds.join(','),
+        })
+        .then((c) => ({
+          // precompute
+          ...c,
+          score: c.upVotes - c.downVotes,
+          isPublished: c.published && !c.adminUnpublished,
+        }))
+
+      if (focusCommentParentResults) {
+        comments.push(...focusCommentParentResults)
+      }
     }
   }
 

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
@@ -378,7 +378,9 @@ module.exports = async (discussion, args, context, info) => {
         parentId && tree.comments && tree.comments.nodes[0]
           ? tree.comments.nodes[0].depth + maxDepth
           : maxDepth
-      filterComments = filterComments.filter((c) => c.depth < maxDepthAbsolute)
+      filterComments = filterComments.filter(
+        (c) => c.depth < maxDepthAbsolute || c.id === focusId, // Ensure focus comment is not filtered
+      )
     }
     filterComments = filterComments.slice(0, first)
 

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
@@ -378,9 +378,7 @@ module.exports = async (discussion, args, context, info) => {
         parentId && tree.comments && tree.comments.nodes[0]
           ? tree.comments.nodes[0].depth + maxDepth
           : maxDepth
-      filterComments = filterComments.filter(
-        (c) => c.depth < maxDepthAbsolute || c.id === focusId, // Ensure focus comment is not filtered
-      )
+      filterComments = filterComments.filter((c) => c.depth < maxDepthAbsolute)
     }
     filterComments = filterComments.slice(0, first)
 

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
@@ -341,6 +341,15 @@ module.exports = async (discussion, args, context, info) => {
       // children, which deepSortTree doesn't calculate a topValue for
       focusComment.topValue = topValue
 
+      // Assign a topValue to all parents of the focusComment
+      // to prevent them from being sliced out due to them not
+      // bubbling to the top
+      comments.forEach((c) => {
+        if (focusComment.parentIds.includes(c.id)) {
+          c.topValue = topValue
+        }
+      })
+
       // Set comment (and its parents as topIds), used later for sorting tree and
       // ensuring comment-tree bubbles to the very top.
       topIds = _([focusComment.id])

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/comments.js
@@ -347,50 +347,6 @@ module.exports = async (discussion, args, context, info) => {
         .concat(focusComment.parentIds)
         .compact()
         .value()
-    } else {
-      // In case the focused comment was not in the initial query result
-      // we fetch the comment as well as it's parents if there are any.
-
-      const focusCommentQuery = `
-        SELECT c.* FROM comments c
-        WHERE c.id = :focusId`
-
-      const focusCommentResult = await pgdb
-        .query(focusCommentQuery, {
-          focusId,
-        })
-        .then((c) => ({
-          // precompute
-          ...c,
-          score: c.upVotes - c.downVotes,
-          isPublished: c.published && !c.adminUnpublished,
-        }))
-
-      if (focusCommentResult) {
-        focusComment = focusCommentResult
-        comments.push(focusCommentResult)
-      }
-    }
-
-    if (focusComment && focusComment.parentIds?.length > 0) {
-      const focusCommentParentQuery = `
-      SELECT c.* FROM comments c
-      WHERE c.id IN (:parentIds)`
-
-      const focusCommentParentResults = await pgdb
-        .query(focusCommentParentQuery, {
-          parentIds: focusComment.parentIds.join(','),
-        })
-        .then((c) => ({
-          // precompute
-          ...c,
-          score: c.upVotes - c.downVotes,
-          isPublished: c.published && !c.adminUnpublished,
-        }))
-
-      if (focusCommentParentResults) {
-        comments.push(...focusCommentParentResults)
-      }
     }
   }
 


### PR DESCRIPTION
## Description
Fix an error that caused focus-urls to break when sharing a reply.
(After spending the better part of a day trying to pin-point the issue, we managed to figure out that is caused by due to the parent-comment being filtered out since they were not assigned a topLevel value, that caused them to remain in the list of initially returned comments)