### PR TITLE
Render the App version in the footer

### DIFF
--- a/apps/www/components/Footer/index.js
+++ b/apps/www/components/Footer/index.js
@@ -4,7 +4,6 @@ import compose from 'lodash/flowRight'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import {
-  BrandMark,
   Logo,
   mediaQueries,
   fontStyles,
@@ -16,7 +15,7 @@ import { OpenSourceIcon } from '@project-r/styleguide'
 import withT from '../../lib/withT'
 import withMe from '../../lib/apollo/withMe'
 import { withSignOut } from '../Auth/SignOut'
-import withInNativeApp, { useInNativeApp } from '../../lib/withInNativeApp'
+import { useInNativeApp } from '../../lib/withInNativeApp'
 import { shouldIgnoreClick } from '../../lib/utils/link'
 import { ZINDEX_FOOTER } from '../constants'
 
@@ -114,16 +113,9 @@ const styles = {
   }),
 }
 
-const Footer = ({
-  t,
-  me,
-  signOut,
-  inNativeIOSApp,
-  isOnMarketingPage,
-  hasActiveMembership,
-}) => {
+const Footer = ({ t, me, signOut, isOnMarketingPage, hasActiveMembership }) => {
   const [colorScheme] = useColorContext()
-  const { inNativeApp, inNativeAppVersion } = useInNativeApp()
+  const { inNativeApp, inNativeAppVersion, inNativeIOSApp } = useInNativeApp()
 
   const navLinkStyle = useMemo(
     () =>
@@ -387,9 +379,4 @@ const FooterWithStaticColorContext = (props) => {
   )
 }
 
-export default compose(
-  withT,
-  withMe,
-  withSignOut,
-  withInNativeApp,
-)(FooterWithStaticColorContext)
+export default compose(withT, withMe, withSignOut)(FooterWithStaticColorContext)

--- a/apps/www/components/Footer/index.js
+++ b/apps/www/components/Footer/index.js
@@ -111,6 +111,11 @@ const styles = {
       },
     },
   }),
+  devInfo: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'end',
+  }),
 }
 
 const Footer = ({ t, me, signOut, isOnMarketingPage, hasActiveMembership }) => {
@@ -331,13 +336,7 @@ const Footer = ({ t, me, signOut, isOnMarketingPage, hasActiveMembership }) => {
             <Address t={t} />
           </div>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'end',
-          }}
-        >
+        <div {...styles.devInfo}>
           <span
             style={{ ...fontStyles.sansSerifRegular14 }}
             {...colorScheme.set('color', 'text')}

--- a/apps/www/components/Footer/index.js
+++ b/apps/www/components/Footer/index.js
@@ -16,7 +16,7 @@ import { OpenSourceIcon } from '@project-r/styleguide'
 import withT from '../../lib/withT'
 import withMe from '../../lib/apollo/withMe'
 import { withSignOut } from '../Auth/SignOut'
-import withInNativeApp from '../../lib/withInNativeApp'
+import withInNativeApp, { useInNativeApp } from '../../lib/withInNativeApp'
 import { shouldIgnoreClick } from '../../lib/utils/link'
 import { ZINDEX_FOOTER } from '../constants'
 
@@ -123,6 +123,8 @@ const Footer = ({
   hasActiveMembership,
 }) => {
   const [colorScheme] = useColorContext()
+  const { inNativeApp, inNativeAppVersion } = useInNativeApp()
+
   const navLinkStyle = useMemo(
     () =>
       css({
@@ -337,7 +339,13 @@ const Footer = ({
             <Address t={t} />
           </div>
         </div>
-        <div style={{ textAlign: 'right' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'end',
+          }}
+        >
           <span
             style={{ ...fontStyles.sansSerifRegular14 }}
             {...colorScheme.set('color', 'text')}
@@ -357,6 +365,14 @@ const Footer = ({
               {t('footer/opensource')}
             </a>
           </span>
+          {inNativeApp && (
+            <span
+              {...navLinkStyle}
+              style={{ ...fontStyles.sansSerifRegular14 }}
+            >
+              v{inNativeAppVersion}
+            </span>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Previously the version number of the app could only be seen in the phone settings or in the app-/play-store.
With this PR the version number will be shown at the very bottom of the footer. (right aligned just as the open source link directly above the version number.

## Screenshot
<img width="739" alt="image" src="https://user-images.githubusercontent.com/30313631/169091625-6bd7638c-514a-4ee7-a74b-10ad7e9b4aaf.png">
