### PR TITLE
Fix Authorization Loop

### DIFF
--- a/apps/www/components/Auth/TokenAuthorization.js
+++ b/apps/www/components/Auth/TokenAuthorization.js
@@ -129,7 +129,11 @@ class TokenAuthorization extends Component {
     )
   }
   autoAuthorize() {
-    if (!this.state.authorizing && shouldAutoAuthorize(this.props)) {
+    if (
+      !this.state.authorizing &&
+      !this.state.authorizeError &&
+      shouldAutoAuthorize(this.props)
+    ) {
       this.authorize()
     }
   }

--- a/apps/www/components/Pledge/Merci.js
+++ b/apps/www/components/Pledge/Merci.js
@@ -150,7 +150,7 @@ class Merci extends Component {
       )
     }
 
-    if (signInError && email && query.id) {
+    if (!me && signInError && email && query.id) {
       return (
         <>
           <H1>{t('merci/postpay/signInError/title')}</H1>


### PR DESCRIPTION
Currently when `unauthorizedSession` validates a token but the following `authorizeSession` fails for any reason (throws a error, including api timeout) the front end get's stuck in a loop and fires the `authorizeSession` mutation non stop. This change properly stops the automatic `authorizeSession` if it fails.

Additionally on a post pay account link it was possible that a sign in error continued to show after somebody signed in successfully. This is also fixed.