### PR TITLE
fix(www/audio): complete migrating variable ActivePlayerItem -> LegayPlayerItem introduced with #276

### DIFF
--- a/apps/www/components/Audio/AudioProvider.tsx
+++ b/apps/www/components/Audio/AudioProvider.tsx
@@ -182,6 +182,7 @@ const AudioProvider = ({ children }) => {
     setAudioPlayerVisible(false)
     clearTimeoutId.current = setTimeout(() => {
       setActivePlayerItem(undefined)
+      setLegacyPlayerItem(undefined)
     }, 300)
   }
 
@@ -213,14 +214,14 @@ const AudioProvider = ({ children }) => {
   // Legacy in-app audio player this will open up the player for the last played element
   // This may be deleted sometime in the future once every app version below v2.2.0 is discontinued
   useEffect(() => {
-    setAudioPlayerVisible(!!activePlayerItem)
-  }, [activePlayerItem])
+    setAudioPlayerVisible(!!legacyPlayerItem)
+  }, [legacyPlayerItem])
 
   // This clears the persisted active-player state in the browser or the native app.
   // If a value was persisted the above effect kept on opening the player.
   useEffect(() => {
     if (isAudioQueueAvailable) {
-      setActivePlayerItem(null)
+      setLegacyPlayerItem(null)
     }
   }, [isAudioQueueAvailable])
 


### PR DESCRIPTION
## Description

With #276 I moved the active-playeritem state from the controller to the context. Due to that I renamed the previous activeItem (used in the legacy-player) to legacyPlayerItem. It seems I renamed it, instead of refactoring the variable-name. In combination with #277 this now causes the audio-player to close and lock the body after the last track is removed from the player.

This PR updates those references which caused the player to auto-close and lock the body-scroll
