### PR TITLE
fix(www/discussion): improve the order-by button-styling to better communicate the active state

### DIFF
--- a/packages/styleguide/src/components/Tabs/TabButton.tsx
+++ b/packages/styleguide/src/components/Tabs/TabButton.tsx
@@ -48,6 +48,9 @@ const styles = {
   link: css({
     ...plainLinkRule,
   }),
+  activeLink: css({
+    textDecoration: 'underline',
+  }),
   active: css({
     ...sansSerifMedium16,
   }),
@@ -82,7 +85,12 @@ const TabButton = React.forwardRef<
       ref={ref}
       href={href}
       onClick={onClick}
-      {...css(styles.default, isActive && styles.active, href && styles.link)}
+      {...css(
+        styles.default,
+        isActive && styles.active,
+        href && styles.link,
+        href && isActive && !border && styles.activeLink,
+      )}
       {...plainButtonRule}
       {...(!isActive && hoverRule)}
       {...colorScheme.set(


### PR DESCRIPTION
## Description 

Fixes #183.

Active link TabButtons now have `text-decoration: underline` styling unless `border={false}` is set.

### Screenshot

<img width="688" alt="image" src="https://user-images.githubusercontent.com/30313631/186427947-563be413-19f2-48de-ac08-2af40b45a7e4.png">
