### PR TITLE
fix(ImageCrop): prevent metdadata change without explicit recrop

### DIFF
--- a/apps/publikator/components/editor/modules/meta/AudioForm.js
+++ b/apps/publikator/components/editor/modules/meta/AudioForm.js
@@ -121,7 +121,7 @@ export default withT(({ t, editor, node, onInputChange, format }) => {
           </MetaOption>
         )}
       </MetaOptionGroup>
-      {/*<MetaOptionGroupTitle>Audio-Cover und Vorschau</MetaOptionGroupTitle>
+      <MetaOptionGroupTitle>Audio-Cover und Vorschau</MetaOptionGroupTitle>
       <MetaOption>
         <ImageCrop
           image={node.data.get('image')}
@@ -129,7 +129,7 @@ export default withT(({ t, editor, node, onInputChange, format }) => {
           onChange={(crop) => onChange('audioCoverCrop')(crop)}
           format={format}
         />
-      </MetaOption>*/}
+      </MetaOption>
     </MetaSection>
   )
 })

--- a/apps/publikator/components/editor/utils/ImageCrop.js
+++ b/apps/publikator/components/editor/utils/ImageCrop.js
@@ -24,7 +24,9 @@ const isDifferent = (area1, area2, delta = 0) =>
     Math.abs(area1.width - area2.width) > delta ||
     Math.abs(area1.height - area2.height) > delta)
 
