### PR TITLE
Layout fixes

### DIFF
--- a/packages/styleguide/src/components/Figure/Slate.tsx
+++ b/packages/styleguide/src/components/Figure/Slate.tsx
@@ -5,6 +5,7 @@ import {
   FigureImage as InnerFigureImage,
   FigureByline as InnerByline,
 } from './index'
+import { css } from 'glamor'
 
 export const PLACEHOLDER = '/static/placeholder.png'
 
@@ -27,7 +28,13 @@ export const FigureImage: React.FC<{
   [x: string]: unknown
 }> = ({ children, images, alt, attributes, ...props }) => {
   return (
-    <div {...attributes} {...props}>
+    <div
+      {...attributes}
+      {...props}
+      {...css({
+        '&:not(:last-child)': { marginBottom: 5 },
+      })}
+    >
       <div contentEditable={false}>
         <InnerFigureImage
           src={images?.default?.url || PLACEHOLDER}

--- a/packages/styleguide/src/components/TeaserFront/SplitHeadline.js
+++ b/packages/styleguide/src/components/TeaserFront/SplitHeadline.js
@@ -9,6 +9,10 @@ const size = {
     fontSize: pxToRem('38px'),
     lineHeight: pxToRem('43px'),
   },
+  sUp: {
+    fontSize: pxToRem('58px'),
+    lineHeight: pxToRem('60px'),
+  },
   m: {
     fontSize: pxToRem('60px'),
     lineHeight: pxToRem('70px'),
@@ -28,6 +32,12 @@ const size = {
 }
 
 const sizes = {
+  small: css({
+    ...size.s,
+    [mUp]: {
+      ...size.sUp,
+    },
+  }),
   large: css({
     ...size.s,
     [mUp]: {
@@ -78,10 +88,13 @@ const styles = {
   }),
 }
 
-export const Editorial = ({ children, large, medium }) => {
+export const Editorial = ({ children, large, medium, small }) => {
   const sizedStyle = css(
     styles.editorial,
-    (large && sizes.large) || (medium && sizes.medium) || sizes.default,
+    (large && sizes.large) ||
+      (medium && sizes.medium) ||
+      (small && sizes.small) ||
+      sizes.default,
   )
   return (
     <h1 {...styles.base} {...sizedStyle}>
@@ -90,10 +103,13 @@ export const Editorial = ({ children, large, medium }) => {
   )
 }
 
-export const Interaction = ({ children, large, medium }) => {
+export const Interaction = ({ children, large, medium, small }) => {
   const sizedStyle = css(
     styles.interaction,
-    (large && sizes.large) || (medium && sizes.medium) || sizes.default,
+    (large && sizes.large) ||
+      (medium && sizes.medium) ||
+      (small && sizes.small) ||
+      sizes.default,
   )
   return (
     <h1 {...styles.base} {...sizedStyle}>

--- a/packages/styleguide/src/templates/Front/index.js
+++ b/packages/styleguide/src/templates/Front/index.js
@@ -349,6 +349,7 @@ const createFrontSchema = ({
             ? TeaserFrontSplitHeadline.Editorial
             : TeaserFrontSplitHeadline.Interaction
         const sizes = {
+          small: titleSize === 'small',
           medium: titleSize === 'medium',
           large: titleSize === 'large',
         }


### PR DESCRIPTION
– Smaller "Small" Headline for Split Image Tile on the Front
<img width="1441" alt="Screen Shot 2022-11-08 at 11 05 38" src="https://user-images.githubusercontent.com/3907984/200536217-95d94719-1d2a-4766-a72d-8c884082af31.png">

– Margin between Image and Ca
<img width="858" alt="Screen Shot 2022-11-08 at 11 03 51" src="https://user-images.githubusercontent.com/3907984/200536489-8aeed775-5113-4a09-ba98-e37276c0be7f.png">

