### PR TITLE
fix(ACtionbar): correct audioplayer visibility handling

### DIFF
--- a/apps/www/components/Article/ActionBarOverlay.js
+++ b/apps/www/components/Article/ActionBarOverlay.js
@@ -15,14 +15,13 @@ const ActionBarOverlay = ({ children }) => {
   const [overlayVisible, setOverlayVisible] = useState(false)
   const isDesktop = useMediaQuery(mediaQueries.mUp)
   const { isAudioQueueAvailable } = useAudioQueue()
-  const { isVisible: audioPlayerVisible } = useAudioContext()
+  const { audioPlayerVisible } = useAudioContext()
 
   const audioPlayerOffset = audioPlayerVisible
     ? isAudioQueueAvailable
-      ? MINI_AUDIO_PLAYER_HEIGHT + 10
+      ? MINI_AUDIO_PLAYER_HEIGHT + 16
       : AUDIO_PLAYER_HEIGHT + 20
     : 0
-
   const lastY = useRef()
   const diff = useRef(0)
 


### PR DESCRIPTION
before (actionbar invisible, behind audio player)

<img width="398" alt="Screenshot 2022-11-04 at 15 12 39" src="https://user-images.githubusercontent.com/20746301/199995972-13468b4e-95ab-4321-8a33-7166ea5051f7.png">


after
<img width="396" alt="Screenshot 2022-11-04 at 15 11 20" src="https://user-images.githubusercontent.com/20746301/199995840-a428d07d-692a-4614-9cd9-ec047998099a.png">


fixes:
https://www.notion.so/republikmagazin/12-Audio-player-over-floating-action-bar-in-article-8008aca33fb94e1fb6967855112a2c2d