### PR TITLE
fix(www): update translation string in Account/Memberships

### DIFF
--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3570,7 +3570,7 @@
     },
     {
       "key": "memberships/latestPeriod/renew/true/autoPay/false",
-      "value": "Bezahlt bis am {formattedEndDate}"
+      "value": "Erneuerung vor dem {formattedEndDate} nötig"
     },
     {
       "key": "memberships/MONTHLY_ABO/latestPeriod/renew/true/autoPay/false",


### PR DESCRIPTION
This Pull Request replaces misleading string ("paid until") with a hint ("renew before"), if membership is uncancelled but AutoPay is disabled.

**Before/after beauty shot**

<img width="632" alt="Bildschirmfoto 2022-04-05 um 13 54 57" src="https://user-images.githubusercontent.com/331800/161749086-8f4777bb-87c9-472f-952a-2152a168db56.png">