### PR TITLE
Journal: block title as metadata title

### DIFF
--- a/apps/publikator/components/Edit/Sync.js
+++ b/apps/publikator/components/Edit/Sync.js
@@ -1,4 +1,4 @@
-import { renderAsText } from '@project-r/styleguide/editor'
+import { renderSlateAsText } from '@project-r/styleguide'
 
 export const SYNC_LIST = ['shareText']
 
@@ -14,5 +14,5 @@ export const getSyncText = (value, path) => {
     if (!node?.children) return ''
     node = node?.children[i]
   })
-  return node?.children ? renderAsText(node.children) : ''
+  return node?.children ? renderSlateAsText(node.children) : ''
 }

--- a/apps/publikator/components/Publication/useValidation.js
+++ b/apps/publikator/components/Publication/useValidation.js
@@ -7,8 +7,7 @@ import { mdastToString } from '../../lib/utils/helpers'
 
 import { SOCIAL_MEDIA } from '../editor/modules/meta/ShareImageForm'
 
-import { Editorial } from '@project-r/styleguide'
-import { renderAsText } from '@project-r/styleguide/editor'
+import { Editorial, renderSlateAsText } from '@project-r/styleguide'
 
 const FRONTEND_HOSTNAME = FRONTEND_BASE_URL && parse(FRONTEND_BASE_URL).hostname
 
@@ -16,7 +15,7 @@ const useValidation = ({ meta, content, t, updateMailchimp }) => {
   const links = useMemo(() => {
     const isFlyer = meta.template === 'flyer'
     const toText = isFlyer
-      ? (node) => renderAsText(node.children)
+      ? (node) => renderSlateAsText(node.children)
       : mdastToString
     const urlKey = isFlyer ? 'href' : 'url'
     const all = []

--- a/apps/www/components/Flyer/Meta.tsx
+++ b/apps/www/components/Flyer/Meta.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
+import { CustomDescendant, renderSlateAsText } from '@project-r/styleguide'
+
 import { PUBLIC_BASE_URL, ASSETS_SERVER_BASE_URL } from '../../lib/constants'
+import { useTranslation } from '../../lib/withT'
 
 import { getCacheKey } from '../Article/metadata'
 import Meta from '../Frame/Meta'
@@ -37,11 +40,37 @@ export const getShareImageUrls = (
   }
 }
 
+const getTitleProps = (
+  value: CustomDescendant[],
+  tileId: string,
+  customDescription: string,
+): Partial<MetaProps> => {
+  const titleNode = value
+    .find((node) => node.id === tileId)
+    ?.children.find((node) => node.type === 'flyerTitle')
+
+  if (!titleNode) return {}
+
+  const title = renderSlateAsText([titleNode])
+
+  return {
+    title,
+    facebookTitle: title,
+    twitterTitle: title,
+    description: customDescription,
+    facebookDescription: customDescription,
+    twitterDescription: customDescription,
+  }
+}
+
 const FlyerMeta: React.FC<{
   documentId: string
   tileId?: string
   meta: MetaProps
-}> = ({ tileId, meta, documentId }) => {
+  value: CustomDescendant[]
+}> = ({ tileId, meta, documentId, value }) => {
+  const { t } = useTranslation()
+
   // Render as usual
   if (!tileId && meta) {
     return <Meta data={meta} />
@@ -53,6 +82,7 @@ const FlyerMeta: React.FC<{
     <Meta
       data={{
         ...meta,
+        ...getTitleProps(value, tileId, t('article/flyer/tile/description')),
         image: shareImageUrl.toString(),
         twitterImage: shareImageUrl.toString(),
         facebookImage: shareImageUrl.toString(),

--- a/apps/www/components/Flyer/Meta.tsx
+++ b/apps/www/components/Flyer/Meta.tsx
@@ -51,7 +51,7 @@ const getTitleProps = (
 
   if (!titleNode) return {}
 
-  const title = renderSlateAsText([titleNode])
+  const title = `Republik-Journal: ${renderSlateAsText([titleNode])}`
 
   return {
     title,

--- a/apps/www/components/Flyer/index.tsx
+++ b/apps/www/components/Flyer/index.tsx
@@ -20,6 +20,12 @@ import Nav from './Nav'
 export type MetaProps = {
   path: string
   publishDate: string
+  title: string
+  description: string
+  facebookTitle: string
+  facebookDescription: string
+  twitterTitle: string
+  twitterDescription: string
   [x: string]: unknown
 }
 
@@ -49,7 +55,7 @@ const Page: React.FC<{
         />
       </RenderContextProvider>
       <Footer>{actionBar}</Footer>
-      <Meta documentId={documentId} meta={meta} tileId={tileId} />
+      <Meta documentId={documentId} meta={meta} tileId={tileId} value={value} />
     </Flyer.Layout>
   )
 }

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -3453,6 +3453,10 @@
       "value": "Mehr Kurzes:"
     },
     {
+      "key": "article/flyer/tile/description",
+      "value": "Mehr Kurzes auf republik.ch/journal"
+    },
+    {
       "key": "progress/restore/time",
       "value": "{day} um {time} Uhr"
     },

--- a/packages/styleguide/src/editor.ts
+++ b/packages/styleguide/src/editor.ts
@@ -13,6 +13,4 @@ export { default as ColorPicker } from './components/Editor/Forms/ColorPicker'
 
 export { FLYER_DATE_FORMAT } from './components/Flyer/Date'
 
-export { default as renderAsText } from './components/Editor/Render/text'
-
 export { getDatePath } from './templates/Article/utils'

--- a/packages/styleguide/src/lib.ts
+++ b/packages/styleguide/src/lib.ts
@@ -193,6 +193,7 @@ export * from './components/Icons'
 export * from './templates'
 
 export { default as SlateRender } from './components/Editor/Render'
+export { default as renderSlateAsText } from './components/Editor/Render/text'
 export { default as flyerSchema } from './components/Editor/schema/flyer'
 export { RenderContextProvider } from './components/Editor/Render/Context'
 


### PR DESCRIPTION
Sharing of individual journal blocks: when the block has a title, this becomes the title on social media, and we use a default sentence as description.
If the block doesn't have a title, we keep using the title and description set for the entire journal.

<img width="598" alt="Screen Shot 2022-11-29 at 17 08 40" src="https://user-images.githubusercontent.com/3907984/204581603-72c2af39-1730-43e1-807c-b56ac02f681f.png">
