### PR TITLE
fix(admin): render address name in payments list

### DIFF
--- a/apps/admin/components/Payments/List/Table.js
+++ b/apps/admin/components/Payments/List/Table.js
@@ -70,7 +70,7 @@ const Table = ({ items, sort, onSort, ...props }) => {
             <Label>Name</Label>
           </th>
           <th {...styles.left}>
-            <Label>Adresse</Label>
+            <Label>Anschrift</Label>
           </th>
           <th
             {...styles.interactive}
@@ -102,6 +102,8 @@ const Table = ({ items, sort, onSort, ...props }) => {
             user: { address },
           } = payment
 
+          const name = user.name || `${user.firstName} ${user.lastName}`
+
           return (
             <tr key={`payment-${index}`} {...styles.row}>
               <td>{displayDate(payment.createdAt)}</td>
@@ -109,19 +111,19 @@ const Table = ({ items, sort, onSort, ...props }) => {
               <td>{payment.method}</td>
               <td>
                 <Link route='user' params={{ userId: user.id }}>
-                  <a {...styles.link}>
-                    {user.name || `${user.firstName} ${user.lastName}`}
-                  </a>
+                  <a {...styles.link}>{name}</a>
                 </Link>
               </td>
               <td>
                 {address &&
                   [
+                    name !== address.name && address.name,
                     address.line1,
                     address.line2,
-                    [address.postalCode, address.city].join(' '),
+                    [address.postalCode, address.city].join(' ').trim(),
                   ]
                     .filter(Boolean)
+                    .map((string) => string.trim())
                     .join(', ')}
               </td>
               <td>{chfFormat(payment.total / 100)}</td>


### PR DESCRIPTION
This Pull Request will render `Address.name` in Admin-Tool payments list if string differs from a users name. It helps Finance to find payments easier.

<img width="1006" alt="Bildschirmfoto 2022-04-28 um 17 32 38" src="https://user-images.githubusercontent.com/331800/165789505-c1cfc078-0c64-4d61-9071-c2e2fb48e695.png">

