### PR TITLE
feat(www/front): show play-buttons on all tiles that have audio that isn't synthetic

### DIFF
--- a/apps/www/components/Front/index.js
+++ b/apps/www/components/Front/index.js
@@ -34,7 +34,6 @@ import { useRouter } from 'next/router'
 import { useMe } from '../../lib/context/MeContext'
 import { useAudioContext } from '../Audio/AudioProvider'
 import useAudioQueue from '../Audio/hooks/useAudioQueue'
-import { trackEvent } from '../../lib/matomo'
 import { AudioPlayerLocations } from '../Audio/types/AudioActionTracking'
 
 const styles = {

--- a/packages/backend-modules/documents/lib/mdast/resolve.js
+++ b/packages/backend-modules/documents/lib/mdast/resolve.js
@@ -65,6 +65,7 @@ const contentUrlResolver = (
         const hasAudio = audioSourceMp3 || audioSourceAac || audioSourceOgg
         node.data.urlMeta = {
           documentId: linkedDoc.id,
+          hasAudio,
           audioSourceKind: hasAudio && audioSourceKind,
           repoId: linkedDoc.meta.repoId,
           publishDate: linkedDoc.meta.publishDate,

--- a/packages/styleguide/src/templates/Front/index.js
+++ b/packages/styleguide/src/templates/Front/index.js
@@ -54,7 +54,9 @@ import createLiveTeasers from './liveTeasers'
 import { ColorContextProvider } from '../../components/Colors/ColorContext'
 
 const playFn = (onPlay, { urlMeta }) =>
-  onPlay && urlMeta?.audioSourceKind === 'readAloud'
+  onPlay &&
+  urlMeta?.hasAudio &&
+  urlMeta?.audioSourceKind !== 'syntheticReadAloud'
     ? () => onPlay(urlMeta.documentId)
     : undefined
 


### PR DESCRIPTION
- fix(www/front): remove unused import
- feat(api): add has audio to urlMeta to be used in the front
- feat(www/front): render play button for all tiles with audio unless kind == 'syntheticReadAloud'

## Description

With these changes, the play button will be shown for all article-tiles that have an audioSource and the audioSourceKind !== 'syntheticReadAloud'.
(The problem was that the play-button wasn't shown for podcasts)

