### PR TITLE
feat: document api keys

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -252,6 +252,11 @@ GITHUB_LOGIN=
 # querying a single document by path is always allowed
 #DOCUMENTS_RESTRICT_TO_ROLES=member,editor
 
+# Document API Keys can be used to query
+# restricted member only documents without a cookie
+# for example: frontend caches and Google News sitemap
+# DOCUMENTS_API_KEYS=[{"key":"long-safe-secret","name":"frontend"}]
+
 # maintenance: disable publishing
 # DISABLE_PUBLISH=true
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -250,7 +250,10 @@ GITHUB_LOGIN=
 # restricts the documents endpoint to users with the following roles
 # totalCount is always available
 # querying a single document by path is always allowed
-#DOCUMENTS_RESTRICT_TO_ROLES=member,editor
+# DOCUMENTS_RESTRICT_TO_ROLES=member,editor
+
+# strip links from overview pages
+DOCUMENTS_LINKS_RESTRICTED=/
 
 # Document API Keys can be used to query
 # restricted member only documents without a cookie

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -258,7 +258,7 @@ DOCUMENTS_LINKS_RESTRICTED=/
 # Document API Keys can be used to query
 # restricted member only documents without a cookie
 # for example: frontend caches and Google News sitemap
-# DOCUMENTS_API_KEYS=[{"key":"long-safe-secret","name":"frontend"}]
+# DOCUMENTS_API_KEYS=[{"name":"frontend","value":"long-safe-secret"}]
 
 # maintenance: disable publishing
 # DISABLE_PUBLISH=true

--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -8,6 +8,8 @@ const util = require('util')
 
 const { NODE_ENV, COOKIE_NAME, WS_KEEPALIVE_INTERVAL } = process.env
 
+const documentApiKeyScheme = 'DocumentApiKey'
+
 module.exports = (
   server,
   httpServer,
@@ -22,10 +24,17 @@ module.exports = (
     },
   })
 
-  const createContext = ({ scope = undefined, user, ...rest } = {}) => {
+  const createContext = ({ scope = undefined, user, req, ...rest } = {}) => {
+    const authorization = req?.get('Authorization')
+    const documentApiKey = authorization?.startsWith(documentApiKeyScheme)
+      ? authorization.slice(documentApiKeyScheme.length + 1)
+      : null
+
     const context = createGraphqlContext({
       ...rest,
+      req,
       scope,
+      documentApiKey,
       user: global && global.testUser !== undefined ? global.testUser : user,
     })
     // prime User dataloader with me

--- a/packages/backend-modules/documents/graphql/resolvers/Document.js
+++ b/packages/backend-modules/documents/graphql/resolvers/Document.js
@@ -81,9 +81,9 @@ module.exports = {
         processEmbedImageUrlsInContent(doc.content, addFormatAuto),
       ])
 
-      processMembersOnlyZonesInContent(doc.content, context.user)
+      processMembersOnlyZonesInContent(doc.content, context.user, doc._apiKey)
       processNodeModifiersInContent(doc.content, context.user)
-      processIfHasAccess(doc.content, context.user)
+      processIfHasAccess(doc.content, context.user, doc._apiKey)
     }
     return doc.content
   },
@@ -98,6 +98,7 @@ module.exports = {
         urlPrefix,
         searchString,
         context.user || null,
+        doc._apiKey,
       )
 
       await processRepoImageUrlsInMeta(doc.content, addFormatAuto)
@@ -163,9 +164,9 @@ module.exports = {
           processEmbedImageUrlsInContent(node, addFormatAuto),
         ])
 
-        processMembersOnlyZonesInContent(node, context.user)
+        processMembersOnlyZonesInContent(node, context.user, doc._apiKey)
         processNodeModifiersInContent(node, context.user)
-        processIfHasAccess(node, context.user)
+        processIfHasAccess(node, context.user, doc._apiKey)
 
         return extractIdsFromNode(node, doc.meta.repoId)
       })

