### PR TITLE
More Journal Fixes

### DIFF
--- a/apps/publikator/components/Calendar/Day.js
+++ b/apps/publikator/components/Calendar/Day.js
@@ -12,7 +12,7 @@ import Repo, { Placeholder } from './Repo'
 import { ascending } from 'd3-array'
 import { parseJSONObject } from '../../lib/safeJSON'
 import { WEEK_TEMPLATE_REPOS } from '../../lib/settings'
-import withT from '../../lib/withT'
+
 const templateRepos = parseJSONObject(WEEK_TEMPLATE_REPOS)
 
 const styles = {

--- a/apps/publikator/components/Calendar/Day.js
+++ b/apps/publikator/components/Calendar/Day.js
@@ -3,6 +3,7 @@ import { fontStyles } from '@project-r/styleguide'
 import {
   columnDateFormat,
   getPlaceholders,
+  getTitleForTemplate,
   reformatPlaceholder,
   reformatUrlDate,
 } from '../../lib/utils/calendar'
@@ -30,7 +31,7 @@ const styles = {
   }),
 }
 
-const Repos = withT(({ t, repos, isNewsletter, ...props }) => {
+const Repos = ({ repos, isNewsletter, ...props }) => {
   const sortedRepos = repos.sort((repo1, repo2) =>
     ascending(
       new Date(repo1.meta.publishDate),
@@ -47,11 +48,7 @@ const Repos = withT(({ t, repos, isNewsletter, ...props }) => {
               latestCommit: {
                 document: {
                   meta: {
-                    title: t(
-                      `repo/add/template/${repo.template}`,
-                      null,
-                      repo.template,
-                    ),
+                    title: getTitleForTemplate(new Date(repo.meta.publishDate)),
                     template: repo.template,
                   },
                 },
@@ -81,7 +78,7 @@ const Repos = withT(({ t, repos, isNewsletter, ...props }) => {
       )}
     </div>
   )
-})
+}
 
 export const ReposByTemplate = ({
   template,

--- a/apps/publikator/components/Calendar/Day.js
+++ b/apps/publikator/components/Calendar/Day.js
@@ -2,8 +2,8 @@ import { css } from 'glamor'
 import { fontStyles } from '@project-r/styleguide'
 import {
   columnDateFormat,
+  suggestTemplateTitle,
   getPlaceholders,
-  getTitleForTemplate,
   reformatPlaceholder,
   reformatUrlDate,
 } from '../../lib/utils/calendar'
@@ -48,8 +48,8 @@ const Repos = ({ repos, isNewsletter, ...props }) => {
               latestCommit: {
                 document: {
                   meta: {
-                    title: getTitleForTemplate(new Date(repo.meta.publishDate)),
                     template: repo.template,
+                    ...suggestTemplateTitle(repo.meta?.publishDate),
                   },
                 },
               },

--- a/apps/publikator/components/ContentEditor/index.js
+++ b/apps/publikator/components/ContentEditor/index.js
@@ -42,7 +42,7 @@ export const getInitialValue = (options) => {
       children: [
         {
           type: 'headline',
-          children: [{ text: 'Bis nachher!' }],
+          children: [{ text: 'Danke fürs Interesse.' }],
         },
         {
           type: 'flyerSignature',

--- a/apps/publikator/components/Edit/EditView.js
+++ b/apps/publikator/components/Edit/EditView.js
@@ -106,13 +106,15 @@ const EditView = ({
           style={{ zIndex: 23, position: 'sticky', top: HEADER_HEIGHT }}
         />
       )}
-      <div {...styles.phase}>
-        <PhaseSummary
-          commitId={(repo?.commit || repo?.latestCommit)?.id}
-          repoId={repo?.id}
-          hasUncommittedChanges={hasUncommittedChanges}
-        />
-      </div>
+      {!readOnly && (
+        <div {...styles.phase}>
+          <PhaseSummary
+            commitId={(repo?.commit || repo?.latestCommit)?.id}
+            repoId={repo?.id}
+            hasUncommittedChanges={hasUncommittedChanges}
+          />
+        </div>
+      )}
       {!!content?.children && (
         <ContentEditor
           key={editorKey}

--- a/apps/publikator/components/Edit/index.js
+++ b/apps/publikator/components/Edit/index.js
@@ -454,6 +454,7 @@ const EditLoader = ({
                 content={content}
                 setContent={setContent}
                 publishDate={repo?.meta?.publishDate || publishDate}
+                readOnly={readOnly}
               />
             )
           }}

--- a/apps/publikator/components/Edit/index.js
+++ b/apps/publikator/components/Edit/index.js
@@ -200,15 +200,14 @@ const EditLoader = ({
     }
     setDidUnlock(true)
     setAcknowledgedUsers(activeUsers)
-    setReadOnly(false)
     notifyBackend('create')
     unlock()
   }
 
   const beginChangesHandler = () => {
     setBeginChanges(new Date())
-    setReadOnly(false)
     notifyBackend('create')
+    unlock()
   }
 
   const concludeChanges = (notify = true) => {

--- a/apps/publikator/lib/utils/calendar.js
+++ b/apps/publikator/lib/utils/calendar.js
@@ -9,6 +9,7 @@ export const urlDateHourFormat = '%Y-%m-%dT%H:%M'
 export const displayDateTimeFormat = '%d.%m %H:%M'
 export const datePickerFormat = '%d.%m.%y'
 export const columnDateFormat = '%A, %d.%m'
+const titleDateFormat = '%a %d.%m'
 
 export const getUrlDate = swissTime.format(urlDateFormat)
 export const parseUrlDate = swissTime.parse(urlDateFormat)
@@ -73,3 +74,5 @@ export const reformatPlaceholder = (placeholder, publishDate) => ({
   },
   isPlaceholder: true,
 })
+
+export const getTitleForTemplate = (date) => formatDate(date, titleDateFormat)

--- a/apps/publikator/lib/utils/calendar.js
+++ b/apps/publikator/lib/utils/calendar.js
@@ -9,12 +9,12 @@ export const urlDateHourFormat = '%Y-%m-%dT%H:%M'
 export const displayDateTimeFormat = '%d.%m %H:%M'
 export const datePickerFormat = '%d.%m.%y'
 export const columnDateFormat = '%A, %d.%m'
-const titleDateFormat = '%a %d.%m'
+export const templateDateFormat = columnDateFormat
 
 export const getUrlDate = swissTime.format(urlDateFormat)
 export const parseUrlDate = swissTime.parse(urlDateFormat)
 
-const formatDate = (date, format) => swissTime.format(format)(date)
+export const formatDate = (date, format) => swissTime.format(format)(date)
 
 export const displayDateTime = (string) =>
   string && formatDate(new Date(string), displayDateTimeFormat)
@@ -75,4 +75,12 @@ export const reformatPlaceholder = (placeholder, publishDate) => ({
   isPlaceholder: true,
 })
 
-export const getTitleForTemplate = (date) => formatDate(date, titleDateFormat)
+export const suggestTemplateTitle = (publishDate) => {
+  if (publishDate) {
+    return {
+      title: formatDate(new Date(publishDate), templateDateFormat),
+    }
+  }
+
+  return {}
+}

--- a/apps/publikator/pages/flyer/[owner]/[repo]/preview.js
+++ b/apps/publikator/pages/flyer/[owner]/[repo]/preview.js
@@ -52,6 +52,7 @@ const PreviewPage = ({ router: { query }, data, t }) => {
               <SlateRender
                 value={cleanupTree(content.children, true)}
                 schema={flyerSchema}
+                skip={['flyerOpeningP']}
               />
             </VariableContext.Provider>
           </ColorContextProvider>

--- a/packages/styleguide/src/components/Editor/schema/flyer.tsx
+++ b/packages/styleguide/src/components/Editor/schema/flyer.tsx
@@ -8,7 +8,7 @@ import {
   ArticleTitle,
   ArticleFormat,
 } from '../../ArticlePreview'
-import { FlyerTile } from '../../Flyer'
+import { FlyerTile, FlyerTileOpening } from '../../Flyer'
 import { FlyerAuthor } from '../../Flyer/Author'
 import { FlyerDate } from '../../Flyer/Date'
 import { PullQuote, PullQuoteText } from '../../Flyer/PullQuote'
@@ -21,7 +21,7 @@ const schema: SchemaConfig = {
   container: Flyer.Layout,
   flyerTile: FlyerTile,
   flyerTileMeta: FlyerTile,
-  flyerTileOpening: FlyerTile,
+  flyerTileOpening: FlyerTileOpening,
   flyerTileClosing: FlyerTile,
   flyerAuthor: FlyerAuthor,
   flyerMetaP: Flyer.MetaP,

--- a/packages/styleguide/src/components/Editor/schema/flyerEditor.tsx
+++ b/packages/styleguide/src/components/Editor/schema/flyerEditor.tsx
@@ -2,7 +2,7 @@ import { SchemaConfig } from '../custom-types'
 import { EditorQuizContainer, EditorQuizItem } from '../../Flyer/Quiz'
 import { Flyer } from '../../Typography'
 import { Invisible, Error } from '../Core/SpecialChars'
-import { EditorFlyerTile } from '../../Flyer'
+import { EditorFlyerTile, FlyerTile } from '../../Flyer'
 
 const schema: SchemaConfig = {
   link: Flyer.NoRefA,
@@ -10,6 +10,7 @@ const schema: SchemaConfig = {
   quiz: EditorQuizContainer,
   invisible: Invisible,
   error: Error,
+  flyerTileOpening: FlyerTile,
   flyerTile: EditorFlyerTile,
 }
 

--- a/packages/styleguide/src/components/Flyer/index.tsx
+++ b/packages/styleguide/src/components/Flyer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 import { useColorContext } from '../Colors/ColorContext'
 import { mUp } from '../../theme/mediaQueries'
 import { Message } from '../Editor/Render/Message'
@@ -22,15 +22,14 @@ const styles = {
     [mUp]: {
       padding: '90px 0',
     },
-    '& > *': {},
-    '& > :not(.ui-element)': {
-      // paddingTop: 90,
-    },
-    '& > :not(.ui-element) ~ :not(.ui-element)': {
-      // paddingTop: 'inherit',
-    },
     '& > :last-child': {
       marginBottom: '0 !important',
+    },
+  }),
+  contentOpening: css({
+    marginBottom: -72,
+    [mUp]: {
+      marginBottom: -144,
     },
   }),
 }
@@ -48,6 +47,19 @@ export const FlyerTile: React.FC<{
       {...colorScheme.set('borderBottomColor', 'flyerText')}
     >
       <div {...styles.content}>{children}</div>
+    </div>
+  )
+}
+
+export const FlyerTileOpening: React.FC<{
+  attributes: any
+  [x: string]: unknown
+}> = ({ children, attributes, ...props }) => {
+  return (
+    <div {...props} {...attributes}>
+      <div {...styles.content} {...styles.contentOpening}>
+        {children}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
- Journal title when created through calendar is now based on publish date. (Before all journals were named `Journal` and that's not very enlightening.)
<img width="144" alt="Screen Shot 2022-09-20 at 17 32 29" src="https://user-images.githubusercontent.com/3907984/191301079-b426e459-7084-430e-9123-b4ebd581f88e.png">

- progagate readonly props to the editor itself, hiding the toolbar when in readonly mode.
<img width="1680" alt="Screen Shot 2022-09-21 at 10 39 26" src="https://user-images.githubusercontent.com/3907984/191510760-cf35a706-46fb-4399-a327-503c4acf047a.png">

- adjust end salutation in template

- remove trennstrich when not rendering bgrüssung (now also shown as such in preview)
<img width="802" alt="Screen Shot 2022-09-21 at 15 39 34" src="https://user-images.githubusercontent.com/3907984/191523999-9cee2d77-8ca4-4596-a898-18d7b93b210e.png">
ring begrüssung (request from Oli)