-const CreepyCropper = ({ onChange, onReset, image, crop: initialCropArea }) => {
+const isBase64 = (img) => img.startsWith('data:image/jpeg;base64')
+
+const InnerCropper = ({ onChange, onReset, image, crop: initialCropArea }) => {
   const prevImage = usePrevious(image)
 
   const [cropperKey, setCropperKey] = useState(1)
@@ -45,9 +47,12 @@ const CreepyCropper = ({ onChange, onReset, image, crop: initialCropArea }) => {
   }, [initialCropArea])
 
   useEffect(() => {
-    // TODO: tighten condition to excluse case where the one img is a url the other a base64 img
-    console.log({ prevImage, image })
-    if (prevImage && prevImage !== image) {
+    if (
+      prevImage &&
+      prevImage !== image &&
+      // exclude case where the previous img is base64 and new image is url
+      !(isBase64(prevImage) && !isBase64(image))
+    ) {
       onReset()
     }
   }, [image, prevImage])
@@ -183,7 +188,7 @@ const ImageCrop = ({ onChange, image, format, crop }) => {
                 </span>
               </button>
             ) : (
-              <CreepyCropper
+              <InnerCropper
                 image={image}
                 crop={crop}
                 onChange={onChange}

--- a/apps/publikator/components/editor/utils/ImageCrop.js
+++ b/apps/publikator/components/editor/utils/ImageCrop.js
@@ -45,6 +45,8 @@ const CreepyCropper = ({ onChange, onReset, image, crop: initialCropArea }) => {
   }, [initialCropArea])
 
   useEffect(() => {
+    // TODO: tighten condition to excluse case where the one img is a url the other a base64 img
+    console.log({ prevImage, image })
     if (prevImage && prevImage !== image) {
       onReset()
     }

--- a/apps/publikator/components/editor/utils/ImageCrop.js
+++ b/apps/publikator/components/editor/utils/ImageCrop.js
@@ -1,12 +1,19 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { css } from 'glamor'
 import withT from '../../../lib/withT'
 import Cropper from 'react-easy-crop'
-import { AudioCoverGenerator, Slider } from '@project-r/styleguide'
+import {
+  AudioCoverGenerator,
+  Slider,
+  fontStyles,
+  Button,
+} from '@project-r/styleguide'
 
 const PADDING = 15
 const SLIDER_HEIGHT = 52
 
 const ImageCrop = ({ onChange, image, format, crop: initialCropArea }) => {
+  const [customCropEnabled, setCustomCropEnabled] = useState(!!initialCropArea)
   const [crop, setCrop] = useState(
     initialCropArea
       ? { x: initialCropArea.x, y: initialCropArea.y }
@@ -73,22 +80,33 @@ const ImageCrop = ({ onChange, image, format, crop: initialCropArea }) => {
     }
   }, [initialCropArea])
 
-  useEffect(() => {
-    // reset state and metadata if image changes
+  const resetStateAndMeta = () => {
     onChange(null)
     setCroppedArea(null)
     setCrop({ x: 0, y: 0 })
     setZoom(1)
+  }
+
+  useEffect(() => {
+    // reset state and metadata if image changes
+    resetStateAndMeta()
   }, [image])
 
+  useEffect(() => {
+    // reset state and metadata if image changes
+    setCrop({ x: 0, y: 0 })
+  }, [customCropEnabled])
+
   const onCropComplete = useCallback((croppedArea, croppedAreaPixels) => {
+    if (!customCropEnabled) {
+      return
+    }
     const croppedAreaInt = Object.fromEntries(
       Object.entries(croppedArea).map(([k, v], i) => [k, Math.floor(v)]),
     )
     setCroppedArea(croppedAreaInt)
     onChange(croppedAreaInt)
   })
-
   return (
     <div ref={containerRef} style={{ width: '100%' }}>
       {!image ? (
@@ -103,30 +121,61 @@ const ImageCrop = ({ onChange, image, format, crop: initialCropArea }) => {
               marginBottom: SLIDER_HEIGHT,
             }}
           >
-            <Cropper
-              image={image}
-              aspect={1}
-              crop={crop}
-              zoom={zoom}
-              onCropChange={setCrop}
-              onCropComplete={onCropComplete}
-            />
-            <div
-              style={{
-                position: 'relative',
-                top: containerWidth / 2,
-                width: previewSize,
-              }}
-            >
-              <Slider
-                fullWidth
-                label={'Zoom: ' + zoom}
-                value={zoom * 10}
-                min='10'
-                max='20'
-                onChange={(_, zoom) => setZoom(zoom / 10)}
-              />
-            </div>
+            {!customCropEnabled ? (
+              <button
+                {...css({
+                  position: 'absolute',
+                  border: 'none',
+                  cursor: 'pointer',
+                  height: previewSize,
+                  width: previewSize,
+                  zIndex: 3,
+                })}
+                onClick={() => setCustomCropEnabled(!customCropEnabled)}
+              >
+                <span style={{ color: 'white', ...fontStyles.sansSerifMedium }}>
+                  Eigenen Ausschnitt Setzen
+                </span>
+              </button>
+            ) : (
+              <>
+                <Cropper
+                  image={image}
+                  aspect={1}
+                  crop={crop}
+                  zoom={zoom}
+                  onCropChange={setCrop}
+                  onCropComplete={onCropComplete}
+                />
+                <div
+                  style={{
+                    position: 'relative',
+                    top: containerWidth / 2,
+                    width: previewSize,
+                  }}
+                >
+                  <Slider
+                    fullWidth
+                    inactive={!customCropEnabled}
+                    label={'Zoom: ' + zoom}
+                    value={zoom * 10}
+                    min='10'
+                    max='20'
+                    onChange={(_, zoom) => setZoom(zoom / 10)}
+                  />
+                  <Button
+                    small
+                    onClick={() => {
+                      setCustomCropEnabled(false)
+                      resetStateAndMeta()
+                    }}
+                    style={{ marginTop: 8 }}
+                  >
+                    Ausschnitt Zurücksetzen
+                  </Button>
+                </div>
+              </>
+            )}
           </div>
           <div
             style={{
@@ -137,14 +186,22 @@ const ImageCrop = ({ onChange, image, format, crop: initialCropArea }) => {
               overflow: 'hidden',
             }}
           >
-            <div
-              style={{
-                marginBottom: -previewSize,
-                paddingBottom: '100%',
-              }}
-            >
-              <img src={image} alt='Preview Crop' style={imageStyle} />
-            </div>
+            {!customCropEnabled ? (
+              <img
+                src={image}
+                alt='Preview Crop'
+                style={{ objectFit: 'cover', width: '100%', height: '100%' }}
+              />
+            ) : (
+              <div
+                style={{
+                  marginBottom: -previewSize,
+                  paddingBottom: '100%',
+                }}
+              >
+                <img src={image} alt='Preview Crop' style={imageStyle} />
+              </div>
+            )}
           </div>
         </>
       )}

--- a/apps/publikator/components/editor/utils/ImageCrop.js
+++ b/apps/publikator/components/editor/utils/ImageCrop.js
@@ -92,11 +92,6 @@ const ImageCrop = ({ onChange, image, format, crop: initialCropArea }) => {
     resetStateAndMeta()
   }, [image])
 
-  useEffect(() => {
-    // reset state and metadata if image changes
-    setCrop({ x: 0, y: 0 })
-  }, [customCropEnabled])
-
   const onCropComplete = useCallback((croppedArea, croppedAreaPixels) => {
     if (!customCropEnabled) {
       return


### PR DESCRIPTION
Requires explicit interaction to add an image crop in metadata.

https://user-images.githubusercontent.com/20746301/194043124-6a4b1586-87c8-4bef-a706-68498e96f044.mov

