### PR TITLE
Pass identifiers to the apollo-client across our web-clients

### DIFF
--- a/apps/admin/lib/apollo/index.ts
+++ b/apps/admin/lib/apollo/index.ts
@@ -1,12 +1,15 @@
+import getConfig from 'next/config'
 import {
   createApolloClientUtilities,
   makeWithDefaultSSR,
 } from '@republik/nextjs-apollo-client'
 import { API_URL } from '../../server/constants'
 
+const { publicRuntimeConfig } = getConfig()
+
 export const { withApollo, initializeApollo } = createApolloClientUtilities({
   name: '@orbiting/admin-app',
-  version: '1.0',
+  version: publicRuntimeConfig.buildId,
   apiUrl: API_URL,
 })
 

--- a/apps/admin/lib/apollo/index.ts
+++ b/apps/admin/lib/apollo/index.ts
@@ -5,6 +5,8 @@ import {
 import { API_URL } from '../../server/constants'
 
 export const { withApollo, initializeApollo } = createApolloClientUtilities({
+  name: '@orbiting/admin-app',
+  version: '1.0',
   apiUrl: API_URL,
 })
 

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -15,7 +15,7 @@ module.exports = withTM(
     eslint: {
       ignoreDuringBuilds: true,
     },
-    generateBuildId: () => buildId,
+    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
     publicRuntimeConfig: {
       buildId,
     },

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -7,7 +7,9 @@ const withTM = require('next-transpile-modules')([
   '@republik/nextjs-apollo-client',
 ])
 
-const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
+const buildId =
+  process.env.SOURCE_VERSION?.substring(0, 10) ||
+  new Date(Date.now()).toISOString()
 
 module.exports = withTM(
   withBundleAnalyzer({
@@ -15,7 +17,7 @@ module.exports = withTM(
     eslint: {
       ignoreDuringBuilds: true,
     },
-    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
+    generateBuildId: () => buildId,
     publicRuntimeConfig: {
       buildId,
     },

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -7,11 +7,17 @@ const withTM = require('next-transpile-modules')([
   '@republik/nextjs-apollo-client',
 ])
 
+const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
+
 module.exports = withTM(
   withBundleAnalyzer({
     poweredByHeader: false,
     eslint: {
       ignoreDuringBuilds: true,
+    },
+    generateBuildId: () => buildId,
+    publicRuntimeConfig: {
+      buildId,
     },
     async redirects() {
       return [

--- a/apps/publikator/lib/apollo/index.ts
+++ b/apps/publikator/lib/apollo/index.ts
@@ -1,10 +1,13 @@
+import getConfig from 'next/config'
 import { createApolloClientUtilities } from '@republik/nextjs-apollo-client'
 
 import { API_URL, API_WS_URL } from '../settings'
 
+const { publicRuntimeConfig } = getConfig()
+
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
   name: '@orbiting/publikator-app',
-  version: '1.0',
+  version: publicRuntimeConfig.buildId,
   apiUrl: API_URL,
   wsUrl: API_WS_URL,
 })

--- a/apps/publikator/lib/apollo/index.ts
+++ b/apps/publikator/lib/apollo/index.ts
@@ -3,6 +3,8 @@ import { createApolloClientUtilities } from '@republik/nextjs-apollo-client'
 import { API_URL, API_WS_URL } from '../settings'
 
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
+  name: '@orbiting/publikator-app',
+  version: '1.0',
   apiUrl: API_URL,
   wsUrl: API_WS_URL,
 })

--- a/apps/publikator/next.config.js
+++ b/apps/publikator/next.config.js
@@ -17,7 +17,7 @@ module.exports = withBundleAnalyzer(
     eslint: {
       ignoreDuringBuilds: true,
     },
-    generateBuildId: () => buildId,
+    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
     publicRuntimeConfig: {
       buildId,
     },

--- a/apps/publikator/next.config.js
+++ b/apps/publikator/next.config.js
@@ -7,7 +7,9 @@ const withTM = require('next-transpile-modules')([
   '@republik/nextjs-apollo-client',
 ])
 
-const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
+const buildId =
+  process.env.SOURCE_VERSION?.substring(0, 10) ||
+  new Date(Date.now()).toISOString()
 
 /**
  * @type {import('next').NextConfig}
@@ -17,7 +19,7 @@ module.exports = withBundleAnalyzer(
     eslint: {
       ignoreDuringBuilds: true,
     },
-    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
+    generateBuildId: () => buildId,
     publicRuntimeConfig: {
       buildId,
     },

--- a/apps/publikator/next.config.js
+++ b/apps/publikator/next.config.js
@@ -7,6 +7,8 @@ const withTM = require('next-transpile-modules')([
   '@republik/nextjs-apollo-client',
 ])
 
+const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -14,6 +16,10 @@ module.exports = withBundleAnalyzer(
   withTM({
     eslint: {
       ignoreDuringBuilds: true,
+    },
+    generateBuildId: () => buildId,
+    publicRuntimeConfig: {
+      buildId,
     },
     webpack: (config) => {
       const alias = Object.assign({}, config.resolve.alias)

--- a/apps/www/components/Footer/index.js
+++ b/apps/www/components/Footer/index.js
@@ -11,6 +11,7 @@ import {
   useColorContext,
 } from '@project-r/styleguide'
 import { OpenSourceIcon } from '@project-r/styleguide'
+import getConfig from 'next/config'
 
 import withT from '../../lib/withT'
 import withMe from '../../lib/apollo/withMe'
@@ -20,6 +21,8 @@ import { ZINDEX_FOOTER } from '../constants'
 
 import SocialLinks from './SocialLinks'
 import Address from './Address'
+
+const { publicRuntimeConfig } = getConfig()
 
 const styles = {
   bg: css({

--- a/apps/www/components/Footer/index.js
+++ b/apps/www/components/Footer/index.js
@@ -11,7 +11,6 @@ import {
   useColorContext,
 } from '@project-r/styleguide'
 import { OpenSourceIcon } from '@project-r/styleguide'
-import getConfig from 'next/config'
 
 import withT from '../../lib/withT'
 import withMe from '../../lib/apollo/withMe'
@@ -21,8 +20,6 @@ import { ZINDEX_FOOTER } from '../constants'
 
 import SocialLinks from './SocialLinks'
 import Address from './Address'
-
-const { publicRuntimeConfig } = getConfig()
 
 const styles = {
   bg: css({

--- a/apps/www/lib/apollo/index.ts
+++ b/apps/www/lib/apollo/index.ts
@@ -7,6 +7,8 @@ import {
 import { createAppWorkerLink } from './appWorkerLink'
 
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
+  name: '@orbiting/www-app',
+  version: '1.0',
   apiUrl: API_URL,
   wsUrl: API_WS_URL,
   mobileConfigOptions: {

--- a/apps/www/lib/apollo/index.ts
+++ b/apps/www/lib/apollo/index.ts
@@ -1,3 +1,4 @@
+import getConfig from 'next/config'
 import { createApolloClientUtilities } from '@republik/nextjs-apollo-client'
 import { API_URL, API_WS_URL } from '../constants'
 import {
@@ -6,9 +7,11 @@ import {
 } from '../withInNativeApp'
 import { createAppWorkerLink } from './appWorkerLink'
 
+const { publicRuntimeConfig } = getConfig()
+
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
   name: '@orbiting/www-app',
-  version: '1.0',
+  version: publicRuntimeConfig.buildId,
   apiUrl: API_URL,
   wsUrl: API_WS_URL,
   mobileConfigOptions: {

--- a/apps/www/lib/errors.js
+++ b/apps/www/lib/errors.js
@@ -1,5 +1,8 @@
 import fetch from 'isomorphic-unfetch'
 import { Component } from 'react'
+import getConfig from 'next/config'
+
+const { publicRuntimeConfig } = getConfig()
 
 let lastError
 
@@ -14,7 +17,11 @@ export const reportError = (context, error) => {
   }
   fetch('/api/reportError', {
     method: 'POST',
-    body: `${context}\n${window.location.href}\n${error}`,
+    body: `${context}\n${window.location.href}\n${
+      publicRuntimeConfig.buildId
+        ? `(buildId: ${publicRuntimeConfig.buildId})\n`
+        : ''
+    }${error}`,
   })
   lastError = error
 }

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -7,7 +7,7 @@ const withTM = require('next-transpile-modules')([
 ])
 
 const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
-const buildId = process.env.SOURCE_VERSION || ''
+const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
 
 /**
  * @type {import('next').NextConfig}

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -14,7 +14,7 @@ const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
  */
 module.exports = withTM(
   withBundleAnalyzer({
-    generateBuildId: () => buildId,
+    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
     publicRuntimeConfig: {
       buildId,
     },

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -7,14 +7,21 @@ const withTM = require('next-transpile-modules')([
 ])
 
 const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
+const buildId = process.env.SOURCE_VERSION || ''
 
+/**
+ * @type {import('next').NextConfig}
+ */
 module.exports = withTM(
   withBundleAnalyzer({
+    generateBuildId: () => buildId,
+    publicRuntimeConfig: {
+      buildId,
+    },
     webpack: (config) => {
       config.externals = config.externals || {}
       config.externals['lru-cache'] = 'lru-cache'
       config.externals['react-dom/server'] = 'react-dom/server'
-
       return config
     },
     poweredByHeader: false,

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -7,14 +7,16 @@ const withTM = require('next-transpile-modules')([
 ])
 
 const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
-const buildId = process.env.SOURCE_VERSION?.substring(0, 10)
+const buildId =
+  process.env.SOURCE_VERSION?.substring(0, 10) ||
+  new Date(Date.now()).toISOString()
 
 /**
  * @type {import('next').NextConfig}
  */
 module.exports = withTM(
   withBundleAnalyzer({
-    generateBuildId: () => buildId || new Date(Date.now()).toISOString(),
+    generateBuildId: () => buildId,
     publicRuntimeConfig: {
       buildId,
     },

--- a/packages/nextjs-apollo-client/src/apollo/apolloClient.ts
+++ b/packages/nextjs-apollo-client/src/apollo/apolloClient.ts
@@ -16,6 +16,8 @@ import possibleTypes from '../generated/possibleTypes.json'
 export const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__'
 
 export type ApolloClientOptions = {
+  name?: string
+  version?: string
   apiUrl: string
   wsUrl?: string
   headers?: { [key: string]: string | number | boolean } | IncomingHttpHeaders
@@ -51,6 +53,8 @@ function createApolloClient(
       possibleTypes,
     }),
     link: createLink(options),
+    name: options.name,
+    version: options.version,
   })
 }
 

--- a/packages/nextjs-apollo-client/src/index.ts
+++ b/packages/nextjs-apollo-client/src/index.ts
@@ -12,7 +12,7 @@ import makeWithApollo from './helpers/withApollo'
  */
 type CreateApolloClientUtilitiesOptions = Pick<
   ApolloClientOptions,
-  'apiUrl' | 'wsUrl' | 'mobileConfigOptions'
+  'apiUrl' | 'wsUrl' | 'mobileConfigOptions' | 'name' | 'version'
 >
 
 /**


### PR DESCRIPTION
- feat(nextjs-apollo-config): allow passing a name and version to the apollo-client
- feat(www): pass buildId to public-runtime config and use it as client-version
- feat(clients): pass buildId to publicRuntimeConfig to pass to apollo-client
