### PR TITLE
fix: signal caching CORS preflight up to 24 hours

### DIFF
--- a/apps/assets/server.js
+++ b/apps/assets/server.js
@@ -38,7 +38,6 @@ const start = (workerId) => {
       // maxAge: <seconds>; up to 24 hours
       // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
       maxAge: 60 * 60 * 24,
-      preflightContinue: true,
       optionsSuccessStatus: 200,
     }
     server.use('*', cors(corsOptions))

--- a/apps/assets/server.js
+++ b/apps/assets/server.js
@@ -35,7 +35,11 @@ const start = (workerId) => {
     const corsOptions = {
       origin: CORS_ALLOWLIST_URL.split(','),
       credentials: true,
-      optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+      // maxAge: <seconds>; up to 24 hours
+      // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+      maxAge: 60 * 60 * 24,
+      preflightContinue: true,
+      optionsSuccessStatus: 200,
     }
     server.use('*', cors(corsOptions))
   }

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -116,7 +116,6 @@ const start = async (
       // maxAge: <seconds>; up to 24 hours
       // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
       maxAge: 60 * 60 * 24,
-      preflightContinue: true,
       optionsSuccessStatus: 200,
     }
     server.use('*', cors(corsOptions))

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -113,7 +113,11 @@ const start = async (
     const corsOptions = {
       origin: CORS_ALLOWLIST_URL.split(','),
       credentials: true,
-      optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+      // maxAge: <seconds>; up to 24 hours
+      // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+      maxAge: 60 * 60 * 24,
+      preflightContinue: true,
+      optionsSuccessStatus: 200,
     }
     server.use('*', cors(corsOptions))
   }


### PR DESCRIPTION
This Pull Request signals a client to cache a preflight request up to 24 hours.

Per default, preflight requests are cached only up to 5 seconds. Setting `maxAge` reduces response latency via www-app to API.

Example www-app posting to GraphQL API; it issues an "preflight req" _before_ posting to GraphQL API. Amount of "preflight req" would drop significantly once we signal browser to cache it.

<img width="572" alt="Bildschirmfoto 2022-09-20 um 09 29 54" src="https://user-images.githubusercontent.com/331800/191195133-cbc1005b-c770-4a67-8392-a7a3dd9255c7.png">

It is safe to assume, CORS headers are unlikely to change in a breaking manner on assets server and GraphQL API server. 

Resources:
- https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
- https://netbasal.com/reduce-response-latency-by-caching-preflight-requests-2c450b6f9cb6