### PR TITLE
fix(Assets): fixes rounding to round down on calculating crop size

### DIFF
--- a/packages/backend-modules/assets/lib/returnImage.js
+++ b/packages/backend-modules/assets/lib/returnImage.js
@@ -187,10 +187,10 @@ module.exports = async ({
 
       if (crop && size) {
         pipeline.extract({
-          left: Math.ceil((cropX / 100) * fileWidth),
-          top: Math.ceil((cropY / 100) * fileHeight),
-          width: Math.ceil((cropWidth / 100) * fileWidth),
-          height: Math.ceil((cropHeight / 100) * fileHeight),
+          left: Math.floor((cropX / 100) * fileWidth),
+          top: Math.floor((cropY / 100) * fileHeight),
+          width: Math.floor((cropWidth / 100) * fileWidth),
+          height: Math.floor((cropHeight / 100) * fileHeight),
         })
       }
 


### PR DESCRIPTION
Math.ceil rounds up, which could lead to a situation where the crop height would exceed the file size.

Using Math.floor fixes the issue. 

Example: Using the crop 0x18y100w82h on an image with the dimensions 2126x2661

it would try to extract:
top: Math.ceil((18 / 100) * 2126) = 478.9 => 479
height: Math.ceil((82 / 100) * 2126) = 2182.02 => 2183
479+2183 = 2662, which is 1 pixel higher than the image - > throws error

With Math.floor ensures that the crop is always lower than the total size.