### PR TITLE
feat(onboarding): add dialog hints to onboarding end

### DIFF
--- a/apps/www/components/Onboarding/Page.js
+++ b/apps/www/components/Onboarding/Page.js
@@ -327,6 +327,33 @@ class Page extends Component {
                 </P>
 
                 <P {...styles.p}>
+                  {t.elements('Onboarding/Sections/Profile/dialogParagraph', {
+                    linkHowTo: (
+                      <Link
+                        key='mitdebattieren-leicht-gemacht'
+                        href='/2022/02/08/mitdebattieren-leicht-gemacht'
+                        passHref
+                      >
+                        <A>
+                          {t(
+                            'Onboarding/Sections/Profile/dialogParagraph/linkHowTo',
+                          )}
+                        </A>
+                      </Link>
+                    ),
+                    linkToDialog: (
+                      <Link key='dialog' href='/dialog' passHref>
+                        <A>
+                          {t(
+                            'Onboarding/Sections/Profile/dialogParagraph/linkToDialog',
+                          )}
+                        </A>
+                      </Link>
+                    ),
+                  })}
+                </P>
+
+                <P {...styles.p}>
                   {t.first.elements(
                     [
                       `Onboarding/Page/${context}/more/questions`,

--- a/apps/www/components/Onboarding/Sections/Profile.js
+++ b/apps/www/components/Onboarding/Sections/Profile.js
@@ -126,10 +126,7 @@ class Profile extends Component {
         {...this.props}
       >
         <P {...styles.p}>
-          {t('Onboarding/Sections/Profile/paragraph1', null, '')}
-        </P>
-        <P {...styles.p}>
-          {t('Onboarding/Sections/Profile/paragraph2', null, '')}
+          {t('Onboarding/Sections/Profile/paragraph', null, '')}
         </P>
         <div {...merge(styles.portrait)}>
           <Portrait

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -5225,12 +5225,8 @@
       "value": "Profil"
     },
     {
-      "key": "Onboarding/Sections/Profile/paragraph1",
-      "value": "Das Profil ist Ihre Visitenkarte bei der Republik."
-    },
-    {
-      "key": "Onboarding/Sections/Profile/paragraph2",
-      "value": "Wir verlinken Ihr Profil zum Beispiel bei Ihren Dialogbeiträgen."
+      "key": "Onboarding/Sections/Profile/paragraph",
+      "value": "Das Profil ist Ihre Visitenkarte bei der Republik. Wir verlinken Ihr Profil zum Beispiel bei Ihren Dialogbeiträgen."
     },
     {
       "key": "Onboarding/Sections/Profile/button/save",
@@ -5239,6 +5235,18 @@
     {
       "key": "Onboarding/Sections/Profile/button/continue",
       "value": "Später"
+    },
+    {
+      "key": "Onboarding/Sections/Profile/dialogParagraph",
+      "value": "Teilen Sie Ihre Meinung, Ihre Kritik und Ihre Fragen mit der Community! Eine anschauliche Übersicht über alle Funktionen finden Sie in der {linkHowTo}, und auf der {linkToDialog} sehen Sie, was aktuell bei der Republik zu reden gibt. "
+    },
+    {
+      "key": "Onboarding/Sections/Profile/dialogParagraph/linkHowTo",
+      "value": "Dialog-Anleitung"
+    },
+    {
+      "key": "Onboarding/Sections/Profile/dialogParagraph/linkToDialog",
+      "value": "Dialog-Übersicht"
     },
     {
       "key": "Trial/Form/withAccess/button/label",


### PR DESCRIPTION
<img width="505" alt="Screenshot 2022-04-13 at 14 55 42" src="https://user-images.githubusercontent.com/20746301/163184782-0137f154-4fe5-4db6-9264-3f1ba5969077.png">

Minimal version. Would be nice to have it more integrated in the flow but it doesn't coneptually fit in the "Einrichten" context. All of the current sections have actions attached to them. The text about dialog is more of a hint, and there is no onboarding action to be taken. Also, it is kind of weird to direct people to the comments section before they have a chance to read the magazine. 

In general, I'm not convinced that the dialog needs to be present in the onboarding - except for dialog notification options. 