### PR TITLE
fix Overlay closing when mouse is released over backdrop

### DIFF
--- a/packages/styleguide/src/components/Overlay/Overlay.tsx
+++ b/packages/styleguide/src/components/Overlay/Overlay.tsx
@@ -152,7 +152,7 @@ export const OverlayRenderer: React.FC<
       style={{ opacity: isVisible ? 1 : 0 }}
       ref={scrollRef}
     >
-      <div {...styles.backdrop} onMouseDown={close} />
+      <div {...styles.backdrop} onClick={close} />
       <div
         {...merge(styles.inner, mUpStyle && { [mUp]: mUpStyle })}
         {...colorScheme.set('backgroundColor', 'overlay')}

--- a/packages/styleguide/src/components/Overlay/Overlay.tsx
+++ b/packages/styleguide/src/components/Overlay/Overlay.tsx
@@ -27,6 +27,15 @@ const styles = {
     overflowY: 'auto',
     WebkitOverflowScrolling: 'touch',
   }),
+  backdrop: css({
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    height: '100vh',
+    width: '100vw',
+  }),
   inner: css({
     position: 'relative',
     zIndex: 1, // to establish a stacking context
@@ -131,9 +140,8 @@ export const OverlayRenderer: React.FC<
   }
 > = ({ isVisible, mUpStyle, children, onClose, ssrMode, scrollRef }) => {
   const close = (e) => {
-    if (e.target === e.currentTarget) {
-      onClose(e)
-    }
+    e.preventDefault()
+    onClose(e)
   }
   const [colorScheme] = useColorContext()
 
@@ -142,9 +150,9 @@ export const OverlayRenderer: React.FC<
       {...styles.root}
       {...(ssrMode && { [ssrAttribute]: true })}
       style={{ opacity: isVisible ? 1 : 0 }}
-      onClick={close}
       ref={scrollRef}
     >
+      <div {...styles.backdrop} onMouseDown={close} />
       <div
         {...merge(styles.inner, mUpStyle && { [mUp]: mUpStyle })}
         {...colorScheme.set('backgroundColor', 'overlay')}


### PR DESCRIPTION
# Description

On any mouse-down event on the modal, if the mouse was then moved out of the modal and onto the backdrop, on release the modal would close.
This was due to the parent element-registering the click on it's self rather than on it's child.
By moving the onClick-handler, that closes the modal, onto a sibling element of the modal this issue can be circumvented.

# Example
## Before

https://user-images.githubusercontent.com/30313631/169085199-042693a6-9cbe-4fab-9f4b-c08b88fca5a8.mov

## After

https://user-images.githubusercontent.com/30313631/169085709-9a7d7f45-e314-4b16-8d8c-529c188fae29.mov


