### PR TITLE
fix(publikator): query Document.id on meta.format to avoid invariant violation

### DIFF
--- a/apps/publikator/components/Publication/Current.js
+++ b/apps/publikator/components/Publication/Current.js
@@ -49,6 +49,7 @@ export const getRepoWithPublications = gql`
           meta {
             path
             format {
+              id
               meta {
                 externalBaseUrl
               }

--- a/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendationItem.js
+++ b/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendationItem.js
@@ -229,6 +229,7 @@ export default compose(
           publishDate
           credits
           format {
+            id
             meta {
               title
               color


### PR DESCRIPTION
This Pull Request should resolve caching errors when opening a doc via repo list.

It was caused due to missing identifier (`id`) on meta.format queries which let to a caching error (invariant violation).

Added to https://github.com/republik/plattform/pull/95/files#diff-fa5d18ff5fd5ad40adb95829b7d4ab87cbb2aa73588976841f01e48e898f07f3R52.

<img width="771" alt="Bildschirmfoto 2022-04-25 um 08 41 18" src="https://user-images.githubusercontent.com/331800/165034155-7573fa8d-690f-4989-b865-028e4968ff57.png">

And while checking, found [this one lacking an identifier, too](https://github.com/republik/plattform/pull/95/files#diff-e3d148c22ad217e6565b38a1216b38ffc08f949b5f30825e8abce485cecbeb80R232) – which might have caused an issue when linking recommendation documents with a format; while Repo-URL is correct and data got fetched, it refused to render recommendation properly. (Might be of interest to @trm217.)

![grafik](https://user-images.githubusercontent.com/331800/165035464-dff43ba0-eced-4ac1-9fd4-a29c7140092c.png)