### PR TITLE
fix(Audioplayer): background fix

### DIFF
--- a/apps/www/components/Audio/AudioPlayer/AudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/AudioPlayer.tsx
@@ -198,7 +198,9 @@ const AudioPlayer = ({
               exit={{ opacity: 0, y: 50 }}
               {...styles.wrapper}
               {...(isExpanded ? styles.wrapperExpanded : styles.wrapperMini)}
-              {...colorScheme.set('backgroundColor', 'default')}
+              {...(inNativeApp && isExpanded
+                ? colorScheme.set('backgroundColor', 'default')
+                : colorScheme.set('backgroundColor', 'overlay'))}
               {...colorScheme.set('boxShadow', 'overlayShadow')}
             >
               {isExpanded ? (


### PR DESCRIPTION
set background to 'default' instdead of 'overlay', making the separation of the UI elements more clear. The reason why it was set to 'default' is because in the native apps in expanded mode, the status bar is colored 'default' and thus it is necessary to have the same color.

This PR sets 'overlay' as the default and only switches the background to 'default' when displayed in the native app and in expanded mode.

before:
<img width="626" alt="Screenshot 2022-11-04 at 14 56 02" src="https://user-images.githubusercontent.com/20746301/199989830-9cbc98b8-0d71-4b18-b164-ac59240621dd.png">

after:
<img width="665" alt="Screenshot 2022-11-04 at 14 55 41" src="https://user-images.githubusercontent.com/20746301/199990412-52314691-538c-49ce-be27-3f40b036c184.png">

