### PR TITLE
fix(ReadAloudInline): fix vertical alignment

### DIFF
--- a/apps/www/components/Article/ReadAloudInline.tsx
+++ b/apps/www/components/Article/ReadAloudInline.tsx
@@ -50,13 +50,9 @@ const styles = {
   }),
   container: css({
     display: 'flex',
-    alignItems: 'flex-start',
     justifyContent: 'space-between',
     padding: '12px 0',
     gap: 16,
-    [mediaQueries.mUp]: {
-      alignItems: 'center',
-    },
   }),
   text: css({
     flex: 1,
@@ -81,7 +77,15 @@ const SyntheticAudio = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
   return (
     <div>
       <hr {...styles.hr} {...colorScheme.set('backgroundColor', 'divider')} />
-      <div {...styles.container}>
+      <div
+        {...styles.container}
+        {...css({
+          alignItems: isSynthetic ? 'flex-start' : 'center',
+          [mediaQueries.mUp]: {
+            alignItems: 'center',
+          },
+        })}
+      >
         <IconButton
           style={{ marginRight: 0 }}
           size={32}


### PR DESCRIPTION
Fixes vertical alignment being off on mobile when article is read by human.

Result:
<img width="339" alt="Screenshot 2022-07-22 at 15 06 17" src="https://user-images.githubusercontent.com/20746301/180445671-6781cc33-4da7-4a0c-adb8-d7d585effb43.png">

