### PR TITLE
fix(ScatterPlots): avoid conflict of point size and breakout size

### DIFF
--- a/packages/styleguide/src/components/Chart/ChartContext.js
+++ b/packages/styleguide/src/components/Chart/ChartContext.js
@@ -250,7 +250,6 @@ export const defaultProps = {
     paddingRight: 1,
     paddingBottom: 50,
     paddingLeft: 30,
-    size: 'size',
     sizeRangeMax: 4,
     label: 'label',
     heightRatio: 1,

--- a/packages/styleguide/src/components/Chart/ScatterPlots.docs.md
+++ b/packages/styleguide/src/components/Chart/ScatterPlots.docs.md
@@ -262,7 +262,7 @@ Use `inlineLabel`, `inlineSecondaryLabel` and `inlineLabelPosition`. Valid posit
       "inlineLabel": "inline",
       "inlineSecondaryLabel": "inline_country",
       "inlineLabelPosition": "inline_pos",
-      "size": "vote_abs",
+      "pointSize": "vote_abs",
       "sizeRangeMax": 40,
       "sizeUnit": "Stimmen",
       "sizeNumberFormat": ".2s",

--- a/packages/styleguide/src/components/Chart/ScatterPlots.js
+++ b/packages/styleguide/src/components/Chart/ScatterPlots.js
@@ -60,8 +60,7 @@ const ScatterPlot = ({
   colorMap,
   colorSort,
   colorDarkMapping,
-  size,
-  sizeRange,
+  pointSize,
   sizeRangeMax,
   sizeUnit,
   sizeNumberFormat,
@@ -86,16 +85,18 @@ const ScatterPlot = ({
   minInnerWidth,
   annotations,
   allowCanvasRendering,
+  ...props
 }) => {
   const data = values
     .filter((d) => d[x] && d[x].length > 0 && d[y] && d[y].length > 0)
     .map((d) => {
-      const dSize = d[size]
+      const sizeDataColumn = pointSize || props.size || 'size'
+      const dSize = d[sizeDataColumn]
       return {
         datum: d,
         x: +d[x],
         y: +d[y],
-        size: dSize === undefined ? 1 : +d[size] || 0,
+        size: dSize === undefined ? 1 : +d[sizeDataColumn] || 0,
       }
     })
 
@@ -207,8 +208,8 @@ const ScatterPlot = ({
     .domain([0, max(data, (d) => d.size)])
     .range([
       0,
-      sizeRange
-        ? sizeRange[1] // backwards compatible
+      props.sizeRange // backwards compatible, sizeRangeMax has default value
+        ? props.sizeRange[1]
         : sizeRangeMax,
     ])
 
@@ -323,7 +324,7 @@ export const propTypes = {
   }).isRequired,
   colorMap: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   colorSort: sortPropType,
-  size: PropTypes.string.isRequired,
+  pointSize: PropTypes.string.isRequired,
   sizeRangeMax: PropTypes.number.isRequired,
   sizeUnit: PropTypes.string,
   sizeNumberFormat: PropTypes.string,


### PR DESCRIPTION
The `size` property of the chart config is usually passed to `Breakout` for breaking out of the normal size. However for scatter plots the `size` prop was also used for the point size within the plot. This lead to conflicts when we e.g. wanted a `narrow` scatter plot with a `size` from the data column `rate`. We worked around this by usually renaming the data column to `narrow` ;-) The new `pointSize` prop (with a fallback to `size` for backwards compat) should make such workaround no longer necessary. I also explored introducing a `breakoutSize` prop but that was way more intrusive.