### PR TITLE
feat(mail): restore interests on Mailchimp if last event was type "cleaned"

### DIFF
--- a/packages/backend-modules/mail/migrations/sqls/20220413113433-mailchimp-log-index-email-down.sql
+++ b/packages/backend-modules/mail/migrations/sqls/20220413113433-mailchimp-log-index-email-down.sql
@@ -1,0 +1,1 @@
+DROP INDEX public."mailchimpLog_email_idx" ;

--- a/packages/backend-modules/mail/migrations/sqls/20220413113433-mailchimp-log-index-email-up.sql
+++ b/packages/backend-modules/mail/migrations/sqls/20220413113433-mailchimp-log-index-email-up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "mailchimpLog_email_idx" ON "public"."mailchimpLog"("email") ;

--- a/packages/backend-modules/migrations/migrations/20220413113433-mailchimp-log-index-email.js
+++ b/packages/backend-modules/migrations/migrations/20220413113433-mailchimp-log-index-email.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/mail/migrations/sqls'
+const file = '20220413113433-mailchimp-log-index-email'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
This Pull Request checks on MailChimp Webhook event type "subscribe" if latest record in `mailchimLog` for an email address is type "cleaned". If so, it will call `enforceSubscription` and thus updating and restoring interests.

It should resolve a race condition (we hot fixed in 57701d787eb6f2075af936451033cbd41f90d933).