### PR TITLE
www Journal Page refactoring

### DIFF
--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -66,7 +66,7 @@ import SectionFeed from '../Sections/SinglePageFeed'
 import HrefLink from '../Link/Href'
 import { withMarkAsReadMutation } from '../Notifications/enhancers'
 import ShareImageFlyer from '../Flyer/ShareImage'
-import FlyerPage from '../Flyer'
+import Flyer from '../Flyer'
 
 import { getMetaData, runMetaFromQuery } from './metadata'
 import ActionBarOverlay from './ActionBarOverlay'
@@ -656,7 +656,7 @@ const ArticlePage = ({
                 </div>
               )}
               {isFlyer ? (
-                <FlyerPage
+                <Flyer
                   meta={meta}
                   documentId={documentId}
                   inNativeApp={inNativeApp}

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -2,6 +2,7 @@ import { cloneElement, useRef, useEffect, useMemo, useContext } from 'react'
 import { css } from 'glamor'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import dynamic from 'next/dynamic'
 import { renderMdast } from 'mdast-react-render'
 import compose from 'lodash/flowRight'
 import {
@@ -12,6 +13,7 @@ import {
   withSubscription,
 } from '@apollo/client/react/hoc'
 import { ApolloConsumer, ApolloProvider, gql, useQuery } from '@apollo/client'
+import { Mutation, Query, Subscription } from '@apollo/client/react/components'
 
 import {
   Center,
@@ -21,7 +23,6 @@ import {
   Interaction,
   TitleBlock,
   Editorial,
-  Flyer,
   TeaserEmbedComment,
   IconButton,
   SeriesNav,
@@ -34,32 +35,27 @@ import {
   createSectionSchema,
   createPageSchema,
   flyerSchema,
-  SlateRender,
-  RenderContextProvider,
   EditIcon,
   createRequire,
 } from '@project-r/styleguide'
 
-import ActionBarOverlay from './ActionBarOverlay'
-import SeriesNavBar from './SeriesNavBar'
-import TrialPayNoteMini from './TrialPayNoteMini'
-import Extract from './Extract'
-import { FlyerWrapper, PayNote } from './PayNote'
-import Progress from './Progress'
-import PodcastButtons from './PodcastButtons'
-import { getDocument } from './graphql/getDocument'
 import withT from '../../lib/withT'
 import { parseJSONObject } from '../../lib/safeJSON'
 import { formatDate } from '../../lib/utils/format'
 import withInNativeApp, { postMessage } from '../../lib/withInNativeApp'
 import { splitByTitle } from '../../lib/utils/mdast'
 import { PUBLIKATOR_BASE_URL } from '../../lib/constants'
-import ShareImage from './ShareImage'
+import { useMe } from '../../lib/context/MeContext'
+import { cleanAsPath } from '../../lib/utils/link'
+
+import CommentLink from '../Discussion/shared/CommentLink'
+import DiscussionContextProvider from '../Discussion/context/DiscussionContextProvider'
+import Discussion from '../Discussion/Discussion'
+import { AudioPlayerLocations } from '../Audio/types/AudioActionTracking'
 import FontSizeSync from '../FontSize/Sync'
 import PageLoader from '../Loader'
 import Frame from '../Frame'
 import ActionBar from '../ActionBar'
-import { BrowserOnlyActionBar } from './BrowserOnly'
 import { AudioContext } from '../Audio/AudioProvider'
 import FormatFeed from '../Feed/Format'
 import StatusError from '../StatusError'
@@ -69,20 +65,21 @@ import SectionNav from '../Sections/SinglePageNav'
 import SectionFeed from '../Sections/SinglePageFeed'
 import HrefLink from '../Link/Href'
 import { withMarkAsReadMutation } from '../Notifications/enhancers'
-import { cleanAsPath } from '../../lib/utils/link'
-import { getMetaData, runMetaFromQuery } from './metadata'
-import FlyerFooter, { FlyerMeta, FlyerNav } from './Flyer'
-import ShareImageFlyer from './ShareImageFlyer'
-import { getFlyerTileActionBar } from '../ActionBar/FlyerTileActionBar'
+import ShareImageFlyer from '../Flyer/ShareImage'
+import FlyerPage from '../Flyer'
 
-import dynamic from 'next/dynamic'
-import CommentLink from '../Discussion/shared/CommentLink'
-import { Mutation, Query, Subscription } from '@apollo/client/react/components'
-import { useMe } from '../../lib/context/MeContext'
-import DiscussionContextProvider from '../Discussion/context/DiscussionContextProvider'
-import Discussion from '../Discussion/Discussion'
+import { getMetaData, runMetaFromQuery } from './metadata'
+import ActionBarOverlay from './ActionBarOverlay'
+import SeriesNavBar from './SeriesNavBar'
+import TrialPayNoteMini from './TrialPayNoteMini'
+import Extract from './Extract'
+import { FlyerWrapper, PayNote } from './PayNote'
+import Progress from './Progress'
+import PodcastButtons from './PodcastButtons'
+import { getDocument } from './graphql/getDocument'
+import ShareImage from './ShareImage'
+import { BrowserOnlyActionBar } from './BrowserOnly'
 import ArticleRecommendationsFeed from './ArticleRecommendationsFeed'
-import { AudioPlayerLocations } from '../Audio/types/AudioActionTracking'
 
 const LoadingComponent = () => <SmallLoader loading />
 
@@ -659,36 +656,15 @@ const ArticlePage = ({
                 </div>
               )}
               {isFlyer ? (
-                <Flyer.Layout>
-                  <RenderContextProvider
-                    t={t}
-                    Link={HrefLink}
-                    nav={
-                      <FlyerNav
-                        repoId={repoId}
-                        publishDate={meta.publishDate}
-                      />
-                    }
-                    ShareTile={getFlyerTileActionBar(
-                      documentId,
-                      meta,
-                      inNativeApp,
-                    )}
-                  >
-                    <SlateRender
-                      value={article.content.children}
-                      schema={schema}
-                      raw
-                      skip={['flyerOpeningP']}
-                    />
-                  </RenderContextProvider>
-                  <FlyerFooter>{actionBarFlyer}</FlyerFooter>
-                  <FlyerMeta
-                    documentId={documentId}
-                    meta={meta}
-                    tileId={share}
-                  />
-                </Flyer.Layout>
+                <FlyerPage
+                  meta={meta}
+                  documentId={documentId}
+                  inNativeApp={inNativeApp}
+                  repoId={repoId}
+                  actionBar={actionBarFlyer}
+                  value={article.content.children}
+                  tileId={share}
+                />
               ) : (
                 <ArticleGallery
                   article={article}

--- a/apps/www/components/Flyer/ActionBar.tsx
+++ b/apps/www/components/Flyer/ActionBar.tsx
@@ -1,14 +1,23 @@
-import { useState } from 'react'
-import { IconButton, ShareIcon, ImageIcon, slug } from '@project-r/styleguide'
+import React, { useState } from 'react'
+import { css } from 'glamor'
+
+import { IconButton, ShareIcon, ImageIcon } from '@project-r/styleguide'
+
 import { PUBLIC_BASE_URL } from '../../lib/constants'
 import { trackEvent } from '../../lib/matomo'
-import ShareOverlay from './ShareOverlay'
 import { useTranslation } from '../../lib/withT'
-import { css } from 'glamor'
 import { postMessage } from '../../lib/withInNativeApp'
-import { getShareImageUrls } from '../Article/Flyer'
 
-const ShareButton = ({ meta, tileId, inNativeApp }) => {
+import ShareOverlay from '../ActionBar/ShareOverlay'
+
+import { getShareImageUrls } from './Meta'
+import { MetaProps } from './index'
+
+const ShareButton: React.FC<{
+  meta: MetaProps
+  tileId: string
+  inNativeApp: boolean
+}> = ({ meta, tileId, inNativeApp }) => {
   const [overlay, showOverlay] = useState(false)
   const { t } = useTranslation()
 
@@ -59,7 +68,11 @@ const ShareButton = ({ meta, tileId, inNativeApp }) => {
   )
 }
 
-const DownloadButton = ({ documentId, meta, tileId }) => {
+const DownloadButton: React.FC<{
+  documentId: string
+  meta: MetaProps
+  tileId: string
+}> = ({ documentId, meta, tileId }) => {
   const { t } = useTranslation()
   const { screenshotUrl, shareImageUrl } = getShareImageUrls(
     documentId,
@@ -95,7 +108,11 @@ const DownloadButton = ({ documentId, meta, tileId }) => {
   )
 }
 
-export const getFlyerTileActionBar =
+export const getTileActionBar: (
+  documentId: string,
+  meta: MetaProps,
+  inNativeApp: boolean,
+) => React.FC<{ tileId?: string }> =
   (documentId, meta, inNativeApp) =>
   ({ tileId }) => {
     if (!tileId) return null

--- a/apps/www/components/Flyer/Footer.tsx
+++ b/apps/www/components/Flyer/Footer.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { css } from 'glamor'
+
+import { mediaQueries, FlyerTile } from '@project-r/styleguide'
+
+const styles = {
+  footer: css({
+    marginTop: -35,
+    [mediaQueries.mUp]: {
+      marginTop: -60,
+    },
+  }),
+}
+
+const FlyerFooter: React.FC = ({ children }) => {
+  return (
+    <FlyerTile {...styles.footer} innerStyle={{ paddingTop: 0 }}>
+      {children}
+    </FlyerTile>
+  )
+}
+
+export default FlyerFooter

--- a/apps/www/components/Flyer/Meta.tsx
+++ b/apps/www/components/Flyer/Meta.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { PUBLIC_BASE_URL, ASSETS_SERVER_BASE_URL } from '../../lib/constants'
+
+import { getCacheKey } from '../Article/metadata'
+import Meta from '../Frame/Meta'
+
+import { MetaProps } from './index'
+
+export const getShareImageUrls = (
+  documentId: string,
+  meta: MetaProps,
+  tileId: string,
+  showAll?: boolean,
+): {
+  screenshotUrl: string
+  shareImageUrl: string
+} => {
+  const screenshotUrl = new URL(meta.path, PUBLIC_BASE_URL)
+  screenshotUrl.searchParams.set('extract', tileId)
+
+  if (showAll) {
+    screenshotUrl.searchParams.set('showAll', 'true')
+  }
+
+  const dimensions = showAll ? [450, 1] : [600, 314]
+
+  const shareImageUrl = new URL('/render', ASSETS_SERVER_BASE_URL)
+  shareImageUrl.searchParams.set('viewport', dimensions.join('x'))
+  shareImageUrl.searchParams.set('zoomFactor', '2')
+  shareImageUrl.searchParams.set('updatedAt', getCacheKey(documentId, meta))
+  shareImageUrl.searchParams.set('url', screenshotUrl.toString())
+
+  return {
+    screenshotUrl: screenshotUrl.toString(),
+    shareImageUrl: shareImageUrl.toString(),
+  }
+}
+
+const FlyerMeta: React.FC<{
+  documentId: string
+  tileId?: string
+  meta: MetaProps
+}> = ({ tileId, meta, documentId }) => {
+  // Render as usual
+  if (!tileId && meta) {
+    return <Meta data={meta} />
+  }
+
+  const { shareImageUrl } = getShareImageUrls(documentId, meta, tileId)
+
+  return (
+    <Meta
+      data={{
+        ...meta,
+        image: shareImageUrl.toString(),
+        twitterImage: shareImageUrl.toString(),
+        facebookImage: shareImageUrl.toString(),
+        url: `${PUBLIC_BASE_URL}${meta.path}?share=${tileId}`,
+      }}
+    />
+  )
+}
+
+export default FlyerMeta

--- a/apps/www/components/Flyer/ShareImage.tsx
+++ b/apps/www/components/Flyer/ShareImage.tsx
@@ -1,5 +1,7 @@
-import { Fragment } from 'react'
+import React from 'react'
+import { css } from 'glamor'
 import Head from 'next/head'
+
 import {
   SlateRender,
   ColorContextProvider,
@@ -10,8 +12,10 @@ import {
   mediaQueries,
   fontFamilies,
   useMediaQuery,
+  CustomDescendant,
+  flyerSchema,
 } from '@project-r/styleguide'
-import { css } from 'glamor'
+
 import { useTranslation } from '../../lib/withT'
 
 const styles = {
@@ -55,7 +59,7 @@ const styles = {
   }),
 }
 
-const Branding = () => {
+const Branding: React.FC = () => {
   const isDesktop = useMediaQuery(mediaQueries.mUp)
   const { t } = useTranslation()
   return (
@@ -72,9 +76,13 @@ const Branding = () => {
   )
 }
 
-const ShareImageFlyer = ({ tileId, value, schema, showAll }) => {
+const ShareImage: React.FC<{
+  tileId: string
+  value: CustomDescendant[]
+  showAll?: boolean
+}> = ({ tileId, value, showAll }) => {
   return (
-    <Fragment>
+    <>
       <Head>
         <meta name='robots' content='noindex' />
       </Head>
@@ -84,7 +92,7 @@ const ShareImageFlyer = ({ tileId, value, schema, showAll }) => {
             <div {...(!showAll && styles.inner)}>
               <SlateRender
                 value={value.filter((block) => block.id === tileId)}
-                schema={schema}
+                schema={flyerSchema}
                 skip={['flyerMetaP']}
               />
             </div>
@@ -92,7 +100,7 @@ const ShareImageFlyer = ({ tileId, value, schema, showAll }) => {
         </RenderContextProvider>
       </ColorContextProvider>
       {showAll && <Branding />}
-    </Fragment>
+    </>
   )
 }
-export default ShareImageFlyer
+export default ShareImage

--- a/apps/www/components/Flyer/index.tsx
+++ b/apps/www/components/Flyer/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+import {
+  Flyer,
+  RenderContextProvider,
+  SlateRender,
+  flyerSchema,
+  CustomDescendant,
+} from '@project-r/styleguide'
+
+import { useTranslation } from '../../lib/withT'
+
+import HrefLink from '../Link/Href'
+
+import { getTileActionBar } from './ActionBar'
+import Footer from './Footer'
+import Meta from './Meta'
+import Nav from './Nav'
+
+export type MetaProps = {
+  path: string
+  publishDate: string
+  [x: string]: unknown
+}
+
+const Page: React.FC<{
+  meta: MetaProps
+  repoId: string
+  documentId: string
+  inNativeApp: boolean
+  tileId?: string
+  value: CustomDescendant[]
+  actionBar: JSX.Element
+}> = ({ meta, repoId, documentId, inNativeApp, tileId, value, actionBar }) => {
+  const { t } = useTranslation()
+  return (
+    <Flyer.Layout>
+      <RenderContextProvider
+        t={t}
+        Link={HrefLink}
+        nav={<Nav repoId={repoId} publishDate={meta.publishDate} />}
+        ShareTile={getTileActionBar(documentId, meta, inNativeApp)}
+      >
+        <SlateRender
+          value={value}
+          schema={flyerSchema}
+          raw
+          skip={['flyerOpeningP']}
+        />
+      </RenderContextProvider>
+      <Footer>{actionBar}</Footer>
+      <Meta documentId={documentId} meta={meta} tileId={tileId} />
+    </Flyer.Layout>
+  )
+}
+
+export default Page

--- a/packages/styleguide/src/components/Typography/Flyer.tsx
+++ b/packages/styleguide/src/components/Typography/Flyer.tsx
@@ -8,7 +8,10 @@ import { useRenderContext } from '../Editor/Render/Context'
 import { pxToRem } from './utils'
 import colors from '../../theme/colors'
 
-export const Layout = ({ children, attributes = {} }) => {
+type BaseProps = { attributes?: any; [x: string]: unknown }
+type Typography = React.FC<BaseProps>
+
+export const Layout: Typography = ({ children, attributes }) => {
   const [colorScheme] = useColorContext()
   return (
     <div {...colorScheme.set('background', 'flyerBg')} {...attributes}>
@@ -17,7 +20,7 @@ export const Layout = ({ children, attributes = {} }) => {
   )
 }
 
-export const H1 = ({ children, attributes = {}, ...props }) => {
+export const H1: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
 
   return (
@@ -43,7 +46,7 @@ export const H1 = ({ children, attributes = {}, ...props }) => {
   )
 }
 
-export const H2 = ({ children, attributes = {}, ...props }) => {
+export const H2: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <h2
@@ -70,7 +73,7 @@ export const H2 = ({ children, attributes = {}, ...props }) => {
   )
 }
 
-export const H3 = ({ children, attributes = {}, ...props }) => {
+export const H3: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <h3
@@ -95,11 +98,7 @@ export const H3 = ({ children, attributes = {}, ...props }) => {
   )
 }
 
-export const P: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
-  children,
-  attributes,
-  ...props
-}) => {
+export const P: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <p
@@ -128,7 +127,7 @@ export const P: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
   )
 }
 
-export const MetaP = ({ children, attributes = {}, ...props }) => {
+export const MetaP: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <p
@@ -152,7 +151,7 @@ export const MetaP = ({ children, attributes = {}, ...props }) => {
   )
 }
 
-export const OpeningP = ({ children, attributes = {}, ...props }) => {
+export const OpeningP: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <p
@@ -176,11 +175,7 @@ export const OpeningP = ({ children, attributes = {}, ...props }) => {
   )
 }
 
-export const Small: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
-  children,
-  attributes,
-  ...props
-}) => {
+export const Small: Typography = ({ children, attributes, ...props }) => {
   const [colorScheme] = useColorContext()
 
   return (
@@ -204,19 +199,23 @@ export const Small: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
   )
 }
 
-export const Emphasis = ({ children, attributes = {}, ...props }) => (
+export const Emphasis: Typography = ({ children, attributes, ...props }) => (
   <strong {...props} {...attributes}>
     {children}
   </strong>
 )
 
-export const Cursive = ({ children, attributes = {}, ...props }) => (
+export const Cursive: Typography = ({ children, attributes, ...props }) => (
   <em {...props} {...attributes}>
     {children}
   </em>
 )
 
-export const StrikeThrough = ({ children, attributes = {}, ...props }) => (
+export const StrikeThrough: Typography = ({
+  children,
+  attributes,
+  ...props
+}) => (
   <span
     {...attributes}
     {...props}
@@ -240,7 +239,7 @@ const ulRule = css({
   },
 })
 
-export const UL = ({ children, attributes = {}, ...props }) => {
+export const UL: Typography = ({ children, attributes, ...props }) => {
   return (
     <ul {...attributes} {...props} {...ulRule}>
       {children}
@@ -256,7 +255,7 @@ const olRule = css({
   },
 })
 
-export const OL = ({ children, attributes = {}, ...props }) => {
+export const OL: Typography = ({ children, attributes, ...props }) => {
   return (
     <ol {...attributes} {...props} {...olRule}>
       {children}
@@ -283,10 +282,10 @@ const listItemRule = css({
   },
 })
 export const ListItem: React.FC<{
-  attributes: any
+  attributes?: any
   children: React.ReactNode
-  style: any
-}> = ({ children, attributes = {}, style = {} }) => {
+  style?: any
+}> = ({ children, attributes, style = {} }) => {
   const [colorScheme] = useColorContext()
   return (
     <li
@@ -312,15 +311,15 @@ const linkStyle = css({
 // TODO: forwardRef is problematic inside Slate:
 //  for now we use the noref compoment inside the editor
 //  we should check what causes this and if it can be fixed
-export const NoRefA = ({ children, attributes, ...props }) => (
+export const NoRefA: Typography = ({ children, attributes, ...props }) => (
   <a {...attributes} {...props} {...linkStyle}>
     {children}
   </a>
 )
 
 // Outside the editor we use a A with forwardRef for Next.js Link compat
-const A = forwardRef<HTMLAnchorElement, any>(
-  ({ children, attributes = {}, ...props }, ref) => (
+const A = forwardRef<HTMLAnchorElement, BaseProps>(
+  ({ children, attributes, ...props }, ref) => (
     <a {...attributes} {...props} {...linkStyle} ref={ref}>
       {children}
     </a>

--- a/packages/styleguide/src/components/Typography/Flyer.tsx
+++ b/packages/styleguide/src/components/Typography/Flyer.tsx
@@ -17,7 +17,7 @@ export const Layout = ({ children, attributes = {} }) => {
   )
 }
 
-export const H1 = ({ children, attributes, ...props }) => {
+export const H1 = ({ children, attributes = {}, ...props }) => {
   const [colorScheme] = useColorContext()
 
   return (
@@ -43,7 +43,7 @@ export const H1 = ({ children, attributes, ...props }) => {
   )
 }
 
-export const H2 = ({ children, attributes, ...props }) => {
+export const H2 = ({ children, attributes = {}, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <h2
@@ -70,7 +70,7 @@ export const H2 = ({ children, attributes, ...props }) => {
   )
 }
 
-export const H3 = ({ children, attributes, ...props }) => {
+export const H3 = ({ children, attributes = {}, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <h3
@@ -128,7 +128,7 @@ export const P: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
   )
 }
 
-export const MetaP = ({ children, attributes, ...props }) => {
+export const MetaP = ({ children, attributes = {}, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <p
@@ -152,7 +152,7 @@ export const MetaP = ({ children, attributes, ...props }) => {
   )
 }
 
-export const OpeningP = ({ children, attributes, ...props }) => {
+export const OpeningP = ({ children, attributes = {}, ...props }) => {
   const [colorScheme] = useColorContext()
   return (
     <p
@@ -204,19 +204,19 @@ export const Small: React.FC<{ attributes?: any; [x: string]: unknown }> = ({
   )
 }
 
-export const Emphasis = ({ children, attributes, ...props }) => (
+export const Emphasis = ({ children, attributes = {}, ...props }) => (
   <strong {...props} {...attributes}>
     {children}
   </strong>
 )
 
-export const Cursive = ({ children, attributes, ...props }) => (
+export const Cursive = ({ children, attributes = {}, ...props }) => (
   <em {...props} {...attributes}>
     {children}
   </em>
 )
 
-export const StrikeThrough = ({ children, attributes, ...props }) => (
+export const StrikeThrough = ({ children, attributes = {}, ...props }) => (
   <span
     {...attributes}
     {...props}
@@ -320,7 +320,7 @@ export const NoRefA = ({ children, attributes, ...props }) => (
 
 // Outside the editor we use a A with forwardRef for Next.js Link compat
 const A = forwardRef<HTMLAnchorElement, any>(
-  ({ children, attributes, ...props }, ref) => (
+  ({ children, attributes = {}, ...props }, ref) => (
     <a {...attributes} {...props} {...linkStyle} ref={ref}>
       {children}
     </a>

--- a/packages/styleguide/src/components/Typography/Flyer.tsx
+++ b/packages/styleguide/src/components/Typography/Flyer.tsx
@@ -284,7 +284,7 @@ const listItemRule = css({
 export const ListItem: React.FC<{
   attributes?: any
   children: React.ReactNode
-  style?: any
+  style?: React.CSSProperties
 }> = ({ children, attributes, style = {} }) => {
   const [colorScheme] = useColorContext()
   return (


### PR DESCRIPTION
- extract code from article page into `flyer/` folder
- split different components (e.g. flyer nav, flyer footer…) into different files
- add typescript
- reorder imports hierarchically
- types for `Typography/Flyer`

**No kitten should be harmed and no functionality should be affected by this refactoring**