### PR TITLE
Fix newsletter resubscribe mutation, updateMe mutation

### DIFF
--- a/apps/www/components/Account/NewsletterSubscriptions/index.js
+++ b/apps/www/components/Account/NewsletterSubscriptions/index.js
@@ -10,16 +10,20 @@ import FrameBox from '../../Frame/Box'
 import { P } from '../Elements'
 
 import { withMembership } from '../../Auth/checkRoles'
-import { newsletterFragment, newsletterSettingsFragment } from '../enhancers'
+import { newsletterFragment } from '../enhancers'
 import NewsletterItem from './NewsletterItem'
 
 export const RESUBSCRIBE_EMAIL = gql`
   mutation resubscribeEmail($userId: ID!) {
     resubscribeEmail(userId: $userId) {
-      ...NewsletterSettings
+      id
+      status
+      subscriptions {
+        ...NewsletterInfo
+      }
     }
   }
-  ${newsletterSettingsFragment}
+  ${newsletterFragment}
 `
 
 export const UPDATE_NEWSLETTER_SUBSCRIPTION = gql`
@@ -39,11 +43,15 @@ export const NEWSLETTER_SETTINGS = gql`
     me {
       id
       newsletterSettings {
-        ...NewsletterSettings
+        id
+        status
+        subscriptions(name: $onlyName) {
+          ...NewsletterInfo
+        }
       }
     }
   }
-  ${newsletterSettingsFragment}
+  ${newsletterFragment}
 `
 
 const NewsletterSubscriptions = ({ t, isMember, free, onlyName }) => (

--- a/apps/www/components/Account/enhancers.js
+++ b/apps/www/components/Account/enhancers.js
@@ -9,17 +9,6 @@ export const newsletterFragment = `
   }
 `
 
-export const newsletterSettingsFragment = `
-  fragment NewsletterSettings on NewsletterSettings {
-    id
-    status
-    subscriptions(name: $onlyName) {
-      ...NewsletterInfo
-    }
-  }
-  ${newsletterFragment}
-`
-
 export const userDetailsFragment = `
   fragment PhoneAndAddressOnUser on User {
     id
@@ -67,11 +56,15 @@ const addMeToRole = gql`
       id
       roles
       newsletterSettings {
-        ...NewsletterSettings
+        id
+        status
+        subscriptions {
+          ...NewsletterInfo
+        }
       }
     }
   }
-  ${newsletterSettingsFragment}
+  ${newsletterFragment}
 `
 
 export const query = gql`

--- a/packages/backend-modules/assets/lib/Portrait.js
+++ b/packages/backend-modules/assets/lib/Portrait.js
@@ -60,8 +60,9 @@ const upload = async (portrait, dry = false) => {
 
 const del = (portraitUrl) => {
   if (!portraitUrl) {
-    return
+    return Promise.resolve()
   }
+
   const [, bucket, path] = new RegExp(/.*?s3\/(.*?)\/(.*?)\?/).exec(portraitUrl)
   debug('del: %o', { bucket, path })
   return S3.del({ bucket, path })


### PR DESCRIPTION
- `newsletterSettingsFragment` got an optional variable; while well intentioned, that was a shitty idea as it is hard to track down which arguments a fragment requires. [Reverted](https://github.com/republik/plattform/pull/194/commits/d182926c9d54e6d5c627c8e4b1fdcb5c8284796a).
- If `updateMe` failes (e.g. tel no too short), it will delete file a new portrait file, too. If there is no new portrait, `Portrait.del` return undefined instead of a resolved promise. Calling `Promise.del(xxx).catch()` caused an "undefined" error. [Fixed](https://github.com/republik/plattform/pull/194/commits/e8aadef1b6c4ad7f68e4ecf34aaa4b3bff2f5b09).