### PR TITLE
fix(www/Checkout): show the contact-form if a user has no fname or lname

### DIFF
--- a/apps/www/components/Pledge/Submit.js
+++ b/apps/www/components/Pledge/Submit.js
@@ -861,38 +861,51 @@ class Submit extends Component {
               <br />
             </>
           )}
-          {me && (
-            <Interaction.P>
-              {t('pledge/contact/signedinAs', {
-                nameOrEmail: me.name
-                  ? `${me.name.trim()} (${me.email})`
-                  : me.email,
-              })}{' '}
-              <A
-                href='#'
-                onClick={(e) => {
-                  e.preventDefault()
-                  this.setState({ emailVerify: false })
-                  this.props.signOut().then(() => {
-                    contactState.onChange({
-                      values: {
-                        firstName: '',
-                        lastName: '',
-                        email: '',
-                      },
-                      dirty: {
-                        firstName: false,
-                        lastName: false,
-                        email: false,
-                      },
+          {customMe && (
+            <>
+              <Label>{t('pledge/contact/email/label')}</Label>
+              <Interaction.P>{customMe.email}</Interaction.P>
+              <br />
+              {me ? (
+                <A
+                  href='#'
+                  onClick={(e) => {
+                    e.preventDefault()
+                    this.setState({ emailVerify: false })
+                    this.props.signOut().then(() => {
+                      contactState.onChange({
+                        values: {
+                          firstName: '',
+                          lastName: '',
+                          email: '',
+                        },
+                        dirty: {
+                          firstName: false,
+                          lastName: false,
+                          email: false,
+                        },
+                      })
+                      this.setState({ showSignIn: false })
                     })
-                    this.setState({ showSignIn: false })
-                  })
-                }}
-              >
-                {t('pledge/contact/signOut')}
-              </A>
-            </Interaction.P>
+                  }}
+                >
+                  {t('pledge/contact/signOut')}
+                </A>
+              ) : (
+                <Link
+                  href={{
+                    pathname: '/angebote',
+                    query: {
+                      package: packageName,
+                    },
+                  }}
+                  replace
+                  passHref
+                >
+                  <A>{t('pledge/contact/signIn/wrongToken')}</A>
+                </Link>
+              )}
+            </>
           )}
         </div>
         <div {...styles.topMargin}>
@@ -965,28 +978,6 @@ class Submit extends Component {
                       ])}
                     </Label>
                     <div style={{ marginTop: 10, marginBottom: 10 }}>
-                      {customMe && !me && (
-                        <>
-                          <Interaction.P>
-                            <Label>{t('pledge/contact/email/label')}</Label>
-                            <br />
-                            {customMe.email}
-                          </Interaction.P>
-                          <br />
-                          <Link
-                            href={{
-                              pathname: '/angebote',
-                              query: {
-                                package: packageName,
-                              },
-                            }}
-                            replace
-                            passHref
-                          >
-                            <A>{t('pledge/contact/signIn/wrongToken')}</A>
-                          </Link>
-                        </>
-                      )}
                       {requireContactData && <FieldSet {...contactState} />}
                     </div>
                   </div>

--- a/apps/www/components/Pledge/Submit.js
+++ b/apps/www/components/Pledge/Submit.js
@@ -827,8 +827,8 @@ class Submit extends Component {
     const isStripePayment =
       selectedPaymentMethod && selectedPaymentMethod.startsWith('STRIPE')
 
-    // In case of Probelesen, a user might have an account, but first and lastname are missing
-    const requireFAndLName = me && (!me.firstName || !me.lastName)
+    // even with token or when signed in we still need name fields
+    const requireContactData = contactState.fields.length > 0
 
     return (
       <>
@@ -954,7 +954,7 @@ class Submit extends Component {
             )}
             {
               // Only render the browser API in case we're not using a browser payment API
-              (!me || requireFAndLName) &&
+              requireContactData &&
                 this.props.selectedPaymentMethod &&
                 !this.isStripeWalletPayment() && (
                   <div {...styles.topMargin}>
@@ -965,7 +965,7 @@ class Submit extends Component {
                       ])}
                     </Label>
                     <div style={{ marginTop: 10, marginBottom: 10 }}>
-                      {customMe && !requireFAndLName ? (
+                      {customMe && !me && (
                         <>
                           <Interaction.P>
                             <Label>{t('pledge/contact/email/label')}</Label>
@@ -986,9 +986,8 @@ class Submit extends Component {
                             <A>{t('pledge/contact/signIn/wrongToken')}</A>
                           </Link>
                         </>
-                      ) : (
-                        <FieldSet {...contactState} />
                       )}
+                      {requireContactData && <FieldSet {...contactState} />}
                     </div>
                   </div>
                 )

--- a/apps/www/components/Pledge/Submit.js
+++ b/apps/www/components/Pledge/Submit.js
@@ -827,6 +827,9 @@ class Submit extends Component {
     const isStripePayment =
       selectedPaymentMethod && selectedPaymentMethod.startsWith('STRIPE')
 
+    // In case of Probelesen, a user might have an account, but first and lastname are missing
+    const requireFAndLName = me && (!me.firstName || !me.lastName)
+
     return (
       <>
         <div {...styles.topMargin}>
@@ -951,7 +954,7 @@ class Submit extends Component {
             )}
             {
               // Only render the browser API in case we're not using a browser payment API
-              !me &&
+              (!me || requireFAndLName) &&
                 this.props.selectedPaymentMethod &&
                 !this.isStripeWalletPayment() && (
                   <div {...styles.topMargin}>
@@ -962,7 +965,7 @@ class Submit extends Component {
                       ])}
                     </Label>
                     <div style={{ marginTop: 10, marginBottom: 10 }}>
-                      {customMe && !me ? (
+                      {customMe && !requireFAndLName ? (
                         <>
                           <Interaction.P>
                             <Label>{t('pledge/contact/email/label')}</Label>

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -2657,10 +2657,6 @@
       "value": "Kontaktinformationen des Zahlenden"
     },
     {
-      "key": "pledge/contact/signedinAs",
-      "value": "Sie sind angemeldet als: {nameOrEmail}"
-    },
-    {
       "key": "pledge/contact/pastPledges/1",
       "value": "Sie haben bereits einmal mitgemacht."
     },


### PR DESCRIPTION
## Description

As of now the contact-form was only shown if both the me and customMe are not present. However with problesen, a me-object might exist but the first and lastname are missing.
This PR adds an additional check that shows the contact-form even if me is present, when fName or lName are missing