### PR TITLE
fix(www): redirect /webfinger, provide .well-known before redirect

### DIFF
--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -10,9 +10,12 @@ PUBLIC_BASE_URL=http://localhost:3010
 PUBLIKATOR_BASE_URL=http://localhost:3005
 ADMIN_BASE_URL=http://localhost:3006
 
+# Used for Mastodon WebFinger redirect
+# "Translate `user@domain` mentions to actor profile URIs."
+# MASTODON_BASE_URL=
+
 # API key to access restricted GraphQL queries
 # SSG_DOCUMENTS_API_KEY=
-
 
 # cookie names
 COOKIE_NAME=connect.sid


### PR DESCRIPTION
This Pull Request provides static files in `public/.well-known/` before redirect to `PUBLIC_BASE_URL` kicks in. A change necessar to accomodate domain validation ("republik.ch/.well-known/...", "www.republik.ch/.well-known/...", etc.).

It also redirects `/.well-known/webfinger` to URL provided in `MASTODON_BASE_URL`.
