### PR TITLE
fix(Flyer): dimensions of shareimage tweak

### DIFF
--- a/apps/www/components/Flyer/Meta.tsx
+++ b/apps/www/components/Flyer/Meta.tsx
@@ -26,7 +26,7 @@ export const getShareImageUrls = (
     screenshotUrl.searchParams.set('showAll', 'true')
   }
 
-  const dimensions = showAll ? [450, 1] : [600, 314]
+  const dimensions = showAll ? [760, 1] : [600, 314]
 
   const shareImageUrl = new URL('/render', ASSETS_SERVER_BASE_URL)
   shareImageUrl.searchParams.set('viewport', dimensions.join('x'))


### PR DESCRIPTION
before:
<img width="591" alt="Screenshot 2022-12-01 at 09 11 32" src="https://user-images.githubusercontent.com/20746301/205003797-3efea5d4-8453-4237-aa41-c749007d1699.png">


after:
<img width="595" alt="Screenshot 2022-12-01 at 09 13 26" src="https://user-images.githubusercontent.com/20746301/205003815-c5ac7166-a911-4f20-9b7f-d77a12514801.png">
