### PR TITLE
feat(Article): append link to read aloud page

### DIFF
--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -452,7 +452,8 @@ const ActionBar = ({
       },
       label: t('PodcastButtons/play'),
       show:
-        !!meta.audioSource && meta.audioSource.kind !== 'syntheticReadAloud',
+        !!meta?.audioSource &&
+        !['syntheticReadAloud', 'readAloud'].includes(meta.audioSource.kind),
       modes: ['articleTop'],
     },
     {

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -315,16 +315,12 @@ const ArticlePage = ({
   const podcast =
     hasMeta &&
     (meta.podcast || (meta.audioSource && meta.format?.meta?.podcast))
-  const syntheticAudioSource =
+  const isSyntheticReadAloud =
     hasMeta &&
     meta.audioSource &&
-    meta.audioSource.kind === 'syntheticReadAloud' &&
-    meta.audioSource
-  const readAloudSource =
-    hasMeta &&
-    meta.audioSource &&
-    meta.audioSource.kind === 'readAloud' &&
-    meta.audioSource
+    meta.audioSource.kind === 'syntheticReadAloud'
+  const isReadAloud =
+    hasMeta && meta.audioSource && meta.audioSource.kind === 'readAloud'
   const newsletterMeta =
     hasMeta && (meta.newsletter || meta.format?.meta?.newsletter)
 
@@ -657,7 +653,8 @@ const ArticlePage = ({
                         {actionBar ||
                         isSection ||
                         showNewsletterSignupTop ||
-                        !!syntheticAudioSource ? (
+                        isSyntheticReadAloud ||
+                        isReadAloud ? (
                           <Center breakout={breakout}>
                             {actionBar && (
                               <div
@@ -673,7 +670,7 @@ const ArticlePage = ({
                                 {actionBar}
                               </div>
                             )}
-                            {(!!syntheticAudioSource || !!readAloudSource) && (
+                            {(isSyntheticReadAloud || isReadAloud) && (
                               <ReadAloudInline meta={meta} t={t} />
                             )}
                             {isSection && !hideSectionNav && (

--- a/apps/www/components/Article/ReadAloudInline.tsx
+++ b/apps/www/components/Article/ReadAloudInline.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { css } from 'glamor'
 import {
   IconButton,
@@ -59,21 +59,37 @@ const styles = {
     margin: 0,
   }),
   title: css({
-    ...fontStyles.sansSerifMedium15,
+    ...fontStyles.sansSerifMedium16,
     textDecoration: 'none',
     cursor: 'pointer',
-    margin: '0px 0 4px 0',
     padding: 0,
+  }),
+  link: css({
+    ...fontStyles.sansSerif16,
   }),
 }
 
-const SyntheticAudio = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
+const ReadAloudInline = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
   const { toggleAudioPlayer } = useContext<AudioContextType>(AudioContext)
   const [colorScheme] = useColorContext()
   const { kind } = meta.audioSource
   const isSynthetic = kind === 'syntheticReadAloud'
-  const Icon = isSynthetic ? AudioIcon : PodcastIcon
-  const eventCategory = isSynthetic ? 'SyntheticAudio' : 'ReadAloudAudio'
+  const isReadAloud = kind === 'readAloud'
+
+  const { Icon, eventCategory, title, label, href } = useMemo(
+    () => ({
+      Icon: (isSynthetic && AudioIcon) || PodcastIcon,
+      eventCategory: (isSynthetic && 'SyntheticAudio') || 'ReadAloudAudio',
+      title: t(`article/${kind}/title`),
+      label: t(`article/${kind}/link`),
+      href:
+        (isSynthetic && '/synthetic-read-aloud') ||
+        (isReadAloud && '/read-aloud') ||
+        false,
+    }),
+    [kind],
+  )
+
   return (
     <div>
       <hr {...styles.hr} {...colorScheme.set('backgroundColor', 'divider')} />
@@ -115,12 +131,15 @@ const SyntheticAudio = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
             {...colorScheme.set('color', 'text')}
             {...styles.title}
           >
-            {t(`article/${kind}/title`)}
-          </a>{' '}
-          {isSynthetic && (
-            <Editorial.A href='/2022/05/04/helfen-sie-uns-die-synthetische-stimme-zu-verbessern/diskussion'>
-              {t('article/syntheticReadAloud/errorLink')}
-            </Editorial.A>
+            {title}
+          </a>
+          {label && href && (
+            <>
+              {' '}
+              <Editorial.A href={href} {...styles.link}>
+                {label}
+              </Editorial.A>
+            </>
           )}
         </p>
       </div>
@@ -129,4 +148,4 @@ const SyntheticAudio = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
   )
 }
 
-export default SyntheticAudio
+export default ReadAloudInline

--- a/apps/www/components/Article/ReadAloudInline.tsx
+++ b/apps/www/components/Article/ReadAloudInline.tsx
@@ -50,22 +50,22 @@ const styles = {
   }),
   container: css({
     display: 'flex',
-    justifyContent: 'space-between',
-    padding: '12px 0',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    padding: '16px 0',
     gap: 16,
   }),
   text: css({
     flex: 1,
-    margin: 0,
+    margin: '2px 0',
   }),
   title: css({
     ...fontStyles.sansSerifMedium16,
     textDecoration: 'none',
-    cursor: 'pointer',
-    padding: 0,
   }),
   link: css({
-    ...fontStyles.sansSerif16,
+    ...fontStyles.sansSerifRegular16,
+    whiteSpace: 'nowrap',
   }),
 }
 
@@ -84,15 +84,7 @@ const ReadAloudInline = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
   return (
     <div>
       <hr {...styles.hr} {...colorScheme.set('backgroundColor', 'divider')} />
-      <div
-        {...styles.container}
-        {...css({
-          alignItems: isSynthetic ? 'flex-start' : 'center',
-          [mediaQueries.mUp]: {
-            alignItems: 'center',
-          },
-        })}
-      >
+      <div {...styles.container}>
         <IconButton
           style={{ marginRight: 0 }}
           size={32}

--- a/apps/www/components/Article/ReadAloudInline.tsx
+++ b/apps/www/components/Article/ReadAloudInline.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { css } from 'glamor'
 import {
   IconButton,
@@ -72,23 +72,14 @@ const styles = {
 const ReadAloudInline = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
   const { toggleAudioPlayer } = useContext<AudioContextType>(AudioContext)
   const [colorScheme] = useColorContext()
+
   const { kind } = meta.audioSource
   const isSynthetic = kind === 'syntheticReadAloud'
-  const isReadAloud = kind === 'readAloud'
-
-  const { Icon, eventCategory, title, label, href } = useMemo(
-    () => ({
-      Icon: (isSynthetic && AudioIcon) || PodcastIcon,
-      eventCategory: (isSynthetic && 'SyntheticAudio') || 'ReadAloudAudio',
-      title: t(`article/${kind}/title`),
-      label: t(`article/${kind}/link`),
-      href:
-        (isSynthetic && '/synthetic-read-aloud') ||
-        (isReadAloud && '/read-aloud') ||
-        false,
-    }),
-    [kind],
-  )
+  const Icon = (isSynthetic && AudioIcon) || PodcastIcon
+  const eventCategory = (isSynthetic && 'SyntheticAudio') || 'ReadAloudAudio'
+  const title = t(`article/${kind}/title`)
+  const label = t(`article/${kind}/hint/label`)
+  const link = t(`article/${kind}/hint/link`)
 
   return (
     <div>
@@ -133,11 +124,11 @@ const ReadAloudInline = ({ meta, t }: { meta: Meta; t: (sting) => string }) => {
           >
             {title}
           </a>
-          {label && href && (
+          {label && link && (
             <>
               {' '}
-              <Editorial.A href={href} {...styles.link}>
-                {label}
+              <Editorial.A href={link}>
+                <span {...styles.link}>{label}</span>
               </Editorial.A>
             </>
           )}

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3241,12 +3241,16 @@
       "value": "Beitrag von synthetischer Stimme vorlesen lassen."
     },
     {
-      "key": "article/syntheticReadAloud/errorLink",
+      "key": "article/syntheticReadAloud/link",
       "value": "Fehler melden"
     },
     {
       "key": "article/readAloud/title",
-      "value": "Beitrag vorlesen lassen"
+      "value": "Beitrag vorlesen lassen."
+    },
+    {
+      "key": "article/readAloud/link",
+      "value": "Alle vorgelesenen Beiträge"
     },
     {
       "key": "article/series/episode",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3241,16 +3241,24 @@
       "value": "Beitrag von synthetischer Stimme vorlesen lassen."
     },
     {
-      "key": "article/syntheticReadAloud/link",
+      "key": "article/syntheticReadAloud/hint/label",
       "value": "Fehler melden"
+    },
+    {
+      "key": "article/syntheticReadAloud/hint/link",
+      "value": "/2022/05/04/helfen-sie-uns-die-synthetische-stimme-zu-verbessern/diskussion"
     },
     {
       "key": "article/readAloud/title",
       "value": "Beitrag vorlesen lassen."
     },
     {
-      "key": "article/readAloud/link",
+      "key": "article/readAloud/hint/label",
       "value": "Alle vorgelesenen Beiträge"
+    },
+    {
+      "key": "article/readAloud/hint/link",
+      "value": "/format/vorgelesen"
     },
     {
       "key": "article/series/episode",


### PR DESCRIPTION
**Before**
<img width="716" alt="Bildschirmfoto 2022-08-08 um 09 54 39" src="https://user-images.githubusercontent.com/331800/183368261-519597fe-2c97-48dc-9e14-0afcba3d84c7.png">

**After**
<img width="724" alt="Bildschirmfoto 2022-08-08 um 09 49 22" src="https://user-images.githubusercontent.com/331800/183368143-7b588c53-6dfe-4649-b77f-aa1527bcb16e.png">

Upon deploy, add redirections beforehand
- /synthetic-read-aloud
- /read-aloud
