### PR TITLE
feat: prepare carpet-text for 2023

### DIFF
--- a/apps/www/components/Front/index.js
+++ b/apps/www/components/Front/index.js
@@ -35,15 +35,10 @@ import Link from 'next/link'
 import { useGetFrontQuery } from './graphql/getFrontQuery.graphql'
 import { useRouter } from 'next/router'
 import { useMe } from '../../lib/context/MeContext'
+import { useAudioContext } from '../Audio/AudioProvider'
 import useAudioQueue from '../Audio/hooks/useAudioQueue'
+import { AudioPlayerLocations } from '../Audio/types/AudioActionTracking'
 import FrontAudioPlayButton from './FrontAudioPlayButton'
-import { knownYears, currentYear } from '../Overview/Page'
-
-// Get all years that have a yearly overview in descending order
-const archivedYears = Object.keys(knownYears)
-  .filter((key) => /^[0-9]{4}$/.test(key))
-  .sort((a, b) => b - a) // descending
-const yearsWithOverview = Array.from(new Set([currentYear, ...archivedYears])) // remove possible duplicates
 
 const styles = {
   prepublicationNotice: css({
@@ -274,7 +269,7 @@ const Front = ({
                 <div style={{ marginBottom: 10 }}>
                   {t.elements('front/chronology', {
                     years: intersperse(
-                      yearsWithOverview.map((year) => (
+                      [2022, 2021, 2020, 2019, 2018].map((year) => (
                         <Link key={year} href={`/${year}`} passHref>
                           <Editorial.A style={{ color: colors.negative.text }}>
                             {year}

--- a/apps/www/components/Front/index.js
+++ b/apps/www/components/Front/index.js
@@ -53,6 +53,9 @@ const styles = {
   }),
 }
 
+// Years to link to that have a yearly overview page
+const archivedYears = [2023, 2022, 2021, 2020, 2019, 2018]
+
 export const RenderFront = ({ front, nodes, isFrontExtract = false }) => {
   const { t } = useTranslation()
   const { isEditor, hasAccess } = useMe()
@@ -269,7 +272,7 @@ const Front = ({
                 <div style={{ marginBottom: 10 }}>
                   {t.elements('front/chronology', {
                     years: intersperse(
-                      [2022, 2021, 2020, 2019, 2018].map((year) => (
+                      archivedYears.map((year) => (
                         <Link key={year} href={`/${year}`} passHref>
                           <Editorial.A style={{ color: colors.negative.text }}>
                             {year}

--- a/apps/www/components/Front/index.js
+++ b/apps/www/components/Front/index.js
@@ -35,10 +35,15 @@ import Link from 'next/link'
 import { useGetFrontQuery } from './graphql/getFrontQuery.graphql'
 import { useRouter } from 'next/router'
 import { useMe } from '../../lib/context/MeContext'
-import { useAudioContext } from '../Audio/AudioProvider'
 import useAudioQueue from '../Audio/hooks/useAudioQueue'
-import { AudioPlayerLocations } from '../Audio/types/AudioActionTracking'
 import FrontAudioPlayButton from './FrontAudioPlayButton'
+import { knownYears, currentYear } from '../Overview/Page'
+
+// Get all years that have a yearly overview in descending order
+const archivedYears = Object.keys(knownYears)
+  .filter((key) => /^[0-9]{4}$/.test(key))
+  .sort((a, b) => b - a) // descending
+const yearsWithOverview = Array.from(new Set([currentYear, ...archivedYears])) // remove possible duplicates
 
 const styles = {
   prepublicationNotice: css({
@@ -269,7 +274,7 @@ const Front = ({
                 <div style={{ marginBottom: 10 }}>
                   {t.elements('front/chronology', {
                     years: intersperse(
-                      [2022, 2021, 2020, 2019, 2018].map((year) => (
+                      yearsWithOverview.map((year) => (
                         <Link key={year} href={`/${year}`} passHref>
                           <Editorial.A style={{ color: colors.negative.text }}>
                             {year}

--- a/apps/www/components/Overview/Page.js
+++ b/apps/www/components/Overview/Page.js
@@ -24,7 +24,12 @@ import { P } from './Elements'
 import { getTeasersFromDocument } from './utils'
 import Link from 'next/link'
 
-const knownYears = {
+// Year-overview that is currently being tracked
+// once completed add it to the knownYears map
+export const currentYear = 2023
+// Map of all years that have a completed yearly overview
+// and the path to the data-source for that year
+export const knownYears = {
   2018: { path: '/2018' },
   2019: { path: '/2019' },
   2020: { path: '/2020' },

--- a/apps/www/components/Overview/Page.js
+++ b/apps/www/components/Overview/Page.js
@@ -29,6 +29,7 @@ const knownYears = {
   2019: { path: '/2019' },
   2020: { path: '/2020' },
   2021: { path: '/' },
+  2022: { path: '/' },
 }
 
 const getAll = gql`

--- a/apps/www/components/Overview/Page.js
+++ b/apps/www/components/Overview/Page.js
@@ -24,12 +24,7 @@ import { P } from './Elements'
 import { getTeasersFromDocument } from './utils'
 import Link from 'next/link'
 
-// Year-overview that is currently being tracked
-// once completed add it to the knownYears map
-export const currentYear = 2023
-// Map of all years that have a completed yearly overview
-// and the path to the data-source for that year
-export const knownYears = {
+const knownYears = {
   2018: { path: '/2018' },
   2019: { path: '/2019' },
   2020: { path: '/2020' },

--- a/apps/www/components/Overview/pages/2022.js
+++ b/apps/www/components/Overview/pages/2022.js
@@ -534,7 +534,6 @@ const text = {
         ids={['mBRrvK31g']}
         format='republik/format-ich-hab-mich-getaeuscht'
       >
-        {/* TODO: double check if id is required */}
         getäuscht
       </Highlight>{' '}
       – Sie{' '}

--- a/apps/www/components/Overview/pages/2023.js
+++ b/apps/www/components/Overview/pages/2023.js
@@ -1,0 +1,21 @@
+import { Highlight } from '../Elements'
+import Page from '../Page'
+
+const text = {
+  //Januar: (p) => <></>,
+  //Februar: (p) => <></>,
+  //März: (p) => <></>,
+  //April: (p) => <></>,
+  //Mai: (p) => <></>,
+  //Juni: (p) => <></>,
+  //Juli: (p) => <></>,
+  //August: (p) => <></>,
+  //September: (p) => <></>,
+  //Oktober: (p) => <></>,
+  //November: (p) => <></>,
+  //Dezember: (p) => <></>,
+}
+
+const Overview2023 = (props) => <Page {...props} year={2023} text={text} />
+
+export default Overview2023

--- a/apps/www/pages/2018.js
+++ b/apps/www/pages/2018.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2018'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2018/index.js
+++ b/apps/www/pages/2018/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2018'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2019.js
+++ b/apps/www/pages/2019.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2019'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2019/index.js
+++ b/apps/www/pages/2019/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2019'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2020.js
+++ b/apps/www/pages/2020.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2020'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2020/index.js
+++ b/apps/www/pages/2020/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2020'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2021.js
+++ b/apps/www/pages/2021.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2021'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2021/index.js
+++ b/apps/www/pages/2021/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2021'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2022.js
+++ b/apps/www/pages/2022.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2022'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2022/index.js
+++ b/apps/www/pages/2022/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2022'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2023.js
+++ b/apps/www/pages/2023.js
@@ -1,0 +1,4 @@
+import Page from '../components/Overview/pages/2023'
+import { withDefaultSSR } from '../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2023.js
+++ b/apps/www/pages/2023.js
@@ -1,4 +1,0 @@
-import Page from '../components/Overview/pages/2023'
-import { withDefaultSSR } from '../lib/apollo/helpers'
-
-export default withDefaultSSR(Page)

--- a/apps/www/pages/2023/index.js
+++ b/apps/www/pages/2023/index.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2023'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)

--- a/apps/www/pages/2023/wochen.js
+++ b/apps/www/pages/2023/wochen.js
@@ -1,0 +1,4 @@
+import Page from '../../components/Overview/pages/2023'
+import { withDefaultSSR } from '../../lib/apollo/helpers'
+
+export default withDefaultSSR(Page)


### PR DESCRIPTION
## Description
- add 2022 to known years
- add 2023 overview-page
- add 2023 overview-page to the Front loader archived years list.
- move year overview-pages into the corresponding year-folder for a less bloaty pages folder (the paths remain the same)
   - For example: /2022.js -> /2022/index.js

## Todo
- [x] merge in the evening of 30. Dez
- [x] publish commit in '/archive' document
