### PR TITLE
Redirect Mini Sprint

### DIFF
--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -218,6 +218,7 @@ const ArticlePage = ({
   isPreview,
   markAsReadMutation,
   serverContext,
+  clientRedirection,
 }) => {
   const actionBarRef = useRef()
   const bottomActionBarRef = useRef()
@@ -238,6 +239,7 @@ const ArticlePage = ({
     variables: {
       path: cleanedPath,
     },
+    skip: clientRedirection,
   })
 
   const article = articleData?.article
@@ -440,7 +442,11 @@ const ArticlePage = ({
         render={() => {
           if (!article) {
             return (
-              <StatusError statusCode={404} serverContext={serverContext} />
+              <StatusError
+                statusCode={404}
+                clientRedirection={clientRedirection}
+                serverContext={serverContext}
+              />
             )
           }
           return extract === 'share' ? (
@@ -504,7 +510,11 @@ const ArticlePage = ({
         render={() => {
           if (!article || !schema) {
             return (
-              <StatusError statusCode={404} serverContext={serverContext} />
+              <StatusError
+                statusCode={404}
+                clientRedirection={clientRedirection}
+                serverContext={serverContext}
+              />
             )
           }
 

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -775,14 +775,6 @@ const ArticlePage = ({
               {me && hasActiveMembership && (
                 <ArticleRecommendationsFeed path={cleanedPath} />
               )}
-              {(hasActiveMembership || isFormat) && (
-                <>
-                  <br />
-                  <br />
-                  <br />
-                  <br />
-                </>
-              )}
               {!suppressPayNotes && payNoteAfter}
             </>
           )

--- a/apps/www/components/Article/PayNote.js
+++ b/apps/www/components/Article/PayNote.js
@@ -17,9 +17,9 @@ import { trackEvent, trackEventOnClick } from '../../lib/matomo'
 import { useRouter } from 'next/router'
 import compose from 'lodash/flowRight'
 import withT, { t } from '../../lib/withT'
-import withInNativeApp from '../../lib/withInNativeApp'
-import withMe from '../../lib/apollo/withMe'
+import { useInNativeApp } from '../../lib/withInNativeApp'
 import { shouldIgnoreClick } from '../../lib/utils/link'
+import { useMe } from '../../lib/context/MeContext'
 
 const styles = {
   banner: css({
@@ -403,15 +403,8 @@ export const InnerPaynote = ({
   )
 }
 
-export const PayNote = compose(
-  withInNativeApp,
-  withMe,
-  withDarkContextWhenBefore,
-)(
+export const PayNote = compose(withDarkContextWhenBefore)(
   ({
-    inNativeIOSApp,
-    hasAccess,
-    hasActiveMembership,
     seed,
     tryOrBuy,
     documentId,
@@ -421,6 +414,8 @@ export const PayNote = compose(
     customMode,
     customOnly,
   }) => {
+    const { meLoading, hasActiveMembership, hasAccess } = useMe()
+    const { inNativeIOSApp } = useInNativeApp()
     const [colorScheme] = useColorContext()
     const { query } = useRouter()
 
@@ -455,7 +450,7 @@ export const PayNote = compose(
 
     return (
       <div
-        data-hide-if-active-membership='true'
+        data-hide-if-active-membership={meLoading ? 'true' : undefined}
         {...styles.banner}
         {...colorScheme.set(
           'backgroundColor',

--- a/apps/www/components/StatusError/index.js
+++ b/apps/www/components/StatusError/index.js
@@ -56,7 +56,11 @@ const StatusError = ({
   const queryString = router.asPath.split('?')[1]
   const clientRedirectionTarget =
     clientRedirection &&
-    `${clientRedirection.target}${queryString ? `?${queryString}` : ''}`
+    `${clientRedirection.target}${
+      queryString
+        ? `${clientRedirection.target.includes('?') ? '&' : '?'}${queryString}`
+        : ''
+    }`
   const { isReady } = router
 
   useEffect(() => {

--- a/apps/www/lib/context/UserAgentContext.tsx
+++ b/apps/www/lib/context/UserAgentContext.tsx
@@ -14,7 +14,7 @@ export const matchIOSUserAgent = (value?: string): boolean =>
     !!value.match(/Mac.+RepublikApp/))
 
 export const matchAndroidUserAgent = (value?: string): boolean =>
-  !!value && !!value.match(/android/i)
+  !!value && !!value.match(/Android/)
 
 type UserAgentValues = {
   userAgent: string

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -321,6 +321,14 @@
       "value": "System nicht verfügbar"
     },
     {
+      "key": "redirection/external/message",
+      "value": "Sie werden auf {link} weitergeleitet."
+    },
+    {
+      "key": "redirection/external/genericLink",
+      "value": "eine externe Webseite"
+    },
+    {
       "key": "marketing/join/button/label",
       "value": "Mitglied werden"
     },

--- a/apps/www/lib/withInNativeApp.js
+++ b/apps/www/lib/withInNativeApp.js
@@ -2,7 +2,7 @@ import Router from 'next/router'
 import { parseJSONObject } from './safeJSON'
 import { matchIOSUserAgent, useUserAgent } from './context/UserAgentContext'
 
-const getNativeAppVersion = (value) => {
+export const getNativeAppVersion = (value) => {
   const matches = value?.match(/RepublikApp\/([.0-9]+)/)
   return matches ? matches[1] : undefined
 }

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -106,16 +106,6 @@ module.exports = withTM(
           destination: '/konto',
           permanent: true,
         },
-        {
-          source: '/ud/report',
-          destination: 'https://ultradashboard.republik.ch/dashboard/15',
-          permanent: false,
-        },
-        {
-          source: '/ud/daily',
-          destination: 'https://ultradashboard.republik.ch/dashboard/17',
-          permanent: false,
-        },
       ]
     },
     experimental: {

--- a/apps/www/pages/[...path].tsx
+++ b/apps/www/pages/[...path].tsx
@@ -11,8 +11,9 @@ type Params = {
 } & ParsedUrlQuery
 
 type Props = {
-  payNoteTryOrBuy: number
-  payNoteSeed: number
+  payNoteTryOrBuy?: number
+  payNoteSeed?: number
+  clientRedirection?: any
 }
 
 export const getStaticPaths: GetStaticPaths<Params> = async () => {

--- a/apps/www/pages/[...path].tsx
+++ b/apps/www/pages/[...path].tsx
@@ -4,6 +4,7 @@ import { ParsedUrlQuery } from 'querystring'
 import { gql } from '@apollo/client'
 import { getDocument } from '../components/Article/graphql/getDocument'
 import { createGetStaticProps } from '../lib/apollo/helpers'
+import { isExternal } from '../components/StatusError'
 
 type Params = {
   path: string[]
@@ -63,6 +64,14 @@ export const getStaticProps = createGetStaticProps<Props, Params>(
     })
 
     if (redirection) {
+      if (isExternal(redirection.target)) {
+        return {
+          props: {
+            clientRedirection: redirection,
+          },
+          revalidate: REVALIDATE_SECONDS,
+        }
+      }
       return {
         revalidate: REVALIDATE_SECONDS,
         redirect: {

--- a/apps/www/pages/install.js
+++ b/apps/www/pages/install.js
@@ -1,0 +1,61 @@
+import Frame from '../components/Frame'
+import StatusError from '../components/StatusError'
+
+import { createGetServerSideProps } from '../lib/apollo/helpers'
+import {
+  matchAndroidUserAgent,
+  matchIOSUserAgent,
+} from '../lib/context/UserAgentContext'
+import { getNativeAppVersion } from '../lib/withInNativeApp'
+
+const InstallNativeAppPage = ({ clientRedirection }) => (
+  <Frame raw>
+    <StatusError status={404} clientRedirection={clientRedirection} />
+  </Frame>
+)
+
+export default InstallNativeAppPage
+
+const getQueryString = (req) => {
+  const queryString = req.url.split('?')[1]
+  return queryString ? `?${queryString}` : ''
+}
+
+export const getServerSideProps = createGetServerSideProps(
+  async (_, { req }) => {
+    const userAgentValue = req.headers['user-agent']
+
+    const inNativeApp = !!getNativeAppVersion(userAgentValue)
+    if (inNativeApp) {
+      return {
+        redirect: {
+          destination: `/${getQueryString(req)}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const isIOS = matchIOSUserAgent(userAgentValue)
+    const isAndroid = matchAndroidUserAgent(userAgentValue)
+    if (!isIOS && !isAndroid) {
+      return {
+        redirect: {
+          destination: `/probelesen${getQueryString(req)}`,
+          permanent: false,
+        },
+      }
+    }
+
+    return {
+      props: {
+        clientRedirection: {
+          target: isIOS
+            ? 'https://apps.apple.com/ch/app/republik/id1392772910'
+            : isAndroid
+            ? 'https://play.google.com/store/apps/details?id=app.republik'
+            : '/probelesen',
+        },
+      },
+    }
+  },
+)

--- a/apps/www/pages/install.js
+++ b/apps/www/pages/install.js
@@ -54,6 +54,7 @@ export const getServerSideProps = createGetServerSideProps(
             : isAndroid
             ? 'https://play.google.com/store/apps/details?id=app.republik'
             : '/probelesen',
+          postExternalTarget: '/probelesen',
         },
       },
     }


### PR DESCRIPTION
We introduce a new `/install` route which roughly follows this logic:
```
- if iOS or Android
	- if inNative App
		- show marketing with probelese/front
		- track visit (incl. utm)
	- else
		- track visit (incl. utm)
		- redirect to App Store on iOS and Play Store on Android
			- open app
				- marketing with probelese
				- track without utms (they are lost)
		- show /probelesen in case page stays open or returning to browser
- else
	- show /probelesen
	- track visit (incl. utm)
```

Additionally following problems were fixed:
- #72 — this was rather tricky since we redirected in three ways to external urls: `next.config.js`, via `getStaticProps` returning a external url to the next redirect engine and in some cases via our `StatusError` component. Newly all external redirects go through our `StatusError` component as `clientRedirection` which also show a loading screen and allow for piwik tracking in our side before people leave. (`/ud/*` routes now come through redirection table again.) 
- pay notes for members, e.g. for `/probelesen` asking member to share, were always hidden via `data-hide-if-active-membership` (css), not they are shown once me is loaded. 
- spacing at article end for member – many br tags create an unnatural whole before member paynotes, margins of format feeds and other elements are totally sufficient – they seem are longer needed

<img width="403" alt="Screenshot 2022-07-28 at 11 30 28" src="https://user-images.githubusercontent.com/410211/181475300-fdf91f58-fd12-4e52-b998-5b23a8474220.png">