### PR TITLE
Limit pending sign-in tokens

### DIFF
--- a/packages/backend-modules/auth/lib/challenges/AccessTokenChallenge.js
+++ b/packages/backend-modules/auth/lib/challenges/AccessTokenChallenge.js
@@ -21,12 +21,19 @@ module.exports = {
       throw new AccessTokenMissingError({ email })
     }
 
+    // Find tokens matching Type, email and payload (and ignoring expiry date
+    // willfully). A payload is unqiue and thus neither Type nor email is
+    // necessary to query but helps speeding up querying, and validating an
+    // AccessToken in payload would fail if email does not match.
     const tokenCount = await pgdb.public.tokens.count({
       type: Type,
       email,
       payload,
     })
 
+    // Since AccessTokens in tokens.payload are unique and should not be present
+    // in tokens at all, we throw an error if there are any returned which is an
+    // unwarrented auth behaviour.
     if (tokenCount >= MAX_VALID_TOKENS) {
       console.error(
         'Unable to generate a new token: Found too many valid tokens.',

--- a/packages/backend-modules/auth/lib/challenges/AccessTokenChallenge.js
+++ b/packages/backend-modules/auth/lib/challenges/AccessTokenChallenge.js
@@ -1,11 +1,11 @@
 const { newAuthError } = require('../AuthError')
 
 const AccessTokenMissingError = newAuthError(
-  'authorize-token-challenge-access-token-missing',
+  'access-token-challenge-access-token-missing',
   'api/auth/accessToken/accessTokenMissing',
 )
 const TokensExceededError = newAuthError(
-  'authorize-token-challenge-tokens-exceeded',
+  'access-token-challenge-tokens-exceeded',
   'api/auth/accessToken/tokensExceeded',
 )
 
@@ -21,21 +21,20 @@ module.exports = {
       throw new AccessTokenMissingError({ email })
     }
 
-    const existingPayloads = await pgdb.public.tokens.find({
+    const tokenCount = await pgdb.public.tokens.count({
       type: Type,
       email,
       payload,
     })
 
-    if (existingPayloads.length >= MAX_VALID_TOKENS) {
+    if (tokenCount >= MAX_VALID_TOKENS) {
       console.error(
         'Unable to generate a new token: Found too many valid tokens.',
       )
       throw new TokensExceededError({ email, MAX_VALID_TOKENS })
     }
 
-    const expiresAt = new Date(new Date().getTime() + TTL)
-    return { payload, expiresAt }
+    return { payload, expiresAt: new Date(new Date().getTime() + TTL) }
   },
   startChallenge: () => {}, // accessToken is generated and validated elsewhere
   validateChallenge: async ({ email, session, req, pgdb }, { payload }) => {

--- a/packages/backend-modules/auth/lib/challenges/AppChallenge.js
+++ b/packages/backend-modules/auth/lib/challenges/AppChallenge.js
@@ -53,12 +53,16 @@ const getNotification = ({ email, token, context }) => {
 module.exports = {
   Type,
   generateNewToken: async ({ email, pgdb }) => {
+    // Find tokens matching Type and email, which have not expired yet.
     const tokenCount = await pgdb.public.tokens.count({
       type: Type,
       email,
       'expiresAt >=': new Date(),
     })
 
+    // Throw an error if there are {MAX_VALID_TOKENS} or more tokens returned,
+    // as having more than a certain number of unexpired tokens is an unwarrented
+    // auth behaviour.
     if (tokenCount >= MAX_VALID_TOKENS) {
       console.error(
         'Unable to generate a new token: Found too many valid tokens.',

--- a/packages/backend-modules/auth/lib/challenges/EmailCodeChallenge.js
+++ b/packages/backend-modules/auth/lib/challenges/EmailCodeChallenge.js
@@ -22,6 +22,7 @@ const { DEFAULT_MAIL_FROM_ADDRESS } = process.env
 module.exports = {
   Type,
   generateNewToken: async ({ email, pgdb }) => {
+    // Find tokens matching Type and email, which have not expired yet.
     const existingPayloads = (
       await pgdb.public.tokens.find({
         type: Type,
@@ -30,6 +31,9 @@ module.exports = {
       })
     ).map((token) => token.payload)
 
+    // Throw an error if there are {MAX_VALID_TOKENS} or more tokens returned,
+    // as having more than a certain number of unexpired tokens is an unwarrented
+    // auth behaviour.
     if (existingPayloads.length >= MAX_VALID_TOKENS) {
       console.error(
         'Unable to generate a new token: Found too many valid tokens.',

--- a/packages/backend-modules/auth/lib/challenges/EmailTokenChallenge.js
+++ b/packages/backend-modules/auth/lib/challenges/EmailTokenChallenge.js
@@ -21,12 +21,16 @@ const Type = 'EMAIL_TOKEN'
 module.exports = {
   Type,
   generateNewToken: async ({ email, pgdb }) => {
+    // Find tokens matching Type and email, which have not expired yet.
     const tokenCount = await pgdb.public.tokens.count({
       type: Type,
       email,
       'expiresAt >=': new Date(),
     })
 
+    // Throw an error if there are {MAX_VALID_TOKENS} or more tokens returned,
+    // as having more than a certain number of unexpired tokens is an unwarrented
+    // auth behaviour.
     if (tokenCount >= MAX_VALID_TOKENS) {
       console.error(
         'Unable to generate a new token: Found too many valid tokens.',

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -1746,7 +1746,7 @@
     },
     {
       "key": "api/auth/emailCode/tokensExceeded",
-      "value": "Anzahl der gleichzeitig gültigen Tokens überschritten"
+      "value": "Zu viele Anmeldeversuche. Probieren Sie es in einer Stunde erneut."
     },
     {
       "key": "api/auth/emailCode/collison",
@@ -1758,7 +1758,15 @@
     },
     {
       "key": "api/auth/accessToken/tokensExceeded",
-      "value": "Anzahl der gleichzeitig gültigen Tokens überschritten"
+      "value": "Zu viele Anmeldeversuche. Probieren Sie es in einigen Minuten erneut."
+    },
+    {
+      "key": "api/auth/app/tokensExceeded",
+      "value": "Zu viele Anmeldeversuche. Probieren Sie es in 10 Minuten erneut."
+    },
+    {
+      "key": "api/auth/emailToken/tokensExceeded",
+      "value": "Zu viele Anmeldeversuche. Probieren Sie es in einer Stunde erneut."
     },
     {
       "key": "api/commit/templateTitle/required",


### PR DESCRIPTION
This Pull Request address [a report from our bug bounty program](https://app.gobugfree.com/account/programs/republik/submissions/KAYPWRGlBq) which could have triggered a vast amount of sign-in emails.

It limits `mutation signIn` with type `EMAIL_TOKEN` to 5 per hour (this imitating an existing rate limit with type `EMAIL_CODE`). It uses a sliding window to open up slots to request more sign-in emails.

It furthermore limits type `APP` – authorizing via App – to 5 requests per 10 minutes.

Once a limit is reached, a `TokensExceededError` is thrown a human readable error message.

It ever so slightly refactors token counting: count tokens instead of fetching them if payloads are not required to generate a new token.

**A screenshot with a sample error message**

<img width="620" alt="Bildschirmfoto 2022-04-05 um 15 56 46" src="https://user-images.githubusercontent.com/331800/161770398-0813fce8-bbfa-49c7-9236-a888da83c5b2.png">

