### PR TITLE
Fix importPayments if CAMT.053 file contains no entries

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053noEntries.xml
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053noEntries.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04 camt.053.001.04.xsd">
+  <BkToCstmrStmt>
+    <Stmt>
+      <Acct>
+        <Id>
+          <IBAN>CH0000000000999999999</IBAN>
+        </Id>
+        <Ownr>
+          <Nm>Project R Genossenschaft Zürich</Nm>
+        </Ownr>
+      </Acct>
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>

--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -213,6 +213,11 @@ function parseXml(s: string) {
 
   const statement = getStatement(Document)
   const iban = getIban(statement)
+
+  if (!statement.Ntry) {
+    return { iban, creditEntries: [] }
+  }
+
   const entries = ensureArray(statement.Ntry)
   const creditEntries = []
 

--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
@@ -34,6 +34,12 @@ describe('parseCamt053():', () => {
     expect(paymentEntries.length).toEqual(3)
   })
 
+  it('works with no entries', async () => {
+    const xmlString = await loadFixture('noEntries')
+    const paymentEntries = parseCamt053(xmlString)
+    expect(paymentEntries.length).toEqual(0)
+  })
+
   it('retruns the amount in cents', async () => {
     const xmlString = await loadFixture('singleEntry')
     const [{ gutschrift }] = parseCamt053(xmlString)


### PR DESCRIPTION
A CAMT.053 statement file usually contains transactions, one or moore `Ntry` records – and also lacking any `Ntry` records.

This Pull Request handles that.