### PR TITLE
fix(nextjs-apollo-client): lock Apollo Client to ~3.5.10

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -23,7 +23,7 @@
     ".next/cache"
   ],
   "dependencies": {
-    "@apollo/client": "^3.5.8",
+    "@apollo/client": "~3.5.10",
     "@next/bundle-analyzer": "^12.2.3",
     "@project-r/styleguide": "*",
     "@republik/nextjs-apollo-client": "*",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@apollo/client": "^3.5.8",
+    "@apollo/client": "~3.5.10",
     "@next/bundle-analyzer": "^12.2.3",
     "@project-r/styleguide": "*",
     "@republik/nextjs-apollo-client": "*",

--- a/packages/nextjs-apollo-client/package.json
+++ b/packages/nextjs-apollo-client/package.json
@@ -16,7 +16,7 @@
     "generate::possibleTypes": "node scripts/generatePossibleTypes.js"
   },
   "devDependencies": {
-    "@apollo/client": "^3.5.8",
+    "@apollo/client": "~3.5.10",
     "@republik/eslint-config-frontend": "*",
     "@types/node": "^17.0.41",
     "@types/react": "^17.0.39",
@@ -31,7 +31,7 @@
     "uuid": "^3.4.0"
   },
   "peerDependencies": {
-    "@apollo/client": "^3.5.8",
+    "@apollo/client": "~3.5.10",
     "graphql": "^15.3.0",
     "next": "^12.2.3",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,7 +61,7 @@
   dependencies:
     cross-fetch "3.1.5"
 
-"@apollo/client@^3.1.5", "@apollo/client@^3.5.8":
+"@apollo/client@^3.1.5":
   version "3.6.9"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
   integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
@@ -78,6 +78,24 @@
     ts-invariant "^0.10.3"
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
+
+"@apollo/client@~3.5.10":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.10.tgz#43463108a6e07ae602cca0afc420805a19339a71"
+  integrity sha512-tL3iSpFe9Oldq7gYikZK1dcYxp1c01nlSwtsMz75382HcI6fvQXyFXUCJTTK3wgO2/ckaBvRGw7VqjFREdVoRw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.4"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.0"
 
 "@apollo/protobufjs@1.2.2":
   version "1.2.2"
@@ -2439,7 +2457,7 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
-"@graphql-typed-document-node/core@^3.1.1":
+"@graphql-typed-document-node/core@^3.0.0", "@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
@@ -12664,7 +12682,7 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.3.0"
 
-graphql-tag@^2.10.4, graphql-tag@^2.11.0, graphql-tag@^2.12.6:
+graphql-tag@^2.10.4, graphql-tag@^2.11.0, graphql-tag@^2.12.3, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -24112,6 +24130,13 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.2:
   dependencies:
     tslib "^1.9.3"
 
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-node@^10.8.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
@@ -26036,7 +26061,7 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable-ts@^1.2.5:
+zen-observable-ts@^1.2.0, zen-observable-ts@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
   integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==


### PR DESCRIPTION
## Description

Lock version the version of `@apollo/client@^3.5.8` in `nextjs-apollo-client` & all apps that use it to `~3.5.10`. This will fix issues that first occurred in `@apollo/client@^3.6.0` 