### PR TITLE
fix: cleaned MailChimp user transactional, access grant transactional

### DIFF
--- a/packages/backend-modules/access/lib/mail.js
+++ b/packages/backend-modules/access/lib/mail.js
@@ -267,10 +267,9 @@ const getGlobalMergeVars = async (
       content:
         !!recipient && !!recipientCampaigns && recipientCampaigns.length > 0,
     },
-
     {
       name: 'recipientIsNotGranter',
-      content: (grant.email || safeRecipient.email) === safeGranter.email,
+      content: email !== safeGranter.email,
     },
 
     // Campaign

--- a/packages/backend-modules/mail/lib/scheduler/cleanedUserMailing.js
+++ b/packages/backend-modules/mail/lib/scheduler/cleanedUserMailing.js
@@ -41,7 +41,12 @@ module.exports = async (from, to, { pgdb }, dryRun = false, onceFor = true) => {
 `,
     { from, to },
   )
-  debug(`${cleanedUsers.length} email addresses found`)
+  debug(
+    `%i email addresses found (from: %s, to: %s)`,
+    cleanedUsers.length,
+    from,
+    to,
+  )
 
   const emailAddressCleanedDateMap = new Map(
     cleanedUsers.map((entry) => {

--- a/packages/backend-modules/mail/lib/scheduler/index.js
+++ b/packages/backend-modules/mail/lib/scheduler/index.js
@@ -14,7 +14,7 @@ const init = async (context) => {
     runFunc: async (_args, context) => {
       const { now, dryRun } = _args
       const to = dayjs(now).format('YYYY-MM-DD')
-      const from = dayjs(now).add(-7, 'day').format('YYYY-MM-DD')
+      const from = dayjs(now).add(-30, 'day').format('YYYY-MM-DD')
       debug(
         `starting job to send mail to users who were cleaned from mailing list between ${from} and ${to}`,
       )


### PR DESCRIPTION
This Pull Request upgrades codes which sends "re-opt-in" emails to ["cleaned MailChimp" users](https://github.com/republik/plattform/commit/88f93b8a8ee350c9df087f4bbc9c6812b20dcb5c) we saw falling of the list in the last 30 days (paused due to MailChimp outage).

It fixes [a faulty merge var](https://github.com/republik/plattform/commit/042702b6546f01b73de4edf0b543a04002e05412) for access grant transactionals – should have been a NOT check all along.

**Deployment Checklist**
- [ ] Deploy code
- [ ] Remove `MAIL_SCHEDULER=false` env var