### PR TITLE
fix(shortenLink): use string as such if not a url

### DIFF
--- a/packages/styleguide/src/components/ExpandableLink/ExpandableLinkCallout.tsx
+++ b/packages/styleguide/src/components/ExpandableLink/ExpandableLinkCallout.tsx
@@ -19,7 +19,13 @@ type Props = {
 
 export const shortenLink = (url) => {
   if (!url) return
-  const addr = new URL(url)
+  let addr
+  try {
+    addr = new URL(url)
+  } catch (e) {
+    console.error(e)
+    return url
+  }
   const host = addr.host
   const path = addr.pathname
   const hasTrailingForwardSlash = path.slice(-1) === '/'

--- a/packages/styleguide/src/components/ExpandableLink/shortenLink.test.js
+++ b/packages/styleguide/src/components/ExpandableLink/shortenLink.test.js
@@ -25,4 +25,8 @@ describe('Link shortening test', () => {
     const res = shortenLink('https://example.com')
     expect(res).toBe('example.com')
   })
+  test('shortenLink: return string as is if it not link', () => {
+    const res = shortenLink('my link will go here')
+    expect(res).toBe('my link will go here')
+  })
 })


### PR DESCRIPTION
- tested locally