### PR TITLE
fix(Form): checkbox and radio a11y compat

### DIFF
--- a/packages/styleguide/src/components/Form/Checkbox.tsx
+++ b/packages/styleguide/src/components/Form/Checkbox.tsx
@@ -37,6 +37,7 @@ const Checkbox: React.FC<{
     : black
     ? colorScheme.set('fill', 'logo')
     : colorScheme.set('fill', 'primary')
+
   return (
     <label
       {...styles.label}
@@ -44,28 +45,38 @@ const Checkbox: React.FC<{
       {...labelColor}
     >
       <span {...(children ? styles.box : styles.boxWithouText)}>
+        <input
+          {...styles.input}
+          name={name}
+          type='checkbox'
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => {
+            onChange(event, event.target.checked)
+          }}
+        />
         {checked ? (
-          <svg {...checkMarkFill} width='18' height='18' viewBox='0 0 18 18'>
+          <svg
+            {...checkMarkFill}
+            {...styles.outlineOnPrevInputFocus}
+            width='18'
+            height='18'
+            viewBox='0 0 18 18'
+          >
             <path
               d='M0 0h18v18H0V0zm7 14L2 9.192l1.4-1.346L7 11.308 14.6 4 16 5.346 7 14z'
-              fill={'inherit'}
+              fill='inherit'
               fillRule='evenodd'
             />
           </svg>
         ) : (
-          <span {...styles.unchecked} {...checkMarkBorderColor} />
+          <span
+            {...styles.unchecked}
+            {...styles.outlineOnPrevInputFocus}
+            {...checkMarkBorderColor}
+          />
         )}
       </span>
-      <input
-        {...styles.input}
-        name={name}
-        type='checkbox'
-        checked={checked}
-        disabled={disabled}
-        onChange={(event) => {
-          onChange(event, event.target.checked)
-        }}
-      />
       {children}
     </label>
   )
@@ -83,9 +94,6 @@ const styles = {
   withoutText: css({
     lineHeight: 0,
   }),
-  input: css({
-    display: 'none',
-  }),
   unchecked: css({
     display: 'inline-block',
     boxSizing: 'border-box',
@@ -95,6 +103,7 @@ const styles = {
     borderStyle: 'solid',
   }),
   box: css({
+    position: 'relative',
     display: 'inline-block',
     padding: '3px 3px 3px 0',
     marginRight: 5,
@@ -102,8 +111,29 @@ const styles = {
     float: 'left',
   }),
   boxWithouText: css({
+    position: 'relative',
     display: 'inline-block',
     padding: '3px 0',
+  }),
+  outlineOnPrevInputFocus: css({
+    'input:focus + &': {
+      outline: 'solid',
+      outlineOffset: 3,
+    },
+    'input:focus:not(:focus-visible) + &': {
+      outline: 'none',
+    },
+  }),
+  input: css({
+    cursor: 'pointer',
+    // hidden but accessible
+    // https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/
+    position: 'absolute',
+    top: 3,
+    left: 0,
+    width: 18,
+    height: 18,
+    opacity: 0,
   }),
 }
 

--- a/packages/styleguide/src/components/Form/Radio.tsx
+++ b/packages/styleguide/src/components/Form/Radio.tsx
@@ -17,14 +17,31 @@ const styles = {
     lineHeight: 0,
   }),
   input: css({
-    display: 'none',
+    cursor: 'pointer',
+    // hidden but accessible
+    // https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 24,
+    height: 24,
+    opacity: 0,
+    '&:focus + svg': {
+      outline: 'solid',
+      outlineOffset: 3,
+    },
+    '&:focus:not(:focus-visible) + svg': {
+      outline: 'none',
+    },
   }),
   box: css({
+    position: 'relative',
     display: 'inline-block',
     marginRight: 10,
     verticalAlign: 'middle',
   }),
   boxWithouText: css({
+    position: 'relative',
     display: 'inline-block',
   }),
 }
@@ -75,17 +92,17 @@ const Radio: React.FC<{
       style={style}
     >
       <span {...(children ? styles.box : styles.boxWithouText)}>
+        <input
+          {...styles.input}
+          name={name}
+          type='radio'
+          value={value}
+          checked={checked}
+          disabled={disabled}
+          onChange={onChange}
+        />
         <RadioCircle checked={checked} disabled={disabled} />
       </span>
-      <input
-        {...styles.input}
-        name={name}
-        type='radio'
-        value={value}
-        checked={checked}
-        disabled={disabled}
-        onChange={onChange}
-      />
       {children}
     </label>
   )


### PR DESCRIPTION
Solution based on this blog post:
https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons/

Decided to just go with a default outline with automatic color (which works well with dark mode) offset by 3px:

<img width="814" alt="Screenshot 2022-06-03 at 16 41 19" src="https://user-images.githubusercontent.com/410211/171877129-d9c06503-d41a-4027-85c6-31d759ae0c55.png">

<img width="826" alt="Screenshot 2022-06-03 at 16 41 30" src="https://user-images.githubusercontent.com/410211/171877154-3bbdf4e1-322d-4526-b2d8-ccc9085bb9bb.png">

Should also make it easier to select the checkbox in e2e tests ;-)


