### PR TITLE
fix(www/search): ensure clear-icon is not 'clicked' when submitting the form

### DIFF
--- a/apps/www/components/Search/Form.js
+++ b/apps/www/components/Search/Form.js
@@ -88,7 +88,7 @@ const Form = compose(
             onChange={update}
             icon={
               !startState ? (
-                <button {...plainButtonRule} onClick={reset}>
+                <button {...plainButtonRule} onClick={reset} type='button'>
                   <CloseIcon
                     style={{ cursor: 'pointer' }}
                     size={30}

--- a/packages/styleguide/src/components/Form/Field.tsx
+++ b/packages/styleguide/src/components/Form/Field.tsx
@@ -307,6 +307,7 @@ const Field = React.forwardRef<
                 inputRef.current.focus()
               }
             }}
+            type='button'
           >
             <CloseIcon
               {...(isFocused


### PR DESCRIPTION
## Description

According to the HTML5 standard, a form that contains a button while not other button with type=submit is present will be "clicked" once the form is submitted.
This caused our Search-Form, which only contains the search-field and the clear-button, to click the clear-button which then reset the page once the input was submitted.

Also updated the clear-icon button in the Field component to ensure that type='button' is also set there.

### References

https://stackoverflow.com/questions/2825856/html-button-to-not-submit-form