### PR TITLE
fix(www/nav): render the back-button in the iOS app on all pages but the magazin-front

### DIFF
--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -1,7 +1,7 @@
 import { useMemo, useState, useRef, useEffect } from 'react'
 import { css } from 'glamor'
 import compose from 'lodash/flowRight'
-import { useRouter, withRouter } from 'next/router'
+import { withRouter } from 'next/router'
 import {
   Logo,
   mediaQueries,
@@ -60,7 +60,6 @@ const Header = ({
   stickySecondaryNav,
   pageColorSchemeKey,
 }) => {
-  const { asPath } = useRouter()
   const [colorScheme] = useColorContext()
   const [isMobile, setIsMobile] = useState()
   const [scrollableHeaderHeight, setScrollableHeaderHeight] =
@@ -73,8 +72,9 @@ const Header = ({
   const lastY = useRef()
   const lastDiff = useRef()
 
-  const isOnHomePage = asPath === '/'
-  const backButton = inNativeIOSApp && me && !isOnHomePage
+  const topLevelPaths = ['/', '/feed', '/dialog', '/format/journal', '/suche']
+  const isOnTopLevelPage = topLevelPaths.includes(router.asPath)
+  const backButton = inNativeIOSApp && me && !isOnTopLevelPage
 
   const toggleExpanded = (target) => {
     if (target === expandedNav) {

--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -1,7 +1,7 @@
 import { useMemo, useState, useRef, useEffect } from 'react'
 import { css } from 'glamor'
 import compose from 'lodash/flowRight'
-import { withRouter } from 'next/router'
+import { useRouter, withRouter } from 'next/router'
 import {
   Logo,
   mediaQueries,
@@ -60,6 +60,7 @@ const Header = ({
   stickySecondaryNav,
   pageColorSchemeKey,
 }) => {
+  const { asPath } = useRouter()
   const [colorScheme] = useColorContext()
   const [isMobile, setIsMobile] = useState()
   const [scrollableHeaderHeight, setScrollableHeaderHeight] =
@@ -72,7 +73,8 @@ const Header = ({
   const lastY = useRef()
   const lastDiff = useRef()
 
-  const backButton = !hasOverviewNav && inNativeIOSApp && me
+  const isOnHomePage = asPath === '/'
+  const backButton = inNativeIOSApp && me && !isOnHomePage
 
   const toggleExpanded = (target) => {
     if (target === expandedNav) {


### PR DESCRIPTION
With #274 hasOverviewNav is not passed on the page component. In the Header however, the backbutton has previously only been rendered, if hasOvervierNav=false.
With this PR we attempt to regain the previous behaviour by generalizing the rule to render the back-button for logged-in users when ever a logged in user is in the iOSApp on a page other than the magazin-front
