### PR TITLE
Journal nav

### DIFF
--- a/apps/publikator/components/ContentEditor/index.js
+++ b/apps/publikator/components/ContentEditor/index.js
@@ -79,8 +79,9 @@ const TOOLBAR = {
 }
 
 const Index = ({ value, publishDate, onChange, readOnly, t }) => {
+  const nav = <FlyerDate date={publishDate} />
   return (
-    <RenderContextProvider t={t} nav={<FlyerDate date={publishDate} />}>
+    <RenderContextProvider t={t} nav={nav}>
       {/* The Editor does its own RenderContextProvider
        * but we also need to do one from the main styleguide entry point
        * cause render components will use that context
@@ -97,6 +98,7 @@ const Index = ({ value, publishDate, onChange, readOnly, t }) => {
           toolbar: TOOLBAR,
           readOnly,
           t,
+          nav,
         }}
       />
     </RenderContextProvider>

--- a/apps/publikator/components/ContentEditor/index.js
+++ b/apps/publikator/components/ContentEditor/index.js
@@ -3,6 +3,7 @@ import {
   flyerSchema,
   RenderContextProvider,
   timeFormat,
+  FlyerDate,
 } from '@project-r/styleguide'
 import {
   Editor,
@@ -77,10 +78,10 @@ const TOOLBAR = {
   showChartCount: true,
 }
 
-const Index = ({ value, onChange, readOnly, t }) => {
+const Index = ({ value, publishDate, onChange, readOnly, t }) => {
   return (
-    <RenderContextProvider t={t}>
-      {/* The Editor does it's own RenderContextProvider
+    <RenderContextProvider t={t} nav={<FlyerDate date={publishDate} />}>
+      {/* The Editor does its own RenderContextProvider
        * but we also need to do one from the main styleguide entry point
        * cause render components will use that context
        */}

--- a/apps/publikator/components/Edit/EditView.js
+++ b/apps/publikator/components/Edit/EditView.js
@@ -116,6 +116,7 @@ const EditView = ({
       )}
       {!!content?.children && (
         <ContentEditor
+          publishDate={publishDate}
           value={content.children}
           onChange={(newValue) =>
             setContent((currentContent) => ({

--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -370,9 +370,21 @@ const ActionBar = ({
           setShareOverlayVisible(!shareOverlayVisible)
         }
       },
-      label: !forceShortLabel ? t('article/actionbar/share') : '',
+      label: !forceShortLabel
+        ? t(
+            `article/actionbar/${mode}/share`,
+            undefined,
+            t('article/actionbar/share'),
+          )
+        : '',
       labelShort:
-        !forceShortLabel && isArticleBottom ? t('article/actionbar/share') : '',
+        !forceShortLabel && isArticleBottom
+          ? t(
+              `article/actionbar/${mode}/share`,
+              undefined,
+              t('article/actionbar/share'),
+            )
+          : '',
       modes: ['articleTop', 'articleOverlay', 'articleBottom', 'flyer'],
       show: true,
     },

--- a/apps/www/components/Article/Flyer.js
+++ b/apps/www/components/Article/Flyer.js
@@ -6,6 +6,7 @@ import {
   IconButton,
   FlyerDate,
   mediaQueries,
+  FlyerTile,
 } from '@project-r/styleguide'
 import Link from 'next/link'
 import { useMe } from '../../lib/context/MeContext'
@@ -14,10 +15,10 @@ const FORMAT_REPO_ID = 'republik/format-journal'
 
 const styles = {
   footer: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    flexWrap: 'wrap',
+    marginTop: -35,
+    [mediaQueries.mUp]: {
+      marginTop: -60,
+    },
   }),
   navi: css({
     display: 'flex',
@@ -129,6 +130,12 @@ export const FlyerNav = ({ repoId, publishDate }) => {
   )
 }
 
-const FlyerFooter = ({ actionBar }) => <div {...styles.footer}>{actionBar}</div>
+const FlyerFooter = ({ children }) => {
+  return (
+    <FlyerTile {...styles.footer} innerStyle={{ paddingTop: 0 }}>
+      {children}
+    </FlyerTile>
+  )
+}
 
 export default FlyerFooter

--- a/apps/www/components/Article/Flyer.js
+++ b/apps/www/components/Article/Flyer.js
@@ -105,7 +105,6 @@ export const FlyerNav = ({ repoId, publishDate }) => {
       publishedAt: publishDate,
       repoId,
     },
-    // @Tobias: could this explode at me?
     skip: !hasAccess,
   })
   const prev = data?.prev.nodes[0]?.entity?.meta

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -641,9 +641,7 @@ const ArticlePage = ({
                       skip={['flyerOpeningP']}
                     />
                   </RenderContextProvider>
-                  <FlyerTile>
-                    <FlyerFooter actionBar={actionBarFlyer} />
-                  </FlyerTile>
+                  <FlyerFooter>{actionBarFlyer}</FlyerFooter>
                 </Flyer.Layout>
               ) : (
                 <ArticleGallery

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -83,7 +83,7 @@ import DiscussionContextProvider from '../Discussion/context/DiscussionContextPr
 import Discussion from '../Discussion/Discussion'
 import ArticleRecommendationsFeed from './ArticleRecommendationsFeed'
 import { getMetaData, runMetaFromQuery } from './metadata'
-import FlyerFooter from './FlyerFooter'
+import FlyerFooter, { FlyerNav } from './Flyer'
 
 const LoadingComponent = () => <SmallLoader loading />
 
@@ -624,7 +624,16 @@ const ArticlePage = ({
               )}
               {isFlyer ? (
                 <Flyer.Layout schema={schema}>
-                  <RenderContextProvider t={t} Link={HrefLink}>
+                  <RenderContextProvider
+                    t={t}
+                    Link={HrefLink}
+                    nav={
+                      <FlyerNav
+                        repoId={repoId}
+                        publishDate={meta.publishDate}
+                      />
+                    }
+                  >
                     <SlateRender
                       value={article.content.children}
                       schema={schema}
@@ -633,11 +642,7 @@ const ArticlePage = ({
                     />
                   </RenderContextProvider>
                   <FlyerTile>
-                    <FlyerFooter
-                      actionBar={actionBarFlyer}
-                      repoId={repoId}
-                      publishDate={meta.publishDate}
-                    />
+                    <FlyerFooter actionBar={actionBarFlyer} />
                   </FlyerTile>
                 </Flyer.Layout>
               ) : (

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3109,6 +3109,10 @@
       "value": "Teilen"
     },
     {
+      "key": "article/actionbar/flyer/share",
+      "value": "Journal teilen"
+    },
+    {
       "key": "article/actionbar/facebook/title",
       "value": "Auf Facebook teilen"
     },

--- a/packages/styleguide/src/components/Editor/Core/helpers/tree.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/tree.ts
@@ -38,7 +38,11 @@ const hasFilledProps = (element: CustomElement): boolean => {
 
 const keepVoid = (element: CustomElement): boolean => {
   const config = elConfig[element.type]
-  return !config?.props?.length || hasFilledProps(element)
+  return (
+    config?.attrs?.neverDelete ||
+    !config?.props?.length ||
+    hasFilledProps(element)
+  )
 }
 
 const keepNonVoid = (element: CustomElement): boolean =>

--- a/packages/styleguide/src/components/Editor/Core/index.tsx
+++ b/packages/styleguide/src/components/Editor/Core/index.tsx
@@ -94,7 +94,7 @@ const SlateEditor: React.FC<SlateEditorProps> = ({
   )
 
   return (
-    <RenderContextProvider t={config.t} Link={config.Link}>
+    <RenderContextProvider t={config.t} Link={config.Link} nav={config.nav}>
       <FormContextProvider>
         <Slate
           editor={editor}

--- a/packages/styleguide/src/components/Editor/Render/Context.tsx
+++ b/packages/styleguide/src/components/Editor/Render/Context.tsx
@@ -1,9 +1,11 @@
 import React, { createContext, useContext, useMemo } from 'react'
 import { createFormatter, Formatter } from '../../../lib/translate'
+import { FlyerDate } from '../../Flyer/Date'
 
 type RenderProps = {
   Link?: React.FC<any>
   t?: Formatter
+  nav?: JSX.Element
 }
 
 export const PlaceholderLink = ({ children }) => React.Children.only(children)
@@ -12,6 +14,7 @@ const emptyFormatter = createFormatter([])
 const RenderContext = createContext<RenderProps>({
   Link: PlaceholderLink,
   t: emptyFormatter,
+  nav: <FlyerDate />,
 })
 
 export const useRenderContext = () => useContext(RenderContext)
@@ -20,8 +23,9 @@ export const RenderContextProvider: React.FC<RenderProps> = ({
   children,
   Link = PlaceholderLink,
   t = emptyFormatter,
+  nav = <FlyerDate />,
 }) => {
-  const value = useMemo(() => ({ Link, t }), [Link, t])
+  const value = useMemo(() => ({ Link, t, nav }), [Link, t, nav])
   return (
     <RenderContext.Provider value={value}>{children}</RenderContext.Provider>
   )

--- a/packages/styleguide/src/components/Editor/config/elements/flyer/components/date.tsx
+++ b/packages/styleguide/src/components/Editor/config/elements/flyer/components/date.tsx
@@ -3,6 +3,8 @@ import { ElementConfigI } from '../../../../custom-types'
 export const config: ElementConfigI = {
   attrs: {
     isVoid: true,
+    // TODO: once the 'date' prop is deleted, we can remove this flag
+    neverDelete: true,
   },
   // TODO: this prop isn't needed anymore
   //  should be deleted in the BE too

--- a/packages/styleguide/src/components/Editor/config/elements/flyer/components/date.tsx
+++ b/packages/styleguide/src/components/Editor/config/elements/flyer/components/date.tsx
@@ -1,31 +1,10 @@
-import {
-  ElementConfigI,
-  ElementFormProps,
-  FlyerDateElement,
-} from '../../../../custom-types'
-import React from 'react'
-import Field from '../../../../../Form/Field'
-
-const Form: React.FC<ElementFormProps<FlyerDateElement>> = ({
-  element,
-  onChange,
-}) => {
-  return (
-    <Field
-      label='Datum'
-      type='date'
-      value={element.date || ' '}
-      onChange={(_, date: string) => {
-        onChange({ date })
-      }}
-    />
-  )
-}
+import { ElementConfigI } from '../../../../custom-types'
 
 export const config: ElementConfigI = {
   attrs: {
     isVoid: true,
   },
-  Form,
+  // TODO: this prop isn't needed anymore
+  //  should be deleted in the BE too
   props: ['date'],
 }

--- a/packages/styleguide/src/components/Editor/custom-types.d.ts
+++ b/packages/styleguide/src/components/Editor/custom-types.d.ts
@@ -421,6 +421,7 @@ export type EditorConfig = {
   readOnly?: boolean
   t?: Formatter
   Link?: React.FC
+  nav?: JSX.Element
 }
 
 export type KeyCombo = {

--- a/packages/styleguide/src/components/Editor/custom-types.d.ts
+++ b/packages/styleguide/src/components/Editor/custom-types.d.ts
@@ -342,6 +342,7 @@ interface ElementAttrsI extends EditorAttrsI {
   blockUi?: BlockUiAttrsI
   isTextInline?: boolean
   stopFormIteration?: boolean
+  neverDelete?: boolean
 }
 
 export type EditorAttr = keyof EditorAttrsI

--- a/packages/styleguide/src/components/Editor/schema/flyer.tsx
+++ b/packages/styleguide/src/components/Editor/schema/flyer.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../ArticlePreview'
 import { FlyerTile, FlyerTileOpening } from '../../Flyer'
 import { FlyerAuthor } from '../../Flyer/Author'
-import { FlyerDate } from '../../Flyer/Date'
+import { FlyerNav } from '../../Flyer/Date'
 import { PullQuote, PullQuoteText } from '../../Flyer/PullQuote'
 import { Quiz, QuizAnswer } from '../../Flyer/Quiz'
 import { DefaultContainer } from '../Render/Containers'
@@ -27,7 +27,8 @@ const schema: SchemaConfig = {
   flyerOpeningP: Flyer.OpeningP,
   flyerPunchline: Flyer.Small,
   flyerSignature: Flyer.OpeningP,
-  flyerDate: FlyerDate,
+  // TODO: rename to flyerNav
+  flyerDate: FlyerNav,
   flyerTitle: Flyer.H3,
   flyerTopic: Flyer.H2,
   articlePreview: ArticlePreview,

--- a/packages/styleguide/src/components/Editor/test/tree-helpers.test.js
+++ b/packages/styleguide/src/components/Editor/test/tree-helpers.test.js
@@ -285,5 +285,107 @@ describe('Slate Editor', () => {
         },
       ])
     })
+
+    it('should not delete nodes with never delete flag', async () => {
+      const value = [
+        {
+          type: 'flyerTileOpening',
+          children: [
+            {
+              type: 'flyerDate',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'headline',
+              children: [
+                {
+                  text: 'Bonjour Madame!',
+                },
+              ],
+            },
+            {
+              type: 'flyerMetaP',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'flyerMetaP',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTopic',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTitle',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerAuthor',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerPunchline',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      expect(cleanupTree(value, true)).toEqual([
+        {
+          type: 'flyerTileOpening',
+          children: [
+            {
+              type: 'flyerDate',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'headline',
+              children: [
+                {
+                  text: 'Bonjour Madame!',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
   })
 })

--- a/packages/styleguide/src/components/Flyer/Date.tsx
+++ b/packages/styleguide/src/components/Flyer/Date.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Flyer } from '../Typography'
 import { timeFormat, timeParse } from '../../lib/timeFormat'
-import { mUp } from '../../theme/mediaQueries'
+import { useRenderContext } from '../Editor/Render/Context'
 import { css } from 'glamor'
+import { mUp } from '../../theme/mediaQueries'
 
 export const FLYER_DATE_FORMAT = '%Y-%m-%d'
 const RENDER_FORMAT_CURRENT_YEAR = '%A, %-d. %B'
@@ -15,10 +16,26 @@ const isCurrentYear = (date?: Date): boolean =>
 
 export const FlyerDate: React.FC<{
   date?: string
+}> = ({ date }) => {
+  const parsedDate = date && parseDate(date.split('T')[0])
+  return (
+    <Flyer.Small contentEditable={false} style={{ opacity: date ? 1 : 0.33 }}>
+      {date
+        ? timeFormat(
+            isCurrentYear(parsedDate)
+              ? RENDER_FORMAT_CURRENT_YEAR
+              : RENDER_FORMAT,
+          )(parsedDate)
+        : 'Publikationsdatum'}
+    </Flyer.Small>
+  )
+}
+
+export const FlyerNav: React.FC<{
   attributes: any
   [x: string]: unknown
-}> = ({ children, attributes, date, ...props }) => {
-  const parsedDate = date && parseDate(date)
+}> = ({ attributes, children, ...props }) => {
+  const { nav } = useRenderContext()
   return (
     <div
       {...attributes}
@@ -30,15 +47,7 @@ export const FlyerDate: React.FC<{
         },
       })}
     >
-      <Flyer.Small contentEditable={false} style={{ opacity: date ? 1 : 0.33 }}>
-        {date
-          ? timeFormat(
-              isCurrentYear(parsedDate)
-                ? RENDER_FORMAT_CURRENT_YEAR
-                : RENDER_FORMAT,
-            )(parsedDate)
-          : 'Datum'}
-      </Flyer.Small>
+      <div contentEditable={false}>{nav}</div>
       {children}
     </div>
   )

--- a/packages/styleguide/src/components/Flyer/index.tsx
+++ b/packages/styleguide/src/components/Flyer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { css, merge } from 'glamor'
+import { css } from 'glamor'
 import { useColorContext } from '../Colors/ColorContext'
 import { mUp } from '../../theme/mediaQueries'
 import { Message } from '../Editor/Render/Message'
@@ -36,8 +36,9 @@ const styles = {
 
 export const FlyerTile: React.FC<{
   attributes: any
+  innerStyle?: object
   [x: string]: unknown
-}> = ({ children, attributes, ...props }) => {
+}> = ({ children, attributes, innerStyle = {}, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <div
@@ -45,8 +46,11 @@ export const FlyerTile: React.FC<{
       {...attributes}
       {...styles.container}
       {...colorScheme.set('borderBottomColor', 'flyerText')}
+      {...colorScheme.set('background', 'flyerBg')}
     >
-      <div {...styles.content}>{children}</div>
+      <div {...styles.content} style={innerStyle}>
+        {children}
+      </div>
     </div>
   )
 }
@@ -55,8 +59,13 @@ export const FlyerTileOpening: React.FC<{
   attributes: any
   [x: string]: unknown
 }> = ({ children, attributes, ...props }) => {
+  const [colorScheme] = useColorContext()
   return (
-    <div {...props} {...attributes}>
+    <div
+      {...props}
+      {...attributes}
+      {...colorScheme.set('background', 'flyerBg')}
+    >
       <div {...styles.content} {...styles.contentOpening}>
         {children}
       </div>

--- a/packages/styleguide/src/components/TeaserFeed/Headline.js
+++ b/packages/styleguide/src/components/TeaserFeed/Headline.js
@@ -8,8 +8,8 @@ import {
   sansSerifMedium22,
   cursiveTitle20,
   cursiveTitle22,
-  flyerTitle20,
-  flyerTitle22,
+  flyerTitle16,
+  flyerTitle18,
 } from '../Typography/styles'
 import { convertStyleToRem, pxToRem } from '../Typography/utils'
 import { useColorContext } from '../Colors/useColorContext'
@@ -42,9 +42,9 @@ const styles = {
     },
   }),
   flyer: css({
-    ...convertStyleToRem(flyerTitle20),
+    ...convertStyleToRem(flyerTitle16),
     [mUp]: {
-      ...convertStyleToRem(flyerTitle22),
+      ...convertStyleToRem(flyerTitle18),
     },
   }),
 }

--- a/packages/styleguide/src/components/Typography/styles.js
+++ b/packages/styleguide/src/components/Typography/styles.js
@@ -337,3 +337,14 @@ export const flyerTitle20 = {
   fontSize: 20,
   lineHeight: '22px',
 }
+
+export const flyerTitle18 = {
+  ...fontStyles.flyerTitle,
+  fontSize: 18,
+  lineHeight: '20px',
+}
+export const flyerTitle16 = {
+  ...fontStyles.flyerTitle,
+  fontSize: 16,
+  lineHeight: '18px',
+}

--- a/packages/styleguide/src/lib.ts
+++ b/packages/styleguide/src/lib.ts
@@ -192,3 +192,4 @@ export { default as flyerSchema } from './components/Editor/schema/flyer'
 export { RenderContextProvider } from './components/Editor/Render/Context'
 
 export { FlyerTile } from './components/Flyer'
+export { FlyerDate } from './components/Flyer/Date'


### PR DESCRIPTION
This PR fulfills several wishes from the art department.

1. Navigation above journal title. The navigation is now passed via a context to the journal itself, and displayed where the date used to be.
<img width="1136" alt="Screen Shot 2022-10-04 at 15 22 33" src="https://user-images.githubusercontent.com/3907984/193831202-242abe43-5ab1-41e5-8d13-81ebdbfa42b9.png">

2. Share button just below the signature (no more footer tile).
<img width="1138" alt="Screen Shot 2022-10-04 at 15 22 45" src="https://user-images.githubusercontent.com/3907984/193832743-ec289c6b-35cb-4f60-b3e5-92e884cab0cf.png">

3. Change share button-label