### PR TITLE
Audio Player: Perf Local Progress & Better State Handling

### DIFF
--- a/apps/www/components/Audio/MediaProgress.js
+++ b/apps/www/components/Audio/MediaProgress.js
@@ -7,7 +7,6 @@ import debounce from 'lodash/debounce'
 import throttle from 'lodash/throttle'
 
 import withMe from '../../lib/apollo/withMe'
-import createPersistedState from '../../lib/hooks/use-persisted-state'
 
 const MediaProgressContext = React.createContext()
 
@@ -33,9 +32,22 @@ const upsertMediaProgressMutation = gql`
   }
 `
 
-const useLocalMediaProgressState = createPersistedState(
-  'republik-progress-media',
-)
+const localStorageKey = 'republik-progress-media'
+
+let fallbackStore
+const getLocalMediaProgress = () => {
+  let value = fallbackStore
+  try {
+    value = JSON.parse(window.localStorage.getItem(localStorageKey))
+  } catch (e) {}
+  return value
+}
+const setLocalMediaProgress = (data) => {
+  fallbackStore = data
+  try {
+    window.localStorage.setItem(localStorageKey, JSON.stringify(data))
+  } catch (e) {}
+}
 
 const MediaProgressProvider = ({
   children,
@@ -44,8 +56,6 @@ const MediaProgressProvider = ({
   upsertMediaProgress,
 }) => {
   const isTrackingAllowed = me && me.progressConsent === true
-  const [localMediaProgress, setLocalMediaProgress] =
-    useLocalMediaProgressState()
 
   const saveMediaProgressNotPlaying = debounce((mediaId, currentTime) => {
     // Fires on pause, on scrub, on end of video.
@@ -101,8 +111,11 @@ const MediaProgressProvider = ({
             return secs - 2
           }
         })
-    } else if (localMediaProgress && localMediaProgress.mediaId === mediaId) {
-      return Promise.resolve(localMediaProgress.currentTime - 2)
+    } else {
+      const localMediaProgress = getLocalMediaProgress()
+      if (localMediaProgress?.mediaId === mediaId) {
+        return Promise.resolve(localMediaProgress.currentTime - 2)
+      }
     }
     return Promise.resolve()
   }

--- a/apps/www/lib/playbackRate.js
+++ b/apps/www/lib/playbackRate.js
@@ -2,3 +2,16 @@ import createPersistedState from './hooks/use-persisted-state'
 
 export const PLAYBACK_RATE_KEY = 'republik-playback-rate'
 export const usePlaybackRate = createPersistedState(PLAYBACK_RATE_KEY)
+
+// MIGRATION ADDED ON 01.04.2022
+// - can be removed after 7 days
+if (typeof window !== undefined) {
+  try {
+    const oldKey = 'republik-plyaback-rate'
+    const oldItem = window.localStorage.getItem(oldKey)
+    if (oldItem) {
+      window.localStorage.setItem(PLAYBACK_RATE_KEY, oldItem)
+      window.localStorage.removeItem(oldKey)
+    }
+  } catch (e) {}
+}

--- a/apps/www/lib/playbackRate.js
+++ b/apps/www/lib/playbackRate.js
@@ -1,4 +1,4 @@
 import createPersistedState from './hooks/use-persisted-state'
 
-export const PLAYBACK_RATE_KEY = 'republik-plyaback-rate'
+export const PLAYBACK_RATE_KEY = 'republik-playback-rate'
 export const usePlaybackRate = createPersistedState(PLAYBACK_RATE_KEY)

--- a/packages/styleguide/src/components/AudioPlayer/ExpandableAudioPlayer.tsx
+++ b/packages/styleguide/src/components/AudioPlayer/ExpandableAudioPlayer.tsx
@@ -137,6 +137,7 @@ const styles = {
   }),
   sourceError: css({
     ...sansSerifRegular12,
+    margin: '4px 0 0 0',
   }),
   sourceErrorButton: css({
     ...underline,
@@ -197,7 +198,7 @@ const AudioInfo = ({
   return (
     <div
       {...styles.textArea}
-      {...(!sourceError && !expanded && styles.ellipsize)}
+      {...(!expanded && styles.ellipsize)}
       style={{
         textAlign: expanded ? 'center' : 'left',
       }}
@@ -205,17 +206,6 @@ const AudioInfo = ({
     >
       {loading ? (
         <InlineSpinner size={25} />
-      ) : sourceError ? (
-        <div {...styles.sourceError} {...colorScheme.set('color', 'disabled')}>
-          {t('styleguide/AudioPlayer/sourceError')}{' '}
-          <button
-            {...plainButtonRule}
-            {...styles.sourceErrorButton}
-            onClick={() => reload()}
-          >
-            {t('styleguide/AudioPlayer/sourceErrorTryAgain')}
-          </button>
-        </div>
       ) : (
         <>
           {title && (
@@ -230,16 +220,29 @@ const AudioInfo = ({
               </a>
             </Link>
           )}
-          <p
-            {...(expanded ? styles.expandedTime : styles.time)}
-            style={{ marginTop: expanded ? 8 : 0 }}
-            {...colorScheme.set('color', 'textSoft')}
-            tabIndex={0}
-          >
-            {formattedCurrentTime && formattedCurrentTime}
-            {formattedCurrentTime && formattedDuration && ' / '}
-            {formattedDuration && formattedDuration}
-          </p>
+          {sourceError ? (
+            <p {...styles.sourceError} {...colorScheme.set('color', 'error')}>
+              {t('styleguide/AudioPlayer/sourceError')}{' '}
+              <button
+                {...plainButtonRule}
+                {...styles.sourceErrorButton}
+                onClick={() => reload()}
+              >
+                {t('styleguide/AudioPlayer/sourceErrorTryAgain')}
+              </button>
+            </p>
+          ) : (
+            <p
+              {...(expanded ? styles.expandedTime : styles.time)}
+              style={{ marginTop: expanded ? 8 : 0 }}
+              {...colorScheme.set('color', 'textSoft')}
+              tabIndex={0}
+            >
+              {formattedCurrentTime && formattedCurrentTime}
+              {formattedCurrentTime && formattedDuration && ' / '}
+              {formattedDuration && formattedDuration}
+            </p>
+          )}
         </>
       )}
     </div>
@@ -325,9 +328,21 @@ const ExpandableAudioPlayer = ({
                 aria-live='assertive'
               >
                 {playing ? (
-                  <PauseIcon size={54} {...colorScheme.set('fill', 'text')} />
+                  <PauseIcon
+                    size={54}
+                    {...colorScheme.set(
+                      'fill',
+                      sourceError ? 'disabled' : 'text',
+                    )}
+                  />
                 ) : (
-                  <PlayIcon size={54} {...colorScheme.set('fill', 'text')} />
+                  <PlayIcon
+                    size={54}
+                    {...colorScheme.set(
+                      'fill',
+                      sourceError ? 'disabled' : 'text',
+                    )}
+                  />
                 )}
               </button>
               <button
@@ -399,7 +414,7 @@ const ExpandableAudioPlayer = ({
         <div {...styles.leftControls}>
           {isExpanded ? (
             <>
-              {download && (
+              {download && !sourceError && (
                 <button {...styles.button} {...plainButtonRule}>
                   <a
                     href={src.mp3 || src.aac || src.mp4}
@@ -427,9 +442,21 @@ const ExpandableAudioPlayer = ({
                 aria-live='assertive'
               >
                 {playing ? (
-                  <PauseIcon size={42} {...colorScheme.set('fill', 'text')} />
+                  <PauseIcon
+                    size={42}
+                    {...colorScheme.set(
+                      'fill',
+                      sourceError ? 'disabled' : 'text',
+                    )}
+                  />
                 ) : (
-                  <PlayIcon size={42} {...colorScheme.set('fill', 'text')} />
+                  <PlayIcon
+                    size={42}
+                    {...colorScheme.set(
+                      'fill',
+                      sourceError ? 'disabled' : 'text',
+                    )}
+                  />
                 )}
               </button>
               <AudioInfo

--- a/packages/styleguide/src/components/AudioPlayer/ExpandableAudioPlayer.tsx
+++ b/packages/styleguide/src/components/AudioPlayer/ExpandableAudioPlayer.tsx
@@ -49,7 +49,7 @@ interface ExtendePlayerProps extends AudioInfoProps {
   scrubRef: React.Ref<HTMLDivElement>
   containerRef: React.Ref<HTMLDivElement>
   playing: boolean
-  playEnabled: boolean
+  canSetTime: boolean
   progress: number
   playbackRate: number
   setPlaybackRate: (rate: number) => void
@@ -251,7 +251,7 @@ const ExpandableAudioPlayer = ({
   scrubRef,
   playbackElement,
   playing,
-  playEnabled,
+  canSetTime,
   progress,
   loading,
   sourceError,
@@ -300,7 +300,7 @@ const ExpandableAudioPlayer = ({
                 {...styles.button}
                 {...plainButtonRule}
                 onClick={
-                  playEnabled
+                  canSetTime
                     ? () => {
                         setTime(audio.currentTime - 10 * playbackRate)
                       }
@@ -310,7 +310,7 @@ const ExpandableAudioPlayer = ({
               >
                 <MdReplay10
                   size={24}
-                  {...(playEnabled && progress > 0
+                  {...(canSetTime && progress > 0
                     ? colorScheme.set('fill', 'text')
                     : colorScheme.set('fill', 'disabled'))}
                 />
@@ -318,7 +318,7 @@ const ExpandableAudioPlayer = ({
               <button
                 {...styles.button}
                 {...plainButtonRule}
-                onClick={playEnabled ? toggle : null}
+                onClick={toggle}
                 title={t(
                   `styleguide/AudioPlayer/${playing ? 'pause' : 'play'}`,
                 )}
@@ -327,19 +327,14 @@ const ExpandableAudioPlayer = ({
                 {playing ? (
                   <PauseIcon size={54} {...colorScheme.set('fill', 'text')} />
                 ) : (
-                  <PlayIcon
-                    size={54}
-                    {...(playEnabled
-                      ? colorScheme.set('fill', 'text')
-                      : colorScheme.set('fill', 'disabled'))}
-                  />
+                  <PlayIcon size={54} {...colorScheme.set('fill', 'text')} />
                 )}
               </button>
               <button
                 {...styles.button}
                 {...plainButtonRule}
                 onClick={
-                  playEnabled
+                  canSetTime
                     ? () => {
                         setTime(audio.currentTime + 30 * playbackRate)
                       }
@@ -349,7 +344,7 @@ const ExpandableAudioPlayer = ({
               >
                 <ForwardIcon
                   size={24}
-                  {...(playEnabled && progress > 0
+                  {...(canSetTime && progress > 0
                     ? colorScheme.set('fill', 'text')
                     : colorScheme.set('fill', 'disabled'))}
                 />
@@ -406,24 +401,16 @@ const ExpandableAudioPlayer = ({
             <>
               {download && (
                 <button {...styles.button} {...plainButtonRule}>
-                  {playEnabled && (
-                    <a
-                      href={src.mp3 || src.aac || src.mp4}
-                      download
-                      title={t('styleguide/AudioPlayer/download')}
-                    >
-                      <DownloadIcon
-                        size={22}
-                        {...colorScheme.set('fill', 'text')}
-                      />
-                    </a>
-                  )}
-                  {!playEnabled && (
+                  <a
+                    href={src.mp3 || src.aac || src.mp4}
+                    download
+                    title={t('styleguide/AudioPlayer/download')}
+                  >
                     <DownloadIcon
                       size={22}
-                      {...colorScheme.set('fill', 'disabled')}
+                      {...colorScheme.set('fill', 'text')}
                     />
-                  )}
+                  </a>
                 </button>
               )}
             </>
@@ -433,7 +420,7 @@ const ExpandableAudioPlayer = ({
                 {...styles.button}
                 {...plainButtonRule}
                 style={{ width: 42, paddingLeft: playing ? 4 : 0 }}
-                onClick={playEnabled ? toggle : null}
+                onClick={toggle}
                 title={t(
                   `styleguide/AudioPlayer/${playing ? 'pause' : 'play'}`,
                 )}
@@ -442,12 +429,7 @@ const ExpandableAudioPlayer = ({
                 {playing ? (
                   <PauseIcon size={42} {...colorScheme.set('fill', 'text')} />
                 ) : (
-                  <PlayIcon
-                    size={42}
-                    {...(playEnabled
-                      ? colorScheme.set('fill', 'text')
-                      : colorScheme.set('fill', 'disabled'))}
-                  />
+                  <PlayIcon size={42} {...colorScheme.set('fill', 'text')} />
                 )}
               </button>
               <AudioInfo

--- a/packages/styleguide/src/components/AudioPlayer/Player.js
+++ b/packages/styleguide/src/components/AudioPlayer/Player.js
@@ -162,7 +162,7 @@ class AudioPlayer extends Component {
     super(props)
 
     this.state = {
-      playEnabled: false,
+      canSetTime: false,
       playing: false,
       progress: 0,
       loading: false,
@@ -235,9 +235,14 @@ class AudioPlayer extends Component {
     this.isSeekable = new Promise((resolve) => {
       this.onSeekable = resolve
     })
-    this.onCanPlay = () => {
+    this.onMetaData = () => {
       this.setState(() => ({
-        playEnabled: true,
+        loading: false,
+      }))
+    }
+    this.onCanSeek = () => {
+      this.setState(() => ({
+        canSetTime: true,
         loading: false,
         sourceError: false,
       }))
@@ -362,24 +367,34 @@ class AudioPlayer extends Component {
     this.audio.addEventListener('play', this.onPlay)
     this.audio.addEventListener('pause', this.onPause)
     this.audio.addEventListener('loadstart', this.onLoadStart)
-    this.audio.addEventListener('canplay', this.onCanPlay)
-    this.audio.addEventListener('canplaythrough', this.onCanPlay)
-    // iOS won't fire canPlay, so rely on meta data.
-    this.audio.addEventListener('loadedmetadata', this.onCanPlay)
+    this.audio.addEventListener('canplay', this.onCanSeek)
+    this.audio.addEventListener('canplaythrough', this.onCanSeek)
+    this.audio.addEventListener('loadedmetadata', this.onMetaData)
 
-    Promise.all([this.getStartTime(), this.isSeekable]).then(([startTime]) => {
-      if (startTime !== undefined) {
-        this.setTime(startTime)
+    this.getStartTime().then((startTime) => {
+      const hasStartTime = startTime !== undefined && startTime !== null
+      const runInitialCmds = () => {
+        this.setAudioPlaybackRate()
+        if (hasStartTime) {
+          this.setTime(startTime)
+        }
+        if (this.props.autoPlay) {
+          this.container && this.container.focus()
+          this.play()
+        }
       }
-      if (this.props.autoPlay) {
-        this.container && this.container.focus()
-
-        this.play()
+      if (this.state.canSetTime) {
+        runInitialCmds()
+      } else {
+        this.isSeekable.then(runInitialCmds)
+        if (hasStartTime || this.props.autoPlay) {
+          // ensure load process is started e.g. on battery devices
+          this.audio.load()
+        }
       }
     })
-
     if (this.audio.readyState >= 1) {
-      this.onSeekable()
+      this.onCanSeek()
     }
     this.setAudioPlaybackRate()
   }
@@ -402,9 +417,9 @@ class AudioPlayer extends Component {
     this.audio.removeEventListener('pause', this.onPause)
     this.audio.removeEventListener('loadstart', this.onLoadStart)
     this.audio.removeEventListener('progress', this.onProgress)
-    this.audio.removeEventListener('canplay', this.onCanPlay)
-    this.audio.removeEventListener('canplaythrough', this.onCanPlay)
-    this.audio.removeEventListener('loadedmetadata', this.onCanPlay)
+    this.audio.removeEventListener('canplay', this.onCanSeek)
+    this.audio.removeEventListener('canplaythrough', this.onCanSeek)
+    this.audio.removeEventListener('loadedmetadata', this.onMetaData)
   }
   render() {
     const {
@@ -427,7 +442,7 @@ class AudioPlayer extends Component {
       playbackRate,
       setPlaybackRate,
     } = this.props
-    const { playEnabled, playing, progress, loading, buffered, sourceError } =
+    const { canSetTime, playing, progress, loading, buffered, sourceError } =
       this.state
     const isVideo = src.mp4 || src.hls
     const leftIconsWidth =
@@ -456,7 +471,6 @@ class AudioPlayer extends Component {
         {...styles.audio}
         {...attributes}
         ref={this.ref}
-        onLoadedMetadata={this.onCanPlay}
         crossOrigin='anonymous'
         playsInline
         webkit-playsinline=''
@@ -478,7 +492,6 @@ class AudioPlayer extends Component {
         {...styles.audio}
         {...attributes}
         ref={this.ref}
-        onLoadedMetadata={this.onCanPlay}
         crossOrigin='anonymous'
       >
         {src.mp3 && (
@@ -505,7 +518,7 @@ class AudioPlayer extends Component {
           audio={this.audio}
           playbackElement={playbackElement}
           playing={playing}
-          playEnabled={playEnabled}
+          canSetTime={canSetTime}
           progress={progress}
           loading={loading}
           sourceError={sourceError}
@@ -555,7 +568,7 @@ class AudioPlayer extends Component {
             <button
               {...styles.button}
               onClick={
-                playEnabled
+                canSetTime
                   ? () => {
                       this.setTime(this.audio.currentTime - 10)
                     }
@@ -565,23 +578,21 @@ class AudioPlayer extends Component {
             >
               <ReplayIcon
                 size={SIZE.replay}
-                {...(playEnabled && progress > 0
+                {...(canSetTime && progress > 0
                   ? colorScheme.set('fill', 'text')
                   : colorScheme.set('fill', 'disabled'))}
               />
             </button>
             <button
               {...styles.button}
-              onClick={playEnabled ? this.toggle : null}
+              onClick={this.toggle}
               title={t(`styleguide/AudioPlayer/${playing ? 'pause' : 'play'}`)}
               aria-live='assertive'
             >
               {!playing && (
                 <PlayIcon
                   size={SIZE.play}
-                  {...(playEnabled
-                    ? colorScheme.set('fill', 'text')
-                    : colorScheme.set('fill', 'disabled'))}
+                  {...colorScheme.set('fill', 'text')}
                 />
               )}
               {playing && (
@@ -594,7 +605,7 @@ class AudioPlayer extends Component {
             <button
               {...styles.button}
               onClick={
-                playEnabled
+                canSetTime
                   ? () => {
                       this.setTime(this.audio.currentTime + 30)
                     }
@@ -604,7 +615,7 @@ class AudioPlayer extends Component {
             >
               <ForwardIcon
                 size={SIZE.forward}
-                {...(playEnabled && progress > 0
+                {...(canSetTime && progress > 0
                   ? colorScheme.set('fill', 'text')
                   : colorScheme.set('fill', 'disabled'))}
               />
@@ -612,24 +623,16 @@ class AudioPlayer extends Component {
           </div>
           {download && (
             <div {...styles.download}>
-              {playEnabled && (
-                <a
-                  href={src.mp3 || src.aac || src.mp4}
-                  download
-                  title={t('styleguide/AudioPlayer/download')}
-                >
-                  <DownloadIcon
-                    size={SIZE.download}
-                    {...colorScheme.set('fill', 'text')}
-                  />
-                </a>
-              )}
-              {!playEnabled && (
+              <a
+                href={src.mp3 || src.aac || src.mp4}
+                download
+                title={t('styleguide/AudioPlayer/download')}
+              >
                 <DownloadIcon
                   size={SIZE.download}
-                  {...colorScheme.set('fill', 'disabled')}
+                  {...colorScheme.set('fill', 'text')}
                 />
-              )}
+              </a>
             </div>
           )}
           {closeHandler && (

--- a/packages/styleguide/src/components/AudioPlayer/docs.md
+++ b/packages/styleguide/src/components/AudioPlayer/docs.md
@@ -38,33 +38,55 @@ Context:
 
 ### Overlay Player
 
-```react|responsive
+```react
 state: {playbackRate: 1}
 ---
-<div
-  style={{
-    position: 'fixed',
-    width: '100%',
-    maxWidth: 414,
-    bottom: 44,
-    right: 0,
-    padding: '0 16px',
-    zIndex: 50,
-    transition: 'all ease-out 0.3s',
-}}>
-  <div style={{backgroundColor: 'white', boxShadow: '0 0 15px rgba(0,0,0,0.1)'}}>
-    <AudioPlayer
-      src={{
-        mp3: 'https://cdn.repub.ch/s3/republik-assets/assets/audio-artikel/republik_diktator_fichter.mp3'
-      }}
-      playbackRate={state.playbackRate}
-      setPlaybackRate={(rate) => setState({playbackRate: rate})}
-      mode='overlay'
-      download
-      title='Vier Schriftstellerinnen schildern die jahrelange russische Bedrohung der Ukraine. Dazu: Der Wochenkommentar und eine neue Podcast-Folge.'
-      t={t}
-    />
+<div style={{ minHeight: 360, position: 'relative' }}>
+  <div
+    style={{
+      position: 'absolute', // normally fixed
+      width: '100%',
+      maxWidth: 414,
+      bottom: 20,
+      right: 0,
+      padding: '0 16px',
+      zIndex: 50,
+      transition: 'all ease-out 0.3s',
+  }}>
+    <div style={{backgroundColor: 'white', boxShadow: '0 0 15px rgba(0,0,0,0.1)'}}>
+      <AudioPlayer
+        src={{
+          mp3: 'https://cdn.repub.ch/s3/republik-assets/assets/audio-artikel/republik_diktator_fichter.mp3'
+        }}
+        playbackRate={state.playbackRate}
+        setPlaybackRate={(rate) => setState({playbackRate: rate})}
+        mode='overlay'
+        download
+        title='Vier Schriftstellerinnen schildern die jahrelange russische Bedrohung der Ukraine. Dazu: Der Wochenkommentar und eine neue Podcast-Folge.'
+        t={t}
+      />
+    </div>
   </div>
+</div>
+```
+
+Missing File
+
+```react
+state: {playbackRate: 1}
+---
+<div style={{backgroundColor: 'white', boxShadow: '0 0 15px rgba(0,0,0,0.1)'}}>
+  <AudioPlayer
+    src={{
+      mp3: '/static/non-existing-sample.mp3'
+    }}
+    playbackRate={state.playbackRate}
+    setPlaybackRate={(rate) => setState({playbackRate: rate})}
+    mode='overlay'
+    download
+    title='Vier Schriftstellerinnen schildern die jahrelange russische Bedrohung der Ukraine. Dazu: Der Wochenkommentar und eine neue Podcast-Folge.'
+    t={t}
+  />
 </div>
 ```
 


### PR DESCRIPTION
## Perf Local Progress

The createPersistedState hook causes a constant re-render of the MediaProgressProvider which in turn caused the article progress to re-render and so forth. For this use case static `localStorage.getItem` and `localStorage.setItem` are much better. Later we shall refactor the players to use a proper media context.

## Lazy Load & Setting Time

iOS lazy loads audio and we used to work around that in a bad and buggy way. Now we respect that but trigger an explicit `audioElement.load()` if we have a media position or it's auto play. `loading` (waits for meta data) is now separate from `canSetTime` (`canPlay` event, used to be `playEnabled`). This should prevent buggy `currentTime` sets before the audio is ready.

## Source Error

There is now an example for the source error in the overview mode and the retry button actually works.

<img width="1000" alt="Screenshot 2022-04-01 at 18 06 49" src="https://user-images.githubusercontent.com/410211/161301022-922f0185-135a-4f23-b22c-649e230aec8d.png">

