### PR TITLE
A11Y: Seitentitel

### DIFF
--- a/apps/www/components/Events/List.js
+++ b/apps/www/components/Events/List.js
@@ -127,7 +127,8 @@ const Overview = compose(
           <Content>
             <Meta
               data={{
-                title: t('events/pageTitle'),
+                pageTitle: t('events/pageTitle'),
+                title: t('events/title'),
                 description: t('events/metaDescription'),
                 url: `${PUBLIC_BASE_URL}/events`,
                 image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`,

--- a/apps/www/components/Frame/Meta.js
+++ b/apps/www/components/Frame/Meta.js
@@ -3,61 +3,93 @@ import Head from 'next/head'
 import { imageSizeInfo, imageResizeUrl } from 'mdast-react-render/lib/utils'
 
 import { CDN_FRONTEND_BASE_URL } from '../../lib/constants'
+import withT from '../../lib/withT'
 
-const Meta = ({ data, data: { url, image, jsonLds } }) => {
-  const title = data.pageTitle || `${data.title} – Republik`
+const Meta = ({ data, t }) => {
+  const {
+    // Default props
+    url,
+    pageTitle,
+    title,
+    description,
+    image,
+
+    // SEO props
+    seoTitle,
+    seoDescription,
+
+    // Twitter props
+    twitterTitle,
+    twitterDescription,
+    twitterImage,
+
+    // Facebook props
+    facebookTitle,
+    facebookDescription,
+    facebookImage,
+
+    // Linked data props
+    jsonLds,
+  } = data
+
+  const metaTitle =
+    (seoTitle && t('components/Frame/Meta/title', { title: seoTitle })) ||
+    (twitterTitle &&
+      t('components/Frame/Meta/title', { title: twitterTitle })) ||
+    pageTitle ||
+    (title && t('components/Frame/Meta/title', { title }))
 
   // to prevent facebook from using a random image from the website we fall back to a square avatar and claim it's below 315px in size to trigger the small image layout
   // - https://developers.facebook.com/docs/sharing/webmasters/images/?locale=en_US
-  const facebookImage =
-    data.facebookImage ||
+  const ogImage =
+    facebookImage ||
     image ||
     `${CDN_FRONTEND_BASE_URL}/static/avatar310.png?size=310x310`
-  const twitterImage = data.twitterImage || image
 
-  const fbSizeInfo = facebookImage && imageSizeInfo(facebookImage)
+  const twitterCard = twitterImage || image
+
+  const { width: ogImageWidth, height: ogImageHeight } =
+    (ogImage && imageSizeInfo(ogImage)) || {}
 
   return (
     <Head>
-      <title>{data.seoTitle || data.twitterTitle || title}</title>
+      <title>{metaTitle}</title>
       <meta
         name='description'
-        content={
-          data.seoDescription || data.twitterDescription || data.description
-        }
+        content={seoDescription || twitterDescription || description}
       />
 
       <meta property='og:type' content='website' />
       {url && <meta property='og:url' content={url} />}
       {url && <link rel='canonical' href={url} />}
-      <meta property='og:title' content={data.facebookTitle || data.title} />
+      <meta property='og:title' content={facebookTitle || title} />
       <meta
         property='og:description'
-        content={data.facebookDescription || data.description}
+        content={facebookDescription || description}
       />
-      {!!facebookImage && <meta property='og:image' content={facebookImage} />}
-      {!!fbSizeInfo && (
-        <meta property='og:image:width' content={fbSizeInfo.width} />
+      {!!ogImage && <meta property='og:image' content={ogImage} />}
+      {!!ogImageWidth && (
+        <meta property='og:image:width' content={ogImageWidth} />
       )}
-      {!!fbSizeInfo && (
-        <meta property='og:image:height' content={fbSizeInfo.height} />
+      {!!ogImageHeight && (
+        <meta property='og:image:height' content={ogImageHeight} />
       )}
 
-      <meta
-        name='twitter:card'
-        content={twitterImage ? 'summary_large_image' : 'summary'}
-      />
       <meta name='twitter:site' content='@RepublikMagazin' />
       <meta name='twitter:creator' content='@RepublikMagazin' />
-      <meta name='twitter:title' content={data.twitterTitle || data.title} />
+      <meta name='twitter:title' content={twitterTitle || title} />
       <meta
         name='twitter:description'
-        content={data.twitterDescription || data.description}
+        content={twitterDescription || description}
       />
-      {!!twitterImage && (
+      <meta
+        name='twitter:card'
+        content={twitterCard ? 'summary_large_image' : 'summary'}
+      />
+      {!!twitterCard && (
         <meta
           name='twitter:image:src'
-          content={imageResizeUrl(twitterImage, '3000x')}
+          content={imageResizeUrl(twitterCard, '3000x')}
         />
       )}
 
@@ -72,4 +104,4 @@ const Meta = ({ data, data: { url, image, jsonLds } }) => {
   )
 }
 
-export default Meta
+export default withT(Meta)

--- a/apps/www/components/Marketing/Pledge.js
+++ b/apps/www/components/Marketing/Pledge.js
@@ -68,7 +68,11 @@ const Pledge = ({ router, serverContext }) => {
           query={query}
         />
       ) : (
-        <PledgeForm crowdfundingName={CROWDFUNDING_PLEDGE} query={query} />
+        <PledgeForm
+          preventMetaUpdate // Form should not call <Meta />
+          crowdfundingName={CROWDFUNDING_PLEDGE}
+          query={query}
+        />
       )}
     </SectionContainer>
   )

--- a/apps/www/components/Pledge/Form.js
+++ b/apps/www/components/Pledge/Form.js
@@ -277,6 +277,7 @@ class Pledge extends Component {
     const { values, errors, dirty, basePledge } = this.state
 
     const {
+      preventMetaUpdate, // flag to prevent <Meta /> being rendered
       loading,
       error,
       isMember,
@@ -314,33 +315,35 @@ class Pledge extends Component {
       '',
     )
 
-    const meta = statementTitle
-      ? {
-          title: t('pledge/form/statement/share/title', statement),
-          description: t('pledge/form/statement/share/description'),
-          image: `${ASSETS_SERVER_BASE_URL}/render?width=1200&height=628&updatedAt=${encodeURIComponent(
-            statement.updatedAt,
-          )}&url=${encodeURIComponent(
-            `${PUBLIC_BASE_URL}/community?share=${statement.id}&package=${queryPackage}`,
-          )}`,
-        }
-      : {
-          title: t.first([
-            pkg && `pledge/meta/package/${pkg.name}/title`,
-            queryGroup && `pledge/meta/group/${queryGroup}/title`,
-            'pledge/meta/title',
-          ]),
-          description: t.first([
-            pkg && `pledge/meta/package/${pkg.name}/description`,
-            queryGroup && `pledge/meta/group/${queryGroup}/description`,
-            'pledge/meta/description',
-          ]),
-          image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`,
-        }
+    const meta =
+      !preventMetaUpdate &&
+      (statementTitle
+        ? {
+            title: t('pledge/form/statement/share/title', statement),
+            description: t('pledge/form/statement/share/description'),
+            image: `${ASSETS_SERVER_BASE_URL}/render?width=1200&height=628&updatedAt=${encodeURIComponent(
+              statement.updatedAt,
+            )}&url=${encodeURIComponent(
+              `${PUBLIC_BASE_URL}/community?share=${statement.id}&package=${queryPackage}`,
+            )}`,
+          }
+        : {
+            title: t.first([
+              pkg && `pledge/meta/package/${pkg.name}/title`,
+              queryGroup && `pledge/meta/group/${queryGroup}/title`,
+              'pledge/meta/title',
+            ]),
+            description: t.first([
+              pkg && `pledge/meta/package/${pkg.name}/description`,
+              queryGroup && `pledge/meta/group/${queryGroup}/description`,
+              'pledge/meta/description',
+            ]),
+            image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`,
+          })
 
     return (
       <Fragment>
-        <Meta data={meta} />
+        {!!meta && <Meta data={meta} />}
         <Loader
           loading={loading}
           error={error}

--- a/apps/www/components/Profile/Page.js
+++ b/apps/www/components/Profile/Page.js
@@ -662,9 +662,12 @@ const Profile = (props) => {
             `${PUBLIC_BASE_URL}/community?share=${user.id}`,
           )}`
         : '',
-    title: user
+    pageTitle: user
       ? t('pages/profile/pageTitle', { name: user.name })
       : t('pages/profile/empty/pageTitle'),
+    title: user
+      ? t('pages/profile/title', { name: user.name })
+      : t('pages/profile/empty/title'),
   }
 
   return (

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -5385,6 +5385,10 @@
       "value": "Wahrscheinlich ist der von Ihnen verwendete Link bereits benutzt worden oder unvollständig. Falls das Problem wider alle Erwartungen weiterhin auftritt, helfen wir Ihnen unter <a href=\"mailto:wahlen19@republik.ch?subject=Nicht%20gefunden\">wahlen19@republik.ch</a> gerne und zügig weiter."
     },
     {
+      "key": "components/Frame/Meta/title",
+      "value": "{title} – Republik"
+    },
+    {
       "key": "pages/cardSetup/title",
       "value": "Profil einrichten – Wahltindär"
     },

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -106,11 +106,15 @@
     },
     {
       "key": "pages/profile/pageTitle",
+      "value": "{name} – Profil – Republik"
+    },
+    {
+      "key": "pages/profile/title",
       "value": "{name} – Profil"
     },
     {
       "key": "pages/profile/empty/pageTitle",
-      "value": "Profil"
+      "value": "Profil – Republik"
     },
     {
       "key": "pages/profile/empty/title",
@@ -538,6 +542,10 @@
     },
     {
       "key": "sections/pageTitle",
+      "value": "Rubriken – Republik"
+    },
+    {
+      "key": "sections/title",
       "value": "Rubriken"
     },
     {
@@ -2890,7 +2898,7 @@
     },
     {
       "key": "shareholder/pageTitle",
-      "value": "Aktionariat"
+      "value": "Aktionariat – Republik"
     },
     {
       "key": "shareholder/title",
@@ -5326,6 +5334,10 @@
     },
     {
       "key": "pages/cardGroups/pageTitle",
+      "value": "«Republik Wahltindär»"
+    },
+    {
+      "key": "pages/cardGroups/title",
       "value": "«Republik Wahltindär»"
     },
     {

--- a/apps/www/pages/aktionariat.js
+++ b/apps/www/pages/aktionariat.js
@@ -12,7 +12,8 @@ import { withDefaultSSR } from '../lib/apollo/helpers'
 
 const ShareholderPage = ({ t }) => {
   const meta = {
-    title: t('shareholder/pageTitle'),
+    pageTitle: t('shareholder/pageTitle'),
+    title: t('shareholder/title'),
     description: t('shareholder/description'),
     image: `${CDN_FRONTEND_BASE_URL}/static/social-media/aktionariat.png`,
   }

--- a/apps/www/pages/rubriken.js
+++ b/apps/www/pages/rubriken.js
@@ -10,7 +10,8 @@ import { withDefaultSSR } from '../lib/apollo/helpers'
 
 const FormatsPage = ({ t }) => {
   const meta = {
-    title: t('sections/pageTitle'),
+    pageTitle: t('sections/pageTitle'),
+    title: t('sections/title'),
     description: t('sections/description'),
     image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`,
   }

--- a/apps/www/pages/wahltindaer/index.js
+++ b/apps/www/pages/wahltindaer/index.js
@@ -128,7 +128,7 @@ const Page = ({ data, data: { cardGroups }, router, t }) => (
     pageColorSchemeKey='light'
     meta={{
       pageTitle: t('pages/cardGroups/pageTitle'),
-      title: t('pages/cardGroups/pageTitle'),
+      title: t('pages/cardGroups/title'),
       description: t('pages/cardGroups/description'),
       url: `${PUBLIC_BASE_URL}/wahltindaer`,
       image: `${CDN_FRONTEND_BASE_URL}/static/social-media/republik-wahltindaer-09.png`,


### PR DESCRIPTION
- Fixes Markting index having its meta title overwritten by Pledge/Form component on that page.
- Hormonizes titles (usually append "– Republik") or return title as is (`pageTitle`).

Fixes #135 