--- a/packages/backend-modules/documents/graphql/resolvers/_queries/document.js
+++ b/packages/backend-modules/documents/graphql/resolvers/_queries/document.js
@@ -1,13 +1,13 @@
 const getDocuments = require('./documents')
 
 module.exports = async (_, args, context, info) => {
-  const { id, path, repoId } = args
+  const { id, path, repoId, apiKey } = args
 
   if (!path && !id && !repoId) {
     throw new Error('Please provide a path or repoId')
   }
 
-  return getDocuments(_, { id, path, repoId }, context, info).then(
+  return getDocuments(_, { id, path, repoId, apiKey }, context, info).then(
     (docCon) => docCon.nodes[0],
   )
 }

--- a/packages/backend-modules/documents/graphql/resolvers/_queries/documents.js
+++ b/packages/backend-modules/documents/graphql/resolvers/_queries/documents.js
@@ -8,6 +8,7 @@ module.exports = async (__, args, context, info) => {
       first: args.first,
       after: args.after,
       before: args.before,
+      apiKey: args.apiKey,
       unrestricted:
         args.unrestricted !== undefined
           ? args.unrestricted
@@ -15,7 +16,7 @@ module.exports = async (__, args, context, info) => {
           ? true
           : undefined,
       filter: {
-        ..._.omit(args, ['first', 'after', 'before', 'unrestricted']),
+        ..._.omit(args, ['first', 'after', 'before', 'unrestricted', 'apiKey']),
         type: 'Document',
       },
       sort: {

--- a/packages/backend-modules/documents/graphql/schema.js
+++ b/packages/backend-modules/documents/graphql/schema.js
@@ -22,10 +22,12 @@ type queries {
     last: Int
     before: String
     after: String
+    apiKey: String
   ): DocumentConnection!
   # (pre)published document
   document(
     path: String!
+    apiKey: String
   ): Document
 }
 `

--- a/packages/backend-modules/documents/lib/process.u.jest.js
+++ b/packages/backend-modules/documents/lib/process.u.jest.js
@@ -1,3 +1,8 @@
+jest.mock('@orbiting/backend-modules-auth', () => ({
+  Roles: {
+    userIsInRoles: jest.fn(),
+  },
+}))
 jest.mock('./restrictions', () => ({
   hasFullDocumentAccess: jest.fn(),
 }))

--- a/packages/backend-modules/documents/lib/process.u.jest.js
+++ b/packages/backend-modules/documents/lib/process.u.jest.js
@@ -1,7 +1,5 @@
-jest.mock('@orbiting/backend-modules-auth', () => ({
-  Roles: {
-    userIsInRoles: jest.fn(),
-  },
+jest.mock('./restrictions', () => ({
+  hasFullDocumentAccess: jest.fn(),
 }))
 
 const UUT = require('./process')
@@ -316,8 +314,8 @@ const getMdast = () => ({
 describe('process', () => {
   describe('processIfHasAccess', () => {
     it('keeps non-member nodes if user has no access', () => {
-      const { Roles } = require('@orbiting/backend-modules-auth')
-      Roles.userIsInRoles.mockReturnValue(false)
+      const { hasFullDocumentAccess } = require('./restrictions')
+      hasFullDocumentAccess.mockReturnValue(false)
 
       const mdast = getMdast()
 
@@ -326,8 +324,8 @@ describe('process', () => {
     })
 
     it('keeps member nodes if user has access', () => {
-      const { Roles } = require('@orbiting/backend-modules-auth')
-      Roles.userIsInRoles.mockReturnValue(true)
+      const { hasFullDocumentAccess } = require('./restrictions')
+      hasFullDocumentAccess.mockReturnValue(true)
 
       const mdast = getMdast()
       UUT.processIfHasAccess(mdast)

--- a/packages/backend-modules/documents/lib/resolve.js
+++ b/packages/backend-modules/documents/lib/resolve.js
@@ -1,6 +1,6 @@
 const checkEnv = require('check-env')
 const visit = require('unist-util-visit')
-const { isValidApiKey, isUserUnrestricted } = require('./restrictions')
+const { hasFullDocumentAccess } = require('./restrictions')
 
 checkEnv(['FRONTEND_BASE_URL'])
 
@@ -214,8 +214,7 @@ const contentUrlResolver = (
     // user is undefined during publish -> no stripping
     // null during document delivery -> strip unless authorized
     user !== undefined &&
-    !isUserUnrestricted(user) &&
-    !isValidApiKey(doc._apiKey)
+    !hasFullDocumentAccess(user, doc._apiKey)
 
   visit(doc.content, 'link', (node) => {
     node.url = urlReplacer(node.url, stripDocLinks)
@@ -272,6 +271,7 @@ const metaUrlResolver = (
   urlPrefix,
   searchString,
   user,
+  apiKey,
 ) => {
   const urlReplacer = createUrlReplacer(
     _all,
@@ -287,7 +287,7 @@ const metaUrlResolver = (
       !episode.document?.meta?.path ||
       episode.document.meta.path === meta.path ||
       user === undefined ||
-      isUserUnrestricted(user)
+      hasFullDocumentAccess(user, apiKey)
     ) {
       return
     }
@@ -302,7 +302,7 @@ const metaUrlResolver = (
         c.url = urlReplacer(c.url)
       })
 
-  if (user === undefined || !isUserUnrestricted(user)) {
+  if (user === undefined || !hasFullDocumentAccess(user, apiKey)) {
     meta.recommendations = null
   }
 }

--- a/packages/backend-modules/documents/lib/resolve.js
+++ b/packages/backend-modules/documents/lib/resolve.js
@@ -3,6 +3,7 @@ const visit = require('unist-util-visit')
 const {
   Roles: { userIsInRoles },
 } = require('@orbiting/backend-modules-auth')
+const { isValidApiKey } = require('./restrictions')
 
 checkEnv(['FRONTEND_BASE_URL'])
 
@@ -217,7 +218,8 @@ const contentUrlResolver = (
     doc?.meta?.path && // not present during publish
     DOCUMENTS_LINKS_RESTRICTED.split(',').includes(doc.meta.path) &&
     user !== undefined &&
-    !userIsInRoles(user, DOCUMENTS_RESTRICT_TO_ROLES.split(','))
+    !userIsInRoles(user, DOCUMENTS_RESTRICT_TO_ROLES.split(',')) &&
+    !isValidApiKey(doc._apiKey)
 
   visit(doc.content, 'link', (node) => {
     node.url = urlReplacer(node.url, stripDocLinks)

--- a/packages/backend-modules/documents/lib/resolve.js
+++ b/packages/backend-modules/documents/lib/resolve.js
@@ -1,8 +1,5 @@
 const checkEnv = require('check-env')
 const visit = require('unist-util-visit')
-const {
-  Roles: { userIsInRoles },
-} = require('@orbiting/backend-modules-auth')
 const { isValidApiKey, isUserUnrestricted } = require('./restrictions')
 
 checkEnv(['FRONTEND_BASE_URL'])
@@ -11,7 +8,6 @@ const {
   GITHUB_LOGIN,
   GITHUB_ORGS = GITHUB_LOGIN,
   FRONTEND_BASE_URL,
-  DOCUMENTS_RESTRICT_TO_ROLES,
   DOCUMENTS_LINKS_RESTRICTED,
 } = process.env
 
@@ -290,9 +286,8 @@ const metaUrlResolver = (
       index <= 1 ||
       !episode.document?.meta?.path ||
       episode.document.meta.path === meta.path ||
-      !DOCUMENTS_RESTRICT_TO_ROLES ||
       user === undefined ||
-      userIsInRoles(user, DOCUMENTS_RESTRICT_TO_ROLES.split(','))
+      isUserUnrestricted(user)
     ) {
       return
     }
@@ -307,11 +302,7 @@ const metaUrlResolver = (
         c.url = urlReplacer(c.url)
       })
 
-  if (
-    user === undefined ||
-    (DOCUMENTS_RESTRICT_TO_ROLES &&
-      !userIsInRoles(user, DOCUMENTS_RESTRICT_TO_ROLES.split(',')))
-  ) {
+  if (user === undefined || !isUserUnrestricted(user)) {
     meta.recommendations = null
   }
 }

--- a/packages/backend-modules/documents/lib/resolve.js
+++ b/packages/backend-modules/documents/lib/resolve.js
@@ -3,7 +3,7 @@ const visit = require('unist-util-visit')
 const {
   Roles: { userIsInRoles },
 } = require('@orbiting/backend-modules-auth')
-const { isValidApiKey } = require('./restrictions')
+const { isValidApiKey, isUserUnrestricted } = require('./restrictions')
 
 checkEnv(['FRONTEND_BASE_URL'])
 
@@ -213,12 +213,12 @@ const contentUrlResolver = (
   )
 
   const stripDocLinks =
-    DOCUMENTS_RESTRICT_TO_ROLES &&
     DOCUMENTS_LINKS_RESTRICTED &&
-    doc?.meta?.path && // not present during publish
-    DOCUMENTS_LINKS_RESTRICTED.split(',').includes(doc.meta.path) &&
+    DOCUMENTS_LINKS_RESTRICTED.split(',').includes(doc.meta?.path) &&
+    // user is undefined during publish -> no stripping
+    // null during document delivery -> strip unless authorized
     user !== undefined &&
-    !userIsInRoles(user, DOCUMENTS_RESTRICT_TO_ROLES.split(',')) &&
+    !isUserUnrestricted(user) &&
     !isValidApiKey(doc._apiKey)
 
   visit(doc.content, 'link', (node) => {

--- a/packages/backend-modules/documents/lib/restrictions.js
+++ b/packages/backend-modules/documents/lib/restrictions.js
@@ -21,11 +21,10 @@ const isValidApiKey = (key) => {
   return !!key && apiKeys.some((apiKey) => apiKey.key === key)
 }
 
-const restrictToRoles =
-  !!DOCUMENTS_RESTRICT_TO_ROLES && DOCUMENTS_RESTRICT_TO_ROLES.split(',')
+const documentsRestrictToRoles = DOCUMENTS_RESTRICT_TO_ROLES?.split(',')
 
 const isUserUnrestricted = (user) =>
-  !restrictToRoles || userIsInRoles(user, restrictToRoles)
+  !documentsRestrictToRoles || userIsInRoles(user, documentsRestrictToRoles)
 
 const includesUnrestrictedChildRepoId = (repoIds) =>
   (repoIds || false) &&

--- a/packages/backend-modules/documents/lib/restrictions.js
+++ b/packages/backend-modules/documents/lib/restrictions.js
@@ -23,8 +23,10 @@ const isValidApiKey = (key) => {
 
 const documentsRestrictToRoles = DOCUMENTS_RESTRICT_TO_ROLES?.split(',')
 
-const isUserUnrestricted = (user) =>
-  !documentsRestrictToRoles || userIsInRoles(user, documentsRestrictToRoles)
+const hasFullDocumentAccess = (user, apiKey) =>
+  !documentsRestrictToRoles ||
+  userIsInRoles(user, documentsRestrictToRoles) ||
+  isValidApiKey(apiKey)
 
 const includesUnrestrictedChildRepoId = (repoIds) =>
   (repoIds || false) &&
@@ -35,7 +37,6 @@ const includesUnrestrictedChildRepoId = (repoIds) =>
   )
 
 module.exports = {
-  isValidApiKey,
-  isUserUnrestricted,
+  hasFullDocumentAccess,
   includesUnrestrictedChildRepoId,
 }

--- a/packages/backend-modules/documents/lib/restrictions.js
+++ b/packages/backend-modules/documents/lib/restrictions.js
@@ -18,7 +18,7 @@ try {
 }
 
 const isValidApiKey = (key) => {
-  return !!key && apiKeys.some((apiKey) => apiKey.key === key)
+  return !!key && apiKeys.some((apiKey) => apiKey.value === key)
 }
 
 const documentsRestrictToRoles = DOCUMENTS_RESTRICT_TO_ROLES?.split(',')

--- a/packages/backend-modules/documents/lib/restrictions.js
+++ b/packages/backend-modules/documents/lib/restrictions.js
@@ -21,13 +21,11 @@ const isValidApiKey = (key) => {
   return !!key && apiKeys.some((apiKey) => apiKey.key === key)
 }
 
-const restrictToRoles = () =>
-  (DOCUMENTS_RESTRICT_TO_ROLES || false) &&
-  DOCUMENTS_RESTRICT_TO_ROLES.length &&
-  DOCUMENTS_RESTRICT_TO_ROLES.split(',')
+const restrictToRoles =
+  !!DOCUMENTS_RESTRICT_TO_ROLES && DOCUMENTS_RESTRICT_TO_ROLES.split(',')
 
 const isUserUnrestricted = (user) =>
-  !restrictToRoles() || userIsInRoles(user, restrictToRoles())
+  !restrictToRoles || userIsInRoles(user, restrictToRoles)
 
 const includesUnrestrictedChildRepoId = (repoIds) =>
   (repoIds || false) &&
@@ -39,7 +37,6 @@ const includesUnrestrictedChildRepoId = (repoIds) =>
 
 module.exports = {
   isValidApiKey,
-  restrictToRoles,
   isUserUnrestricted,
   includesUnrestrictedChildRepoId,
 }

--- a/packages/backend-modules/documents/lib/restrictions.js
+++ b/packages/backend-modules/documents/lib/restrictions.js
@@ -5,7 +5,21 @@ const {
 const {
   DOCUMENTS_RESTRICT_TO_ROLES,
   DOCUMENTS_UNRESTRICTED_CHILDREN_REPO_IDS,
+  DOCUMENTS_API_KEYS,
 } = process.env
+
+let apiKeys = []
+try {
+  if (DOCUMENTS_API_KEYS) {
+    apiKeys = JSON.parse(DOCUMENTS_API_KEYS)
+  }
+} catch (e) {
+  console.error('DOCUMENTS_API_KEYS invalid', e)
+}
+
+const isValidApiKey = (key) => {
+  return !!key && apiKeys.some((apiKey) => apiKey.key === key)
+}
 
 const restrictToRoles = () =>
   (DOCUMENTS_RESTRICT_TO_ROLES || false) &&
@@ -24,6 +38,7 @@ const includesUnrestrictedChildRepoId = (repoIds) =>
   )
 
 module.exports = {
+  isValidApiKey,
   restrictToRoles,
   isUserUnrestricted,
   includesUnrestrictedChildRepoId,

--- a/packages/backend-modules/search/graphql/resolvers/_queries/search.js
+++ b/packages/backend-modules/search/graphql/resolvers/_queries/search.js
@@ -4,6 +4,7 @@ const {
 } = require('@orbiting/backend-modules-auth')
 const {
   isUserUnrestricted,
+  isValidApiKey,
   includesUnrestrictedChildRepoId,
 } = require('@orbiting/backend-modules-documents/lib/restrictions')
 const {
@@ -306,7 +307,14 @@ const mapAggregations = (result, t) => {
 
 const MAX_NODES = 10000 // Limit, but exceedingly high
 
-const getFirst = (first, filter, user, recursive, forceUnrestricted) => {
+const getFirst = (
+  first,
+  filter,
+  user,
+  recursive,
+  forceUnrestricted,
+  apiKey,
+) => {
   // we only restrict the nodes array
   // making totalCount always available
   // querying a single document by path is always allowed
@@ -320,6 +328,7 @@ const getFirst = (first, filter, user, recursive, forceUnrestricted) => {
 
   if (
     !isUserUnrestricted(user) &&
+    !isValidApiKey(apiKey) &&
     !recursive &&
     !path &&
     !oneRepoId &&
@@ -413,7 +422,7 @@ const search = async (__, args, context, info) => {
 
   const first =
     (samples !== false && samples) ||
-    getFirst(_first, filter, user, recursive, unrestricted)
+    getFirst(_first, filter, user, recursive, unrestricted, args.apiKey)
 
   const indicesList = getIndicesList(filter)
   const query = {

--- a/packages/backend-modules/search/graphql/resolvers/_queries/search.js
+++ b/packages/backend-modules/search/graphql/resolvers/_queries/search.js
@@ -362,6 +362,7 @@ const hasFieldRequested = (fieldName, GraphQLResolveInfo) => {
 const search = async (__, args, context, info) => {
   const { user, elastic, t, redis } = context
   const cache = createCache(redis)
+  const apiKey = args.apiKey || context.documentApiKey
 
   const {
     recursive = false,
@@ -372,7 +373,6 @@ const search = async (__, args, context, info) => {
     withoutContent: _withoutContent,
     withoutRelatedDocs = false,
     withoutAggs = false,
-    apiKey,
   } = args
 
   // detect if Document.content is requested

--- a/packages/backend-modules/search/graphql/resolvers/_queries/search.js
+++ b/packages/backend-modules/search/graphql/resolvers/_queries/search.js
@@ -3,8 +3,7 @@ const {
   Roles: { userHasRole },
 } = require('@orbiting/backend-modules-auth')
 const {
-  isUserUnrestricted,
-  isValidApiKey,
+  hasFullDocumentAccess,
   includesUnrestrictedChildRepoId,
 } = require('@orbiting/backend-modules-documents/lib/restrictions')
 const {
@@ -327,8 +326,7 @@ const getFirst = (
   const unrestricted = includesUnrestrictedChildRepoId(format)
 
   if (
-    !isUserUnrestricted(user) &&
-    !isValidApiKey(apiKey) &&
+    !hasFullDocumentAccess(user, apiKey) &&
     !recursive &&
     !path &&
     !oneRepoId &&

--- a/packages/backend-modules/search/graphql/resolvers/_queries/search.js
+++ b/packages/backend-modules/search/graphql/resolvers/_queries/search.js
@@ -374,6 +374,7 @@ const search = async (__, args, context, info) => {
     withoutContent: _withoutContent,
     withoutRelatedDocs = false,
     withoutAggs = false,
+    apiKey,
   } = args
 
   // detect if Document.content is requested
@@ -422,7 +423,7 @@ const search = async (__, args, context, info) => {
 
   const first =
     (samples !== false && samples) ||
-    getFirst(_first, filter, user, recursive, unrestricted, args.apiKey)
+    getFirst(_first, filter, user, recursive, unrestricted, apiKey)
 
   const indicesList = getIndicesList(filter)
   const query = {
@@ -495,6 +496,7 @@ const search = async (__, args, context, info) => {
       connection: response,
       context,
       withoutContent,
+      apiKey,
     })
   }
 

--- a/packages/backend-modules/search/graphql/schema.js
+++ b/packages/backend-modules/search/graphql/schema.js
@@ -18,7 +18,8 @@ type queries {
     sort: SearchSortInput
     first: Int
     after: String
-    before: String,
+    before: String
+    apiKey: String
     # used to (anonymously) track subsequent searches
     # provide the ID from the previous SearchConnection
     trackingId: ID

--- a/packages/backend-modules/search/lib/Documents.js
+++ b/packages/backend-modules/search/lib/Documents.js
@@ -333,6 +333,7 @@ const addRelatedDocs = async ({
   ignorePrepublished,
   context,
   withoutContent,
+  apiKey,
 }) => {
   const docs = getDocsForConnection(connection)
 
@@ -455,6 +456,7 @@ const addRelatedDocs = async ({
     // - including the usernames
     doc._all = [...(doc._all ? doc._all : []), ...relatedDocs, ...docs]
     doc._usernames = usernames
+    doc._apiKey = apiKey
   })
 }
 

--- a/packages/backend-modules/search/lib/options.js
+++ b/packages/backend-modules/search/lib/options.js
@@ -1,14 +1,11 @@
 const debug = require('debug')('search:lib:options')
 
-const { Roles } = require('@orbiting/backend-modules-auth')
-
 const {
-  DOCUMENTS_RESTRICT_TO_ROLES,
-  DOCUMENTS_SAMPLES_REPO_IDS,
-  DOCUMENTS_SAMPLES = 3,
-} = process.env
+  hasFullDocumentAccess,
+} = require('@orbiting/backend-modules-documents/lib/restrictions')
 
-const documentsRestrictToRoles = DOCUMENTS_RESTRICT_TO_ROLES?.split(',')
+const { DOCUMENTS_SAMPLES_REPO_IDS, DOCUMENTS_SAMPLES = 3 } = process.env
+
 const sampleRepoIds = DOCUMENTS_SAMPLES_REPO_IDS?.split(',')
 
 const processors = {
@@ -18,7 +15,7 @@ const processors = {
 
     if (
       !!sampleRepoIds?.includes(filter?.format) &&
-      !Roles.userIsInRoles(user, documentsRestrictToRoles)
+      !hasFullDocumentAccess(user, args.apiKey)
     ) {
       return {
         filters: [

--- a/packages/backend-modules/subscriptions/lib/Subscriptions.js
+++ b/packages/backend-modules/subscriptions/lib/Subscriptions.js
@@ -2,7 +2,7 @@ const { getObjectByIdAndType } = require('./genericObject')
 const Promise = require('bluebird')
 const { uuidForObject } = require('@orbiting/backend-modules-utils')
 const {
-  isUserUnrestricted,
+  hasFullDocumentAccess,
   includesUnrestrictedChildRepoId,
 } = require('@orbiting/backend-modules-documents/lib/restrictions')
 const uniq = require('lodash/uniq')
@@ -329,7 +329,7 @@ const subscriptionIsEligibleForNotifications = async (
   ])
   if (object.__typename === 'Document') {
     return (
-      isUserUnrestricted(user) ||
+      hasFullDocumentAccess(user) ||
       includesUnrestrictedChildRepoId([object.objectId])
     )
   }


### PR DESCRIPTION
Allows to request fully resolved documents without being signed in.

We plan to use it for member cache in the front end and potential site maps.

To test locally make sure to set following env:
```
DOCUMENTS_RESTRICT_TO_ROLES=member
DOCUMENTS_LINKS_RESTRICTED=/
DOCUMENTS_API_KEYS=[{"key":"long-safe-secret","name":"frontend"}]

DOCUMENTS_SAMPLES_REPO_IDS=republik/format-wochenende-newsletter
DOCUMENTS_SAMPLES=3
```

And use this query for example:
```
{
  document(path: "/", apiKey: "long-safe-secret") {
    children(first: 3) {
      nodes {
        body
      }
    }
  }
  documents(feed: true, apiKey: "long-safe-secret", first: 3) {
    totalCount
    nodes {
      meta {
        title
      }
    }
  }
  search(processor: formatFeedSamples, filter: {
    format: "republik/format-wochenende-newsletter"
  }, first: 5, apiKey: "long-safe-secret") {
    totalCount
    nodes {
    	entity {
        ... on Document {
          meta {
            title
          }
        }
      }
    }
  }
}
```

Via Authorization header:
```bash
curl 'http://localhost:5010/graphql' \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: DocumentApiKey long-safe-secret' \
  --data-raw '{"query":"{documents(feed: true, first: 3){nodes{meta{title}}}}","variables":null}'
```
