### PR TITLE
Reintroduce flyer path

### DIFF
--- a/apps/www/components/Frame/Popover/FlyerNavLink.js
+++ b/apps/www/components/Frame/Popover/FlyerNavLink.js
@@ -1,0 +1,14 @@
+import NavLink from './NavLink'
+import useFlyerMeta from './useFlyerMeta'
+
+const FlyerNavLink = ({ children, ...props }) => {
+  const flyerMeta = useFlyerMeta()
+  const href = flyerMeta?.path || '/format/journal'
+  return (
+    <NavLink {...props} formatColor='accentColorFlyer' href={href}>
+      {children}
+    </NavLink>
+  )
+}
+
+export default FlyerNavLink

--- a/apps/www/components/Frame/Popover/FlyerNavLink.js
+++ b/apps/www/components/Frame/Popover/FlyerNavLink.js
@@ -5,7 +5,7 @@ const FlyerNavLink = ({ children, ...props }) => {
   const flyerMeta = useFlyerMeta()
   const href = flyerMeta?.path || '/format/journal'
   return (
-    <NavLink {...props} formatColor='accentColorFlyer' href={href}>
+    <NavLink {...props} href={href}>
       {children}
     </NavLink>
   )

--- a/apps/www/components/Frame/Popover/Nav.js
+++ b/apps/www/components/Frame/Popover/Nav.js
@@ -20,7 +20,7 @@ import SearchForm from '../../Search/Form'
 import NavLink from './NavLink'
 import Sections from './Sections'
 import Link from 'next/link'
-// import { useFlyerMeta } from '../../../lib/apollo/miniNavi'
+import { useFlyerMeta } from '../../../lib/apollo/miniNavi'
 
 const Nav = ({
   me,
@@ -41,7 +41,7 @@ const Nav = ({
   if (expanded) {
     hasExpandedRef.current = true
   }
-  const flyerMeta = undefined // useFlyerMeta()
+  const flyerMeta = useFlyerMeta()
   // post journal launch cleanup task:
   //   - remove conditionals for journal entry
   return (

--- a/apps/www/components/Frame/Popover/Nav.js
+++ b/apps/www/components/Frame/Popover/Nav.js
@@ -18,9 +18,9 @@ import { withMembership } from '../../Auth/checkRoles'
 import Footer from '../../Footer'
 import SearchForm from '../../Search/Form'
 import NavLink from './NavLink'
+import FlyerNavLink from './FlyerNavLink'
 import Sections from './Sections'
 import Link from 'next/link'
-import { useFlyerMeta } from '../../../lib/apollo/miniNavi'
 
 const Nav = ({
   me,
@@ -41,9 +41,7 @@ const Nav = ({
   if (expanded) {
     hasExpandedRef.current = true
   }
-  const flyerMeta = useFlyerMeta()
-  // post journal launch cleanup task:
-  //   - remove conditionals for journal entry
+
   return (
     <>
       <Center {...styles.container} id='nav'>
@@ -101,16 +99,13 @@ const Nav = ({
                     >
                       {t('navbar/feed')}
                     </NavLink>
-                    {flyerMeta?.path && (
-                      <NavLink
-                        large
-                        href={flyerMeta?.path || '/format/journal'}
-                        active={active}
-                        closeHandler={closeHandler}
-                      >
-                        {t('navbar/flyer')}
-                      </NavLink>
-                    )}
+                    <FlyerNavLink
+                      large
+                      active={active}
+                      closeHandler={closeHandler}
+                    >
+                      {t('navbar/flyer')}
+                    </FlyerNavLink>
                   </>
                 )}
                 <NavLink

--- a/apps/www/components/Frame/SecondaryNav.js
+++ b/apps/www/components/Frame/SecondaryNav.js
@@ -62,7 +62,12 @@ export const SecondaryNav = ({
           >
             {t('navbar/feed')}
           </NavLink>
-          <FlyerNavLink active={active} minifeed title={t('navbar/flyer')}>
+          <FlyerNavLink
+            active={active}
+            formatColor='accentColorFlyer'
+            minifeed
+            title={t('navbar/flyer')}
+          >
             {t('navbar/flyer')}
           </FlyerNavLink>
           <NavLink

--- a/apps/www/components/Frame/SecondaryNav.js
+++ b/apps/www/components/Frame/SecondaryNav.js
@@ -16,7 +16,7 @@ import {
   HEADER_HORIZONTAL_PADDING,
 } from '../constants'
 import { useRouter } from 'next/router'
-// import { useFlyerMeta } from '../../lib/apollo/miniNavi'
+import { useFlyerMeta } from '../../lib/apollo/miniNavi'
 
 export const SecondaryNav = ({
   secondaryNav,
@@ -28,7 +28,7 @@ export const SecondaryNav = ({
   const router = useRouter()
   const active = router.asPath
 
-  const flyerMeta = undefined // = useFlyerMeta()
+  const flyerMeta = useFlyerMeta()
 
   return (
     <>

--- a/apps/www/components/Frame/SecondaryNav.js
+++ b/apps/www/components/Frame/SecondaryNav.js
@@ -9,6 +9,7 @@ import {
 
 import withT from '../../lib/withT'
 import NavLink from './Popover/NavLink'
+import FlyerNavLink from './Popover/FlyerNavLink'
 
 import {
   SUBHEADER_HEIGHT,
@@ -16,7 +17,6 @@ import {
   HEADER_HORIZONTAL_PADDING,
 } from '../constants'
 import { useRouter } from 'next/router'
-import { useFlyerMeta } from '../../lib/apollo/miniNavi'
 
 export const SecondaryNav = ({
   secondaryNav,
@@ -27,8 +27,6 @@ export const SecondaryNav = ({
   const [colorScheme] = useColorContext()
   const router = useRouter()
   const active = router.asPath
-
-  const flyerMeta = useFlyerMeta()
 
   return (
     <>
@@ -64,15 +62,9 @@ export const SecondaryNav = ({
           >
             {t('navbar/feed')}
           </NavLink>
-          <NavLink
-            href={flyerMeta?.path || '/format/journal'}
-            active={active}
-            formatColor='accentColorFlyer'
-            minifeed
-            title={t('navbar/flyer')}
-          >
+          <FlyerNavLink active={active} minifeed title={t('navbar/flyer')}>
             {t('navbar/flyer')}
-          </NavLink>
+          </FlyerNavLink>
           <NavLink
             href='/dialog'
             active={active}

--- a/packages/styleguide/src/components/SeriesNav/SeriesNav.js
+++ b/packages/styleguide/src/components/SeriesNav/SeriesNav.js
@@ -122,7 +122,7 @@ function SeriesNav({
                 {titlePath &&
                   t.elements('styleguide/SeriesNav/seriesoverview/link', {
                     link: (
-                      <Link href={titlePath} passHref>
+                      <Link key='link' href={titlePath} passHref>
                         <Editorial.A>
                           {t('styleguide/SeriesNav/seriesoverview')}
                         </Editorial.A>
@@ -180,7 +180,7 @@ SeriesNav.propTypes = {
   repoId: PropTypes.string,
   series: PropTypes.object.isRequired,
   ActionBar: PropTypes.func,
-  Link: PropTypes.func,
+  Link: PropTypes.elementType,
   PayNote: PropTypes.func,
   inline: PropTypes.bool,
   height: PropTypes.number,


### PR DESCRIPTION
Our `NavLink`s to the flyer are rendered behind a `isMember` or  `hasOverviewNav` defined as `hasAccess && wantOverviewNav` check. But I ended up using a hook to query the current flyer path and used it atop of the `SecondaryNav` component which is rendered for everyone.

To remedy this I've introduced two measure:
1. move the hook to a new flyer nav link component that is only rendered when really needed
2. skip the query in the hook when `!hasAccess` and throw an error in dev that the hook should only be used in a sub tree that has access


Edit: also contains unrelated `SeriesNav` changes to fix react warnings I've noticed in my console while testing.