### PR TITLE
Newsletter signup, CLIMATE, READALOUD

### DIFF
--- a/apps/www/components/Account/NewsletterSubscriptions/index.js
+++ b/apps/www/components/Account/NewsletterSubscriptions/index.js
@@ -35,7 +35,7 @@ export const UPDATE_NEWSLETTER_SUBSCRIPTION = gql`
 `
 
 export const NEWSLETTER_SETTINGS = gql`
-  query myNewsletterSettings {
+  query myNewsletterSettings($newsletterName: NewsletterName) {
     me {
       id
       newsletterSettings {
@@ -47,7 +47,7 @@ export const NEWSLETTER_SETTINGS = gql`
 `
 
 const NewsletterSubscriptions = ({ t, isMember, free, onlyName }) => (
-  <Query query={NEWSLETTER_SETTINGS}>
+  <Query query={NEWSLETTER_SETTINGS} variables={{ newsletterName: onlyName }}>
     {({ loading, error, data }) => {
       if (loading || error) {
         return <Loader loading={loading} error={error} />

--- a/apps/www/components/Account/NewsletterSubscriptions/index.js
+++ b/apps/www/components/Account/NewsletterSubscriptions/index.js
@@ -35,7 +35,7 @@ export const UPDATE_NEWSLETTER_SUBSCRIPTION = gql`
 `
 
 export const NEWSLETTER_SETTINGS = gql`
