### PR TITLE
fix(Paynote): fix doubly escaped characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build
 *.pem
 local/
 .idea
+.run
 
 # debug
 npm-debug.log*

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -6542,7 +6542,7 @@
     },
     {
       "key": "article/payNote/default/note",
-      "value": "<a href=\\\"/\\\">Mehr Informationen zur Republik.</a>"
+      "value": "<a href=\"/\">Mehr Informationen zur Republik.</a>"
     },
     {
       "key": "article/payNote/220404-v1/before",


### PR DESCRIPTION
fix "Mehr Informationen zur Republik." link in the Abo-kaufen paynote.

<img width="537" alt="image" src="https://user-images.githubusercontent.com/3907984/168792753-e6b77c45-b23d-4dfc-b56b-b2fdc42956f9.png">

