### PR TITLE
Disable Prefetch in Header

### DIFF
--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -312,7 +312,7 @@ const Header = ({
                   </a>
                 </Link>
               ) : (
-                <Link href='/angebote' passHref>
+                <Link href='/angebote' passHref prefetch={false}>
                   <a
                     data-hide-if-me='true'
                     {...styles.button}

--- a/apps/www/components/Frame/Popover/Sections.js
+++ b/apps/www/components/Frame/Popover/Sections.js
@@ -100,7 +100,7 @@ const Panel = ({
         .concat(formats.nodes)
         .sort((a, b) => ascending(a.meta.title, b.meta.title))
         .map(({ id, meta: formatMeta, linkedDocuments }) => (
-          <Link href={formatMeta.path} key={id} passHref>
+          <Link href={formatMeta.path} key={id} passHref prefetch={false}>
             <a {...styles.formatLink} onClick={() => closeHandler()}>
               <FormatTag
                 color={formatMeta.color || colors[formatMeta.kind]}

--- a/apps/www/components/Frame/ProlongBox.js
+++ b/apps/www/components/Frame/ProlongBox.js
@@ -78,7 +78,7 @@ const ProlongBox = ({ t, prolongBeforeDate, membership }) => {
       prefixTranslationKeys.map((k) => `${k}/explanation`),
       {
         cancelLink: (
-          <Link key='cancelLink' href='/abgang' passHref>
+          <Link key='cancelLink' href='/abgang' passHref prefetch={false}>
             <Editorial.A {...styleTextColor}>
               {t.first(
                 prefixTranslationKeys.map((k) => `${k}/explanation/cancelText`),


### PR DESCRIPTION
`Frame/Header.js` is currently responsible that every not signed in article load triggers a `/angebote` prefetch including hitting the backend.

<img width="1206" alt="Screenshot 2022-10-06 at 23 38 14" src="https://user-images.githubusercontent.com/410211/194423318-1c26cab8-00f2-40f5-9aee-660cf28517aa.png">

## Afterwards

<img width="1206" alt="Screenshot 2022-10-06 at 23 44 42" src="https://user-images.githubusercontent.com/410211/194424317-b6936cb9-7234-4ce6-90f4-5cb12660cc59.png">

## Misc

Also disable section and cancel link prefetch—those pages are rarely used or should be slow 😇 
Buy links in expanded navis still prefetch but only after clicking the navi. Pay notes do not use next link and have never prefetched.
