### PR TITLE
Slight improvements to Publikator Recommendations editor

### DIFF
--- a/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendationItem.js
+++ b/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendationItem.js
@@ -169,17 +169,19 @@ const ArticleRecommendationItem = ({
             </span>
           )}
         </div>
-        <div {...styles.linkWrapper}>
-          {(isPublishedForPublic || isInternallyPublished) && (
-            <PublicationLink publication={latestPublication} />
-          )}
-          <IconButton
-            href={`/repo/${getRelativeRepoUrl(repoId)}/tree`}
-            target='_blank'
-            Icon={EditIcon}
-            fill='#E9A733'
-          />
-        </div>
+        {repoData && (
+          <div {...styles.linkWrapper}>
+            {(isPublishedForPublic || isInternallyPublished) && (
+              <PublicationLink publication={latestPublication} />
+            )}
+            <IconButton
+              href={`/repo/${getRelativeRepoUrl(repoId)}/tree`}
+              target='_blank'
+              Icon={EditIcon}
+              fill='#E9A733'
+            />
+          </div>
+        )}
       </div>
       <div {...styles.closeWrapper}>
         <IconButton

--- a/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendations.js
+++ b/apps/publikator/components/editor/modules/meta/ArticleRecommendations/ArticleRecommendations.js
@@ -124,6 +124,7 @@ const ArticleRecommendations = ({ t, editor, node }) => {
                             setShowRepoSearch(false)
                             addSuggestion(value)
                           }}
+                          autoFocus
                         />
                       </div>
                     </li>

--- a/apps/publikator/components/editor/utils/RepoSearch.js
+++ b/apps/publikator/components/editor/utils/RepoSearch.js
@@ -159,7 +159,7 @@ const ConnectedAutoComplete = graphql(filterRepos, {
     return {
       data: props.data,
       items: nodes.map(createRepoItem),
-      autoFocus: props?.autoFocus,
+      autoFocus: props.autoFocus,
     }
   },
 })((props) => {
@@ -251,7 +251,7 @@ export default class RepoSearch extends Component {
         items={[]}
         onChange={this.changeHandler}
         onFilterChange={this.filterChangeHandler}
-        autoFocus={this.props?.autoFocus}
+        autoFocus={this.props.autoFocus}
       />
     )
   }

--- a/apps/publikator/components/editor/utils/RepoSearch.js
+++ b/apps/publikator/components/editor/utils/RepoSearch.js
@@ -159,6 +159,7 @@ const ConnectedAutoComplete = graphql(filterRepos, {
     return {
       data: props.data,
       items: nodes.map(createRepoItem),
+      autoFocus: props?.autoFocus,
     }
   },
 })((props) => {
@@ -250,6 +251,7 @@ export default class RepoSearch extends Component {
         items={[]}
         onChange={this.changeHandler}
         onFilterChange={this.filterChangeHandler}
+        autoFocus={this.props?.autoFocus}
       />
     )
   }

--- a/packages/styleguide/src/components/Form/Autocomplete.js
+++ b/packages/styleguide/src/components/Form/Autocomplete.js
@@ -20,6 +20,7 @@ const Autocomplete = ({
   onFilterChange,
   icon,
   autoComplete,
+  autoFocus = false,
 }) => {
   return (
     <Downshift
@@ -65,6 +66,7 @@ const Autocomplete = ({
                         }
                       },
                       autoComplete,
+                      autoFocus,
                       placeholder: selectedItem
                         ? itemToString(selectedItem)
                         : '',


### PR DESCRIPTION
## Description

- Only show the Publikator Link when a document was found.
- AutoFocus on RepoSearch input when adding an article to the recommendations 