### PR TITLE
Minor enhancements to Synthetic Read Aloud

### DIFF
--- a/apps/publikator/components/Derivatives/index.js
+++ b/apps/publikator/components/Derivatives/index.js
@@ -157,17 +157,9 @@ const Derivatives = ({ commit, generateDerivative }) => {
 
   const { derivatives, canDeriveSyntheticReadAloud } = commit
 
-  const synthesizedAudio = derivatives
-    .filter((d) => d.type === 'SyntheticReadAloud')
-    .reduce(
-      (prev, curr) =>
-        (!prev && curr) ||
-        (curr.status === 'Ready' && curr) ||
-        (curr.status !== 'Ready' && prev.status === 'Ready' && prev) ||
-        (curr.status !== 'Ready' && prev.status === 'Pending' && prev) ||
-        (curr.status !== 'Ready' && prev.status !== 'Ready' && curr),
-      null,
-    )
+  const synthesizedAudio = derivatives.find(
+    (d) => d.type === 'SyntheticReadAloud',
+  )
 
   return (
     <>

--- a/packages/backend-modules/publikator/graphql/resolvers/Commit.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/Commit.js
@@ -77,7 +77,7 @@ module.exports = {
     const { type } = args
 
     if (type === 'SyntheticReadAloud') {
-      return canDeriveSyntheticReadAloud(commit.meta.template)
+      return canDeriveSyntheticReadAloud(commit.meta)
     }
 
     return false

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/generateDerivative.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/generateDerivative.js
@@ -19,7 +19,7 @@ module.exports = async (_, { commitId }, context) => {
     throw new Error(t('api/publikator/generateDerivative/commit/404'))
   }
 
-  if (!canDeriveSyntheticReadAloud(commit.meta.template)) {
+  if (!canDeriveSyntheticReadAloud(commit.meta)) {
     throw new Error(t('api/publikator/generateDerivative/canNot'))
   }
 

--- a/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
@@ -24,8 +24,19 @@ const debug = createDebug('publikator:lib:Derivative:SyntheticReadAloud')
 
 const documentsRestrictToRoles = DOCUMENTS_RESTRICT_TO_ROLES?.split(',')
 
-export const canDerive = (template: string) =>
-  ['article', 'discussion', 'editorialNewsletter', 'page'].includes(template)
+export const canDerive = (meta: any) => {
+  const isEnabledTemplate = [
+    'article',
+    'discussion',
+    'editorialNewsletter',
+    'page',
+  ].includes(meta.template)
+
+  const hasNoAudioSource =
+    !meta.audioSourceMp3 && !meta.audioSourceAac && !meta.audioSourceOgg
+
+  return isEnabledTemplate && hasNoAudioSource
+}
 
 export const processMeta = async (
   preprocessedMeta: any,
@@ -127,7 +138,7 @@ export const onPublish = async (document: any, pgdb: any, user?: any) => {
     return
   }
 
-  if (!canDerive(document.content?.meta?.template)) {
+  if (!canDerive(document.content?.meta)) {
     handlerDebug('can not derive synthetic read aloud. skipping synthesizing.')
     return
   }


### PR DESCRIPTION
Minor enhancements to Synthetic Read Aloud
- Publikator: Show latest derivative as CTA
- Publikator: Do not render derivative CTA if `meta.audioSource*` is present