-  query myNewsletterSettings($newsletterName: NewsletterName) {
+  query myNewsletterSettings($onlyName: NewsletterName) {
     me {
       id
       newsletterSettings {
@@ -47,7 +47,7 @@ export const NEWSLETTER_SETTINGS = gql`
 `
 
 const NewsletterSubscriptions = ({ t, isMember, free, onlyName }) => (
-  <Query query={NEWSLETTER_SETTINGS} variables={{ newsletterName: onlyName }}>
+  <Query query={NEWSLETTER_SETTINGS} variables={{ onlyName }}>
     {({ loading, error, data }) => {
       if (loading || error) {
         return <Loader loading={loading} error={error} />

--- a/apps/www/components/Account/enhancers.js
+++ b/apps/www/components/Account/enhancers.js
@@ -13,7 +13,7 @@ export const newsletterSettingsFragment = `
   fragment NewsletterSettings on NewsletterSettings {
     id
     status
-    subscriptions {
+    subscriptions(name: $newsletterName) {
       ...NewsletterInfo
     }
   }

--- a/apps/www/components/Account/enhancers.js
+++ b/apps/www/components/Account/enhancers.js
@@ -13,7 +13,7 @@ export const newsletterSettingsFragment = `
   fragment NewsletterSettings on NewsletterSettings {
     id
     status
-    subscriptions(name: $newsletterName) {
+    subscriptions(name: $onlyName) {
       ...NewsletterInfo
     }
   }

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -102,6 +102,13 @@ const TestimonialList = dynamic(
 const ReasonsVideo = dynamic(() => import('../About/ReasonsVideo'), {
   ssr: true,
 })
+const NewsletterSignUpDynamic = dynamic(
+  () => import('../Auth/NewsletterSignUp'),
+  {
+    loading: LoadingComponent,
+    ssr: false,
+  },
+)
 const Votebox = dynamic(() => import('../Vote/Voting'), {
   loading: LoadingComponent,
   ssr: false,
@@ -362,6 +369,7 @@ const ArticlePage = ({
           ELECTION_RESULT_DIVERSITY: ElectionResultDiversity,
           QUESTIONNAIRE: Questionnaire,
           QUESTIONNAIRE_SUBMISSIONS: QuestionnaireSubmissions,
+          NEWSLETTER_SIGNUP: NewsletterSignUpDynamic,
         },
         titleMargin: false,
         titleBreakout,

--- a/apps/www/components/Auth/MacNewsletterSubscription.js
+++ b/apps/www/components/Auth/MacNewsletterSubscription.js
@@ -3,7 +3,7 @@ import compose from 'lodash/flowRight'
 import { graphql } from '@apollo/client/react/hoc'
 import { gql } from '@apollo/client'
 
-import { Button, InlineSpinner } from '@project-r/styleguide'
+import { Button, InlineSpinner, Interaction } from '@project-r/styleguide'
 
 import withT from '../../lib/withT'
 
@@ -17,15 +17,24 @@ class NewsletterSubscription extends Component {
     this.state = {}
   }
   render() {
-    const { t, updateNewsletterSubscription, email, router } = this.props
+    const { name, t, updateNewsletterSubscription, email, router } = this.props
     const { consents } = this.state
 
     const requiredConsents = ['PRIVACY']
     const consentsError = getConsentsError(t, requiredConsents, consents)
     const error = this.state.error || (this.state.dirty && consentsError)
+    const text = t.first(
+      [
+        `macNewsletterSubscription/name:${name}/text`,
+        `macNewsletterSubscription/text`,
+      ],
+      undefined,
+      '',
+    )
 
     return (
       <Fragment>
+        {text && <Interaction.P>{text}</Interaction.P>}
         <div style={{ margin: '20px 0', textAlign: 'left' }}>
           <Consents
             accepted={consents}

--- a/apps/www/components/Auth/Notification.js
+++ b/apps/www/components/Auth/Notification.js
@@ -84,11 +84,20 @@ const AuthNotification = ({ query, goTo, onClose, t, me }) => {
       'newsletter',
     ].includes(type)
   ) {
+    const { name, subscribed, mac } = query
+    title = t.first(
+      [
+        `notifications/newsletter/name:${name}/title`,
+        `notifications/newsletter/title`,
+      ],
+      undefined,
+      '',
+    )
     content = (
       <MacNewsletterSubscription
-        name={query.name}
-        subscribed={!!query.subscribed}
-        mac={query.mac}
+        name={name}
+        subscribed={!!subscribed}
+        mac={mac}
         email={email}
         context={context}
       />

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3770,7 +3770,7 @@
     },
     {
       "key": "notifications/email-confirmed/newsletter/title",
-      "value": "E-Mail-Adresse bestätigt"
+      "value": "Anmeldung bestätigt"
     },
     {
       "key": "notifications/email-confirmed/text",
@@ -3839,6 +3839,14 @@
     {
       "key": "notifications/newsletter/title",
       "value": "Newsletter-Anmeldung"
+    },
+    {
+      "key": "notifications/newsletter/name:READALOUD/title",
+      "value": "Die Republik zum Hören"
+    },
+    {
+      "key": "macNewsletterSubscription/name:READALOUD/text",
+      "value": "Dürfen wir Sie benachrichtigen, sobald die Republik zum Hören verfügbar ist?"
     },
     {
       "key": "macNewsletterSubscription/button",

--- a/packages/backend-modules/mail/NewsletterSubscription.js
+++ b/packages/backend-modules/mail/NewsletterSubscription.js
@@ -2,7 +2,7 @@ const createNewsletterSubscription = (interestConfigurationMap) => ({
   buildSubscription(userId, interestId, subscribed, roles) {
     const { name, ...rest } = this.interestConfiguration(interestId)
     const id = Buffer.from(userId + name).toString('base64')
-    return { userId, subscribed, roles, name, ...rest, id }
+    return { ...rest, name, id, userId, interestId, subscribed, roles }
   },
 
   allInterestConfigurations() {

--- a/packages/backend-modules/mail/NewsletterSubscription.js
+++ b/packages/backend-modules/mail/NewsletterSubscription.js
@@ -1,9 +1,8 @@
 const createNewsletterSubscription = (interestConfigurationMap) => ({
-  buildSubscription(userId, interestId, subscribed) {
-    const interestConfiguration = this.interestConfiguration(interestId)
-    const name = interestConfiguration.name
+  buildSubscription(userId, interestId, subscribed, roles) {
+    const { name, ...rest } = this.interestConfiguration(interestId)
     const id = Buffer.from(userId + name).toString('base64')
-    return { name, id, subscribed }
+    return { userId, subscribed, roles, name, ...rest, id }
   },
 
   allInterestConfigurations() {

--- a/packages/backend-modules/mail/lib/getNewsletterSettings.js
+++ b/packages/backend-modules/mail/lib/getNewsletterSettings.js
@@ -3,15 +3,9 @@ const { SubscriptionHandlerMissingMailError } = require('../errors')
 const logger = console
 
 module.exports = async ({ user }, NewsletterSubscription) => {
-  // circumvent circle dependency
-  const {
-    Roles: { userIsInRoles },
-  } = require('@orbiting/backend-modules-auth')
-
   if (!NewsletterSubscription) throw new SubscriptionHandlerMissingMailError()
 
-  const { id, email, roles } = user
-  const settingsId = Buffer.from(`${id}/NewsletterSettings`).toString('base64')
+  const { email, roles } = user
 
   const supportedInterestConfigs =
     NewsletterSubscription.allInterestConfigurations()
@@ -19,42 +13,15 @@ module.exports = async ({ user }, NewsletterSubscription) => {
   const mailchimp = MailchimpInterface({ logger })
   const member = await mailchimp.getMember(email)
 
-  if (!member) {
-    // member could not be retrieved
-    // return all possible interests / subscriptions
-    const status = ''
-    const subscriptions = supportedInterestConfigs
-      .filter(({ visibleToRoles }) => !visibleToRoles || !visibleToRoles.length)
-      .map(({ interestId }) =>
-        NewsletterSubscription.buildSubscription(
-          user.id,
-          interestId,
-          false,
-          roles,
-        ),
-      )
-    return { id: settingsId, status, subscriptions }
-  }
-
-  const status = member.status
-  const subscriptions = []
-  supportedInterestConfigs.forEach(({ interestId, visibleToRoles }) => {
-    // only return visible interests
-    if (
-      !visibleToRoles ||
-      !visibleToRoles.length ||
-      userIsInRoles(user, visibleToRoles)
-    ) {
-      const subscribed = !!member.interests[interestId]
-      subscriptions.push(
-        NewsletterSubscription.buildSubscription(
-          user.id,
-          interestId,
-          subscribed,
-          roles,
-        ),
-      )
-    }
-  })
-  return { id: settingsId, status, subscriptions }
+  const id = Buffer.from(`${user.id}/NewsletterSettings`).toString('base64')
+  const status = member?.status || ''
+  const subscriptions = supportedInterestConfigs.map(({ interestId }) =>
+    NewsletterSubscription.buildSubscription(
+      user.id,
+      interestId,
+      !!member?.interests?.[interestId], // subscribed
+      roles,
+    ),
+  )
+  return { id, status, subscriptions }
 }

--- a/packages/backend-modules/mail/templates/newsletter_request_CLIMATE.html
+++ b/packages/backend-modules/mail/templates/newsletter_request_CLIMATE.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>Vielen Dank für Ihr Interesse.</p>
+                    <p>
+                      Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem
+                      Link:
+                    </p>
+                    <table
+                      width="100%"
+                      border="0"
+                      cellspacing="0"
+                      cellpadding="0"
+                    >
+                      <tr>
+                        <td>
+                          <table border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td align="center" bgcolor="#3CAD00">
+                                <a
+                                  href="{{CONFIRM_LINK}}"
+                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
+                                  >Anmeldung bestätigen</a
+                                >
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                    <p>
+                      Wenn Sie diese E-Mail öfters unaufgefordert erhalten,
+                      wenden Sie sich bitte an
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >.
+                    </p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/backend-modules/mail/templates/newsletter_request_CLIMATE.txt
+++ b/packages/backend-modules/mail/templates/newsletter_request_CLIMATE.txt
@@ -1,0 +1,18 @@
+Guten Tag
+
+Vielen Dank für Ihr Interesse.
+
+Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem Link:
+
+Anmeldung bestätigen {{CONFIRM_LINK}}
+
+Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an
+kontakt@republik.ch .
+
+Ihre Crew der Republik
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/backend-modules/mail/templates/newsletter_request_READALOUD.html
+++ b/packages/backend-modules/mail/templates/newsletter_request_READALOUD.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>Vielen Dank für Ihr Interesse.</p>
+                    <p>
+                      Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem
+                      Link:
+                    </p>
+                    <table
+                      width="100%"
+                      border="0"
+                      cellspacing="0"
+                      cellpadding="0"
+                    >
+                      <tr>
+                        <td>
+                          <table border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td align="center" bgcolor="#3CAD00">
+                                <a
+                                  href="{{CONFIRM_LINK}}"
+                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
+                                  >Anmeldung bestätigen</a
+                                >
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                    <p>
+                      Wenn Sie diese E-Mail öfters unaufgefordert erhalten,
+                      wenden Sie sich bitte an
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >.
+                    </p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/backend-modules/mail/templates/newsletter_request_READALOUD.txt
+++ b/packages/backend-modules/mail/templates/newsletter_request_READALOUD.txt
@@ -1,0 +1,18 @@
+Guten Tag
+
+Vielen Dank für Ihr Interesse.
+
+Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem Link:
+
+Anmeldung bestätigen {{CONFIRM_LINK}}
+
+Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an
+kontakt@republik.ch .
+
+Ihre Crew der Republik
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/backend-modules/republik-crowdfundings/lib/Mail.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/Mail.js
@@ -27,6 +27,8 @@ const {
   MAILCHIMP_INTEREST_NEWSLETTER_WEEKLY,
   MAILCHIMP_INTEREST_NEWSLETTER_PROJECTR,
   MAILCHIMP_INTEREST_NEWSLETTER_ACCOMPLICE,
+  MAILCHIMP_INTEREST_NEWSLETTER_CLIMATE,
+  MAILCHIMP_INTEREST_NEWSLETTER_READALOUD,
   FRONTEND_BASE_URL,
 } = process.env
 
@@ -47,6 +49,16 @@ const mail = createMail([
     name: 'ACCOMPLICE',
     interestId: MAILCHIMP_INTEREST_NEWSLETTER_ACCOMPLICE,
     visibleToRoles: ['accomplice'],
+  },
+  {
+    name: 'CLIMATE',
+    interestId: MAILCHIMP_INTEREST_NEWSLETTER_CLIMATE,
+    invisible: true,
+  },
+  {
+    name: 'READALOUD',
+    interestId: MAILCHIMP_INTEREST_NEWSLETTER_READALOUD,
+    invisible: true,
   },
 ])
 

--- a/packages/backend-modules/republik/.gitignore
+++ b/packages/backend-modules/republik/.gitignore
@@ -1,1 +1,2 @@
 script/fixMissingPortraitUrls.js
+script/generateNewsletterHmac.js

--- a/packages/backend-modules/republik/graphql/resolvers/NewsletterSettings.js
+++ b/packages/backend-modules/republik/graphql/resolvers/NewsletterSettings.js
@@ -1,0 +1,20 @@
+const {
+  Roles: { userIsInRoles },
+} = require('@orbiting/backend-modules-auth')
+
+const filterMissingRole = ({ roles, visibleToRoles }) =>
+  !visibleToRoles?.length || userIsInRoles(roles, visibleToRoles)
+
+const filterInvisible = ({ invisible }) => !invisible
+
+module.exports = {
+  subscriptions: (settings, args, context) => {
+    const { subscriptions } = settings
+
+    if (args?.name) {
+      return subscriptions.filter(({ name }) => name === args.name)
+    }
+
+    return subscriptions.filter(filterMissingRole).filter(filterInvisible)
+  },
+}

--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/requestNewsletterSubscription.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/requestNewsletterSubscription.js
@@ -8,7 +8,7 @@ module.exports = async (_, args, context) => {
   const { email, name, context: newsletterContext } = args
   const { t } = context
 
-  if (!['PROJECTR'].includes(name)) {
+  if (!['PROJECTR', 'CLIMATE', 'READALOUD'].includes(name)) {
     throw new Error(t('api/newsletters/request/notSupported'))
   }
 

--- a/packages/backend-modules/republik/graphql/schema-types.js
+++ b/packages/backend-modules/republik/graphql/schema-types.js
@@ -75,12 +75,12 @@ extend type User {
 type NewsletterSettings {
   id: ID!
   status: String!
-  subscriptions: [NewsletterSubscription]
+  subscriptions(name: NewsletterName): [NewsletterSubscription]
 }
 
 type NewsletterSubscription {
   id: ID!
-  name: String!
+  name: NewsletterName!
   subscribed: Boolean!
   isEligible: Boolean! @deprecated(reason: "Eligability is handeld elsewhere. Subscription changes are always possible.")
 }

--- a/packages/backend-modules/republik/graphql/schema-types.js
+++ b/packages/backend-modules/republik/graphql/schema-types.js
@@ -131,6 +131,8 @@ enum NewsletterName {
   WEEKLY
   PROJECTR
   ACCOMPLICE
+  CLIMATE
+  READALOUD
 }
 
 type Video {

--- a/packages/backend-modules/republik/script/generateNewsletterHmac.ts
+++ b/packages/backend-modules/republik/script/generateNewsletterHmac.ts
@@ -1,0 +1,36 @@
+require('@orbiting/backend-modules-env').config()
+
+import yargs from 'yargs'
+
+const { t } = require('@orbiting/backend-modules-translate')
+const base64u = require('@orbiting/backend-modules-base64u')
+
+const { authenticate } = require('../lib/Newsletter')
+
+const { FRONTEND_BASE_URL } = process.env
+
+const argv: { email: string; name: string } = yargs
+  .option('email', {
+    description: 'Email address',
+    required: true,
+    type: 'string',
+  })
+  .option('name', {
+    description: 'Newsletter subscription name',
+    required: true,
+    type: 'string',
+  }).argv
+
+const { email, name } = argv
+
+const hmac = authenticate(email, name, 1, t)
+const confirmLink = `${FRONTEND_BASE_URL}/mitteilung?type=newsletter&name=${name}&subscribed=1&email=${base64u.encode(
+  email,
+)}&mac=${hmac}&context=newsletter`
+
+console.log({
+  email,
+  name,
+  hmac,
+  confirmLink,
+})

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -817,6 +817,14 @@
       "value": "Bestätigen Sie Ihre Anmeldung zum Project-R-Newsletter."
     },
     {
+      "key": "api/newsletters/request/CLIMATE/subject",
+      "value": "Bestätigen Sie Ihre Anmeldung zum Klimalabor-Newsletter."
+    },
+    {
+      "key": "api/newsletters/request/READALOUD/subject",
+      "value": "Magazin zum Hören: Bestätigen Sie Ihre Anmeldung."
+    },
+    {
       "key": "api/newsletters/request/notSupported",
       "value": "Diese Art der Anmeldung zum gewählten Newsletter wird noch nicht unterstützt."
     },


### PR DESCRIPTION
This Pull Request adds two now Mailchimp segments to code base: `CLIMATE` (Klimalabor-Newsletter) and `READALOUD` («Hört, Hört» notification once released).

Both segments are invisible and won't be listed. API however returns subscription if queried by name:

```gql
{
  user(slug: "someone") {
    newsletterSettings {
      subscriptions(name: CLIMATE) {
        name
        subscribed
      }
    }
  }
}
``` 

This enables `Auth/NewsletterSubscriptions` to handle invisible Mailchimp segments if a name is provided (used when i. e. `Document.meta.newsletter.name` is set).

It then exposes `Auth/NewsletterSignUp` as a "Dynamic Component".

And it also refactors `Auth/Notifications` and `Auth/MacNewsletterSubscription` to allow for Mailchimp segment specific title and short text:

<img width="584" alt="Bildschirmfoto 2022-08-30 um 15 31 54" src="https://user-images.githubusercontent.com/331800/187460639-a193872c-d1f8-4de4-93bc-a1deccae15de.png">
