### PR TITLE
Fix/read aloud return estimated reading minutes

### DIFF
--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -151,13 +151,9 @@ const ActionBar = ({
     meta.path,
   )
 
-  const readingMinutes = Math.max(
-    meta.estimatedConsumptionMinutes,
-    meta.estimatedReadingMinutes,
-  )
+  const displayMinutes = meta.estimatedConsumptionMinutes % 60
+  const displayHours = Math.floor(meta.estimatedConsumptionMinutes / 60)
 
-  const displayMinutes = readingMinutes % 60
-  const displayHours = Math.floor(readingMinutes / 60)
   const forceShortLabel =
     mode === 'articleOverlay' ||
     mode === 'feed' ||

--- a/packages/backend-modules/documents/graphql/schema-types.js
+++ b/packages/backend-modules/documents/graphql/schema-types.js
@@ -101,7 +101,6 @@ type Meta {
   disableActionBar: Boolean
 
   estimatedReadingMinutes: Int
-  totalMediaMinutes: Int
   estimatedConsumptionMinutes: Int
 
   # template of the article

--- a/packages/backend-modules/documents/lib/meta.js
+++ b/packages/backend-modules/documents/lib/meta.js
@@ -147,10 +147,21 @@ const isReadingMinutesSuppressed = (fields, resolvedFields) =>
         resolvedFields.format.meta.repoId,
       )))
 
-const getEstimatedConsumptionMinutes = (doc, estimatedReadingMinutes) =>
-  doc.meta && doc.meta.audioSource && doc.meta.audioSource.durationMs
-    ? Math.round(doc.meta.audioSource.durationMs / 1000 / 60)
-    : estimatedReadingMinutes
+const getEstimatedConsumptionMinutes = (doc, estimatedReadingMinutes) => {
+  const durationMs = doc.meta?.audioSource?.durationMs
+  const kind = doc.meta?.audioSource?.kind
+
+  // Return audio duration in minutes if audioSource provides duration in ms and
+  // audioSource.kind is neither "readAloud" or "syntheticReadAloud". As their an
+  // audio representation of written content, these should not be counted towards
+  // consumption time.
+  const audioDurationMinutes =
+    !!durationMs &&
+    !['readAloud', 'syntheticReadAloud'].includes(kind) &&
+    Math.round(durationMs / (1000 * 60))
+
+  return Math.max(audioDurationMinutes, estimatedReadingMinutes)
+}
 
 // _meta is present on unpublished docs
 // { repo { publication { commit { document } } } }


### PR DESCRIPTION
This Pull Requests moves reading and media time logic to API.

- app/www depends on `Meta.estimatedConsumptionMinutes` solely
- app/api provides either reading or media consumption time. If an `audioSource` is flagged as `readAloud` or `syntheticReadAloud`, it will return estimated reading time, since "read aloud" is a different representation of written content (like a PDF file)
- app/api loses unused `Meta.totalMediaMinutes`