### PR TITLE
Fix daily statistics report

### DIFF
--- a/packages/backend-modules/statistics/lib/matomo/data.js
+++ b/packages/backend-modules/statistics/lib/matomo/data.js
@@ -20,7 +20,7 @@ const retrieve = async ({ url, date, segment, idSite, period }, { pgdb }) => {
       ${fragmentSegment}
       AND "idSite" = '${idSite}'
       AND period = '${period}'
-      AND template = 'article'
+      AND template IN ('article', 'flyer')
 
     LIMIT 1
   `)


### PR DESCRIPTION
`stringifyNode` became asynchronous and requires a type. This Pull Request fixes that.

It allows flyer templates to be reported daily, too.