### PR TITLE
feat: introduce Meta.suggestSubscription

### DIFF
--- a/apps/www/components/Notifications/SubscribedDocuments.js
+++ b/apps/www/components/Notifications/SubscribedDocuments.js
@@ -12,7 +12,6 @@ import {
 import { css } from 'glamor'
 import SubscribeCheckbox from './SubscribeCheckbox'
 import withT from '../../lib/withT'
-import { ONBOARDING_SECTIONS_REPO_IDS } from '../../lib/constants'
 import { withMembership } from '../Auth/checkRoles'
 
 const styles = {
@@ -20,10 +19,6 @@ const styles = {
     margin: '8px 0 16px',
   }),
 }
-
-const SECTIONS_ALWAYS_SHOWN = ONBOARDING_SECTIONS_REPO_IDS
-  ? ONBOARDING_SECTIONS_REPO_IDS.split(',')
-  : []
 
 const FormatCheckboxes = ({ formats }) => (
   <div {...styles.checkboxes}>
@@ -33,6 +28,8 @@ const FormatCheckboxes = ({ formats }) => (
   </div>
 )
 
+const getSuggestSubscription = (section) => section.meta.suggestSubscription
+
 const getSubscriptionCount = (section) =>
   section.formats.nodes.filter((f) => f.subscribedByMe.active).length
 
@@ -41,10 +38,10 @@ const getVisibleSections = (sections, prevShown = []) =>
     (section) =>
       prevShown.find((s) => s.id === section.id) ||
       getSubscriptionCount(section) ||
-      SECTIONS_ALWAYS_SHOWN.find((repoId) => repoId === section.repoId),
+      getSuggestSubscription(section),
   )
 
-const SubscribedDocuments = ({ t, data: { sections }, isMember }) => {
+const SubscribedDocuments = ({ t, data: { sections } }) => {
   const [showAll, setShowAll] = useState(false)
   const [colorScheme] = useColorContext()
   const sectionNodes = sections && sections.nodes

--- a/apps/www/components/Notifications/enhancers.js
+++ b/apps/www/components/Notifications/enhancers.js
@@ -159,8 +159,9 @@ export const possibleSubscriptions = gql`
         meta {
           title
           color
+          suggestSubscription
         }
-        formats: linkedDocuments(feed: true) {
+        formats: linkedDocuments {
           nodes {
             id
             subscribedByMe {

--- a/apps/www/components/Onboarding/Page.js
+++ b/apps/www/components/Onboarding/Page.js
@@ -38,7 +38,7 @@ import Link from 'next/link'
 const { P } = Interaction
 
 const QUERY = gql`
-  query getOnboarding($repoIds: [ID!]) {
+  query getOnboarding {
     me {
       ...NewsletterUser
       ...AppLoginUser
@@ -50,10 +50,13 @@ const QUERY = gql`
       ...GreetingEmployee
     }
 
-    documents(template: "section", repoIds: $repoIds) {
+    sections: documents(template: "section") {
       nodes {
         id
-        linkedDocuments {
+        meta {
+          suggestSubscription
+        }
+        formats: linkedDocuments {
           totalCount
           nodes {
             ...FormatInfo
@@ -213,20 +216,13 @@ class Page extends Component {
 
     return (
       <Frame meta={meta} raw>
-        <Query
-          query={QUERY}
-          variables={{
-            repoIds:
-              ONBOARDING_SECTIONS_REPO_IDS &&
-              ONBOARDING_SECTIONS_REPO_IDS.split(','),
-          }}
-        >
+        <Query query={QUERY}>
           {({ loading, error, data }) => {
             if (loading || error) {
               return <Loader loading={loading} error={error} />
             }
 
-            const { me: user, employees, documents } = data
+            const { me: user, employees, sections } = data
 
             return (
               <Center>
@@ -273,7 +269,7 @@ class Page extends Component {
                           key={name}
                           name={name}
                           user={user}
-                          sections={documents.nodes}
+                          sections={sections.nodes}
                           onExpand={this.onExpand.bind(this)}
                           isExpanded={expandedSection === name}
                           onContinue={this.onContinue.bind(this)}

--- a/apps/www/components/Onboarding/Sections/Subscriptions.js
+++ b/apps/www/components/Onboarding/Sections/Subscriptions.js
@@ -35,10 +35,10 @@ export const fragments = {
 const Subscriptions = (props) => {
   const { sections, t } = props
 
-  const formats = sections.reduce(
-    (reducer, section) => reducer.concat(section.linkedDocuments.nodes),
-    [],
-  )
+  const formats = sections
+    .filter((section) => section.meta.suggestSubscription)
+    .reduce((reducer, section) => reducer.concat(section.formats.nodes), [])
+
   const isTicked = formats.some(
     (format) => format.subscribedByMe && format.subscribedByMe.active,
   )

--- a/apps/www/components/Onboarding/Sections/Usability.js
+++ b/apps/www/components/Onboarding/Sections/Usability.js
@@ -78,7 +78,7 @@ const Usability = (props) => {
             {t.elements(
               'Onboarding/Sections/Usability/paragraph3',
               {
-                linkMore: (
+                linkMore: PROGRESS_EXPLAINER_PATH && (
                   <Link key='linkMore' href={PROGRESS_EXPLAINER_PATH} passHref>
                     <A>{t('Onboarding/Sections/Usability/linkMore')}</A>
                   </Link>

--- a/packages/backend-modules/documents/graphql/schema-types.js
+++ b/packages/backend-modules/documents/graphql/schema-types.js
@@ -118,6 +118,7 @@ type Meta {
   newsletter: Newsletter
 
   disableActionBar: Boolean
+  suggestSubscription: Boolean
 
   estimatedReadingMinutes: Int
   estimatedConsumptionMinutes: Int

--- a/packages/backend-modules/search/lib/filters.js
+++ b/packages/backend-modules/search/lib/filters.js
@@ -16,13 +16,13 @@ const hasCriteriaBuilder =
   (value, { filter, not = false }) => ({
     clause: not || !value ? 'must_not' : 'must',
     filter: [
-      filter || { match_all: {} },
+      filter,
       {
         exists: {
           field: fieldName,
         },
       },
-    ],
+    ].filter(Boolean),
   })
 
 const dateRangeCriteriaBuilder =
@@ -30,7 +30,7 @@ const dateRangeCriteriaBuilder =
   (range, { filter, not = false }) => ({
     clause: not ? 'must_not' : 'must',
     filter: [
-      filter || { match_all: {} },
+      filter,
       {
         range: {
           [fieldName]: {
@@ -39,7 +39,7 @@ const dateRangeCriteriaBuilder =
           },
         },
       },
-    ],
+    ].filter(Boolean),
   })
 
 const rangeCriteriaBuilder =
@@ -54,7 +54,7 @@ const rangeCriteriaBuilder =
     return {
       clause: 'must',
       filter: [
-        filter || { match_all: {} },
+        filter,
         {
           range: {
             [fieldName]: {
@@ -63,7 +63,7 @@ const rangeCriteriaBuilder =
             },
           },
         },
-      ],
+      ].filter(Boolean),
     }
   }
 

--- a/packages/backend-modules/search/lib/indices/documents.js
+++ b/packages/backend-modules/search/lib/indices/documents.js
@@ -342,6 +342,9 @@ module.exports = {
                 },
               },
             },
+            suggestSubscription: {
+              type: 'boolean',
+            },
           },
         },
       },


### PR DESCRIPTION
This Pull Requests introduces `Meta.suggestSubscription`. It describes whether a section and its format is suggest by default to users.

It queries sections and formats as is, but now with `meta { suggestSubscription }` and filters for that flag.

In return, env variable `ONBOARDING_SECTIONS_REPO_IDS` is not longer needed.

It replaces https://github.com/republik/plattform/pull/299

Examples using "Journal":

/konto/benachrichtigungen

<img width="403" alt="Bildschirmfoto 2022-12-16 um 08 18 59" src="https://user-images.githubusercontent.com/331800/208046431-98ea9d68-1eee-46db-8806-b07a2c0646aa.png">

/einrichten

<img width="355" alt="Bildschirmfoto 2022-12-16 um 08 19 48" src="https://user-images.githubusercontent.com/331800/208046539-8e6fb875-6ce5-49a4-a9f0-d7b945fa51a2.png">

/rubriken

<img width="731" alt="Bildschirmfoto 2022-12-16 um 08 20 23" src="https://user-images.githubusercontent.com/331800/208046922-f06b2ad4-b2a9-4fa7-9e50-d9882262f230.png">

/suche

(section "In alle Kürze" won't appear since `feed` flag is disabled)

<img width="764" alt="Bildschirmfoto 2022-12-16 um 08 20 07" src="https://user-images.githubusercontent.com/331800/208046555-67475c97-0b66-4fbe-bc17-688022b0030b.png">

Pull Request includes [fix(search): drop match_all query in builders](https://github.com/republik/plattform/commit/d8436a5197a97b4e391a53e0d0ae93b40f258358): `match_all` as a fallback can cause unwanted side-effects if filter var is falsy

Release checklist:

- [ ] Create (or reuse) section "In aller Kürze", set meta `suggestSubscription: true`, `feed: false`. Publish.
- [ ] Link section to "Journal". Publish.
- [ ] Add meta `suggestSubscription: true` to repo IDs in `ONBOARDING_SECTIONS_REPO_IDS`
- [ ] Deploy code
- [ ] Remove `ONBOARDING_SECTIONS_REPO_IDS` env variable