### PR TITLE
feat: refetch flyer path every day after 5am

### DIFF
--- a/apps/www/lib/apollo/miniNavi.js
+++ b/apps/www/lib/apollo/miniNavi.js
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client'
+import { useEffect } from 'react'
 
 export const miniNaviQuery = gql`
   query miniNavi {
@@ -15,8 +16,44 @@ export const miniNaviQuery = gql`
   }
 `
 
+let refetchTimeoutId
+
+const PUBLISH_HOURS = 5
+const PUBLISH_MINUTES = 0
+
 export const useFlyerMeta = () => {
-  const { data } = useQuery(miniNaviQuery)
+  const { data, refetch } = useQuery(miniNaviQuery)
+
+  useEffect(() => {
+    if (refetchTimeoutId !== undefined) {
+      return
+    }
+    const now = new Date()
+    const updateTimeToday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      PUBLISH_HOURS,
+      PUBLISH_MINUTES,
+    )
+    const nextUpdateTomorrow = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() + 1,
+      PUBLISH_HOURS,
+      PUBLISH_MINUTES,
+    )
+    const nextUpdateMs =
+      now < updateTimeToday ? updateTimeToday - now : nextUpdateTomorrow - now
+    const refresh = () => {
+      refetch()
+      // recursion 24h later again
+      refetchTimeoutId = setTimeout(() => {
+        refresh()
+      }, 24 * 60 * 60 * 1000)
+    }
+    refetchTimeoutId = setTimeout(refresh, nextUpdateMs)
+  }, [])
 
   return data?.documents.nodes[0]?.meta
 }


### PR DESCRIPTION
Caveat: currently has no clean up. Feels unnecessary in prd but in dev it could go crazy – with hot reload multiple timeouts could be running. A clean up option I could imagine are ref counting:

```
let refs = 0
let timeoutId
export const useFlyerMeta = () => {
  useEffect(() => {
    refs += 1
    if (timeoutId === undefined) timeoutId = setTimeout()
    // ...
    return () => {
      refs -= 1
      if (refs === 0) clearTimeout(timeoutId)
    }
  }, [])
}
```