### PR TITLE
Improves Popover/Sections query loading speed

### DIFF
--- a/apps/www/components/Frame/Popover/Sections.js
+++ b/apps/www/components/Frame/Popover/Sections.js
@@ -36,7 +36,7 @@ const getSectionNav = gql`
               color
               kind
             }
-            linkedDocuments(feed: true) {
+            linkedDocuments(feed: true, first: 0) {
               totalCount
             }
           }

--- a/apps/www/components/Sections/Index.js
+++ b/apps/www/components/Sections/Index.js
@@ -63,7 +63,7 @@ const getSections = gql`
               color
               kind
             }
-            linkedDocuments(feed: true) {
+            linkedDocuments(feed: true, first: 0) {
               totalCount
             }
           }

--- a/packages/backend-modules/search/lib/options.js
+++ b/packages/backend-modules/search/lib/options.js
@@ -63,7 +63,7 @@ const decodeCursor = (cursor) => {
 // Returns args as options w/o nullish props.
 const cleanArgs = (args) =>
   Object.keys(args)
-    .filter((key) => !['undefined', 'null'].includes(typeof args[key]))
+    .filter((key) => ![null, undefined].includes(args[key]))
     .reduce((prev, curr) => ({ ...prev, [curr]: args[curr] }), {})
 
 // Processes search {args} and returns reasonable {options}.

--- a/packages/backend-modules/search/lib/options.js
+++ b/packages/backend-modules/search/lib/options.js
@@ -63,7 +63,7 @@ const decodeCursor = (cursor) => {
 // Returns args as options w/o nullish props.
 const cleanArgs = (args) =>
   Object.keys(args)
-    .filter((key) => args[key] ?? false)
+    .filter((key) => !['undefined', 'null'].includes(typeof args[key]))
     .reduce((prev, curr) => ({ ...prev, [curr]: args[curr] }), {})
 
 // Processes search {args} and returns reasonable {options}.


### PR DESCRIPTION
This Pull Request changes `linkedDocuments` sub-query to return 0 nodes (`first: 0`) while still receiving `totalCount`.

Queries used on
- popover (sections with formats and their doc count)
- section page

It increases query response time.

**Before**
<img width="180" alt="Bildschirmfoto 2022-09-14 um 14 51 03" src="https://user-images.githubusercontent.com/331800/190158900-cc93306e-01b1-4a77-b724-ecc6c4b95006.png">

**After**
<img width="181" alt="Bildschirmfoto 2022-09-14 um 14 51 31" src="https://user-images.githubusercontent.com/331800/190158904-b0326a1a-0627-42d5-bce1-fa037e1aad64.png">

