### PR TITLE
fix(statistics): find previous paths via redirections

### DIFF
--- a/packages/backend-modules/statistics/lib/matomo/collect.js
+++ b/packages/backend-modules/statistics/lib/matomo/collect.js
@@ -179,8 +179,10 @@ const enrichData =
       if (!doc)
         return { ...row, repoId: null, template: null, publishDate: null }
 
-      const { repoId, template, publishDate } = doc.meta
-      return { ...row, repoId, template, publishDate }
+      const { path: currentPath, repoId, template, publishDate } = doc.meta
+      const url = new URL(currentPath, row.url).toString()
+
+      return { ...row, url, repoId, template, publishDate }
     })
 
 const mergeData = (data) =>

--- a/packages/backend-modules/statistics/lib/pgdb/redirections.js
+++ b/packages/backend-modules/statistics/lib/pgdb/redirections.js
@@ -1,0 +1,30 @@
+const debug = require('debug')('statistics:lib:pgdb:redirections')
+
+const find = async ({ date, targets }, { pgdb }) => {
+  debug('find() %o', { date })
+
+  const rows = await pgdb.public.redirections.find(
+    {
+      target: targets,
+      or: [{ 'deletedAt >': date }, { deletedAt: null }],
+    },
+    {
+      fields: ['source', 'target'],
+      orderBy: 'createdAt',
+    },
+  )
+
+  const redirections = {}
+
+  rows.forEach(({ source, target }) => {
+    if (!redirections[target]) {
+      redirections[target] = []
+    }
+
+    redirections[target].push(source)
+  })
+
+  return redirections
+}
+
+module.exports.find = find


### PR DESCRIPTION
matomo/collect did not check redirections table to find old paths

It now checks for previous paths and merges records