### PR TITLE
refactor(www/audio): allow removing the active-item from action-bar and refactor queue-advance

### DIFF
--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -66,7 +66,8 @@ const ActionBar = ({
   const [fontSizeOverlayVisible, setFontSizeOverlayVisible] = useState(false)
   const [shareOverlayVisible, setShareOverlayVisible] = useState(false)
   const [podcastOverlayVisible, setPodcastOverlayVisible] = useState(false)
-  const { toggleAudioPlayer, isPlaying } = useAudioContext()
+  const { toggleAudioPlayer, resetActivePlayerItem, isPlaying } =
+    useAudioContext()
   const {
     addAudioQueueItem,
     removeAudioQueueItem,
@@ -475,6 +476,9 @@ const ActionBar = ({
       onClick: async (e) => {
         e.preventDefault()
         if (itemInAudioQueue) {
+          if (itemActive) {
+            resetActivePlayerItem()
+          }
           await removeAudioQueueItem(itemInAudioQueue.id)
           trackEvent(['ActionBar', 'rmAudioQueue', document.id])
         } else {

--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -227,8 +227,8 @@ const ActionBar = ({
 
   const isArticleBottom = mode === 'articleBottom'
 
-  const itemActive = checkIfActiveItem(document.id)
-  const itemPlaying = isPlaying && itemActive
+  const isActiveAudioItem = checkIfActiveItem(document.id)
+  const itemPlaying = isPlaying && isActiveAudioItem
   const itemInAudioQueue = checkIfInQueue(document.id)
   const showAudioButtons =
     !!meta.audioSource && meta.audioSource.kind !== 'syntheticReadAloud'
@@ -463,7 +463,6 @@ const ActionBar = ({
       group: 'audio',
     },
     {
-      // disabled: itemActive,
       title: t(`AudioPlayer/Queue/${itemInAudioQueue ? 'Remove' : 'Add'}`),
       label: !forceShortLabel
         ? t(
@@ -476,7 +475,7 @@ const ActionBar = ({
       onClick: async (e) => {
         e.preventDefault()
         if (itemInAudioQueue) {
-          if (itemActive) {
+          if (isActiveAudioItem) {
             resetActivePlayerItem()
           }
           await removeAudioQueueItem(itemInAudioQueue.id)
@@ -485,7 +484,6 @@ const ActionBar = ({
           await addAudioQueueItem(document)
           trackEvent(['ActionBar', 'addToAudioQueue', document.id])
         }
-        // TODO: handle error
       },
       modes: ['feed', 'seriesEpisode', 'articleTop'],
       show: isAudioQueueAvailable && showAudioButtons,

--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -462,7 +462,7 @@ const ActionBar = ({
       group: 'audio',
     },
     {
-      disabled: itemActive,
+      // disabled: itemActive,
       title: t(`AudioPlayer/Queue/${itemInAudioQueue ? 'Remove' : 'Add'}`),
       label: !forceShortLabel
         ? t(

--- a/apps/www/components/Audio/AudioPlayerController.tsx
+++ b/apps/www/components/Audio/AudioPlayerController.tsx
@@ -1,6 +1,10 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { usePlaybackRate } from '../../lib/playbackRate'
-import { useAudioContext, useAudioContextEvent } from './AudioProvider'
+import {
+  AudioContextEvent,
+  useAudioContext,
+  useAudioContextEvent,
+} from './AudioProvider'
 import { useInNativeApp } from '../../lib/withInNativeApp'
 import { AudioEvent, AudioEventHandlers } from './types/AudioEvent'
 import notifyApp from '../../lib/react-native/NotifyApp'
@@ -101,7 +105,6 @@ const AudioPlayerController = ({ children }: AudioPlayerContainerProps) => {
     audioQueueIsLoading,
     addAudioQueueItem,
     removeAudioQueueItem,
-    checkIfActiveItem,
   } = useAudioQueue()
   const { getMediaProgress, saveMediaProgress } = useMediaProgress()
 
@@ -522,7 +525,16 @@ const AudioPlayerController = ({ children }: AudioPlayerContainerProps) => {
     setInitialized(true)
   }, [audioQueue, initialized, audioQueueIsLoading, pathname, setUpAppPlayer])
 
-  useAudioContextEvent<void>('togglePlayer', togglePlayer)
+  useAudioContextEvent<void>(AudioContextEvent.TOGGLE_PLAYER, togglePlayer)
+  useAudioContextEvent<void>(
+    AudioContextEvent.RESET_ACTIVE_PLAYER_ITEM,
+    async () => {
+      if (isPlaying) {
+        await onStop()
+      }
+      setActivePlayerItem(null)
+    },
+  )
 
   useNativeAppEvent(AudioEvent.SYNC, syncWithNativeApp, [initialized])
   useNativeAppEvent<string>(

--- a/apps/www/components/Audio/AudioProvider.tsx
+++ b/apps/www/components/Audio/AudioProvider.tsx
@@ -16,6 +16,11 @@ import { AudioPlayerItem } from './types/AudioPlayerItem'
 import useAudioQueue from './hooks/useAudioQueue'
 import EventEmitter from 'events'
 
+export enum AudioContextEvent {
+  TOGGLE_PLAYER = 'togglePlayer',
+  RESET_ACTIVE_PLAYER_ITEM = 'resetActivePlayerItem',
+}
+
 type ToggleAudioPlayerFunc = (playerItem: AudioPlayerItem) => void
 
 export const AudioEventEmitter = new EventEmitter()
@@ -60,6 +65,7 @@ type AudioContextValue = {
   autoPlayActive: boolean
   toggleAudioPlayer: ToggleAudioPlayerFunc
   onCloseAudioPlayer: () => void
+  resetActivePlayerItem: () => void
 }
 
 export const AudioContext = createContext<AudioContextValue>({
@@ -79,6 +85,9 @@ export const AudioContext = createContext<AudioContextValue>({
     throw new Error('not implemented')
   },
   onCloseAudioPlayer: () => {
+    throw new Error('not implemented')
+  },
+  resetActivePlayerItem: () => {
     throw new Error('not implemented')
   },
   activePlayerItem: null,
@@ -103,8 +112,7 @@ const AudioProvider = ({ children }) => {
   const [isPlaying, setIsPlaying] = useState(false)
   const clearTimeoutId = useRef<NodeJS.Timeout | null>()
 
-  const { addAudioQueueItem, clearAudioQueue, isAudioQueueAvailable } =
-    useAudioQueue()
+  const { addAudioQueueItem, isAudioQueueAvailable } = useAudioQueue()
   const { getMediaProgress } = useMediaProgress()
 
   const toggleAudioPlayer = async (playerItem: AudioPlayerItem) => {
@@ -123,7 +131,7 @@ const AudioProvider = ({ children }) => {
 
     if (isAudioQueueAvailable) {
       await addAudioQueueItem(playerItem, 1)
-      AudioEventEmitter.emit('togglePlayer')
+      AudioEventEmitter.emit(AudioContextEvent.TOGGLE_PLAYER)
     } else {
       if (inNativeApp) {
         let currentTime
@@ -160,6 +168,10 @@ const AudioProvider = ({ children }) => {
     }, 300)
   }
 
+  const resetActivePlayerItem = () => {
+    AudioEventEmitter.emit(AudioContextEvent.RESET_ACTIVE_PLAYER_ITEM)
+  }
+
   useEffect(() => {
     setAudioPlayerVisible(!!activePlayerItem)
   }, [activePlayerItem])
@@ -177,6 +189,7 @@ const AudioProvider = ({ children }) => {
         autoPlayActive: autoPlayAudioPlayerItem === activePlayerItem,
         toggleAudioPlayer,
         onCloseAudioPlayer,
+        resetActivePlayerItem,
       }}
     >
       {children}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "yaproxy:staging": "CORS_ORIGIN=http://localhost:3010,http://localhost:3005,http://localhost:3006 PORT=5010 TARGET=https://api.republik.love yaproxy",
     "yaproxy:staging-kufo": "CORS_ORIGIN=http://localhost:3010,http://localhost:3005,http://localhost:3006 PORT=5010 TARGET=https://api.kufo.republik.love yaproxy",
     "yaproxy:android": "COOKIE_DOMAIN_REWRITE=*:10.0.2.2 CORS_ORIGIN=http://10.0.2.2:3010 PORT=5010 TARGET=https://api.republik.ch yaproxy",
+    "yaproxy:android-staging": "COOKIE_DOMAIN_REWRITE=*:10.0.2.2 CORS_ORIGIN=http://10.0.2.2:3010 PORT=5010 TARGET=https://api.republik.love yaproxy",
     "yaproxy:android-kufo": "COOKIE_DOMAIN_REWRITE=*:10.0.2.2 CORS_ORIGIN=http://10.0.2.2:3010 PORT=5010 TARGET=https://api.kufo.republik.love yaproxy",
     "ngrok:start": "ngrok start republik-frontend republik-backend --region=eu",
     "stripe:forward-webhooks": "stripe listen --latest --forward-to localhost:5010/payments/stripe"


### PR DESCRIPTION
## Description

- You can now remove the active item from the action-bar just like any other item in the queue.
- The logic to advance the queue and load the next track is no longer now directly in the onQueueAdvance function. Previously this was done in a useEffect-hook which was removed.
- An extra hook was added to handle the edge case of loading a newly added item as the active item when the queue was empty before.

## Todo

- [x] Android onQueueAdvance no longer working on the first played track (probably line 583 in controller)