### PR TITLE
Prepare for Vercel by replacing functionality implemented in the express-server

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -110,6 +110,17 @@ module.exports = withTM(
           destination: 'https://ultradashboard.republik.ch/dashboard/17',
           permanent: false,
         },
+        // Legacy crowdfunding pages
+        {
+          source: '/updates/wer-sind-sie',
+          destination: '/503',
+          permanent: false,
+        },
+        {
+          source: '/vote',
+          destination: '/503',
+          permanent: false,
+        },
       ]
     },
   }),

--- a/apps/www/server/index.js
+++ b/apps/www/server/index.js
@@ -124,21 +124,6 @@ app.prepare().then(() => {
     )
   }
 
-  // tmp unavailable
-  server.get('/vote', (req, res) => {
-    res.statusCode = 503
-    return app.render(req, res, '/503', req.query)
-  })
-  server.get('/updates/wer-sind-sie', (req, res) => {
-    res.statusCode = 503
-    return app.render(req, res, '/503', req.query)
-  })
-
-  // PayPal donate return url can be posted to
-  server.post('/en', (req, res) => {
-    return app.render(req, res, '/en', req.query)
-  })
-
   // iOS app universal links setup
   // - manual mapping needed to set content type json
   server.use('/.well-known/apple-app-site-association', (req, res) => {


### PR DESCRIPTION
## Description

TBD

## TODO

- [ ] Move rate-limiting inside middleware and find replacement for express-plugin
- [ ] Get rid off curtain functionality (use password-protected preview-deployment on Vercel instead
- [ ] Evaluate if headers set inside www/server/index.js are still needed.

Once all that is done:

- [ ] Deploy test-env to Vercel
- [ ] Bump Turborepo
- [ ] Enable Turbo remote-cache