### PR TITLE
feat(assets): allow controlling quality of the resized images via the query-params

### DIFF
--- a/apps/www/lib/images/assetServerImageLoader.ts
+++ b/apps/www/lib/images/assetServerImageLoader.ts
@@ -4,7 +4,7 @@ import { CDN_FRONTEND_BASE_URL, isDev } from '../constants'
 function assetServerImageLoader({
   src,
   width,
-  quality = 75, // Quality is not yet supported by the assets-server
+  quality,
 }: ImageLoaderProps): string {
   if (!CDN_FRONTEND_BASE_URL) {
     if (isDev) {
@@ -20,6 +20,9 @@ function assetServerImageLoader({
   )
   url.searchParams.set('resize', `${width}x`)
   url.searchParams.set('format', 'auto')
+  if (quality) {
+    url.searchParams.set('quality', quality.toString())
+  }
 
   return url.toString()
 }

--- a/packages/backend-modules/assets/lib/returnImage.js
+++ b/packages/backend-modules/assets/lib/returnImage.js
@@ -56,7 +56,12 @@ module.exports = async ({
     cacheTags = [],
     crop,
     size,
+    quality,
   } = options
+  const qualityInt = parseInt(quality, 10)
+  const resolvedQuality =
+    !isNaN(qualityInt) && qualityInt <= 100 && qualityInt > 0 ? qualityInt : 80
+
   let format =
     _format && supportedFormats.indexOf(_format) !== -1
       ? _format
@@ -213,12 +218,12 @@ module.exports = async ({
           // avoid interlaced pngs
           // - not supported in pdfkit
           progressive: format === 'jpeg',
-          quality: 80,
+          quality: resolvedQuality,
         })
       } else if (isJPEG) {
         pipeline.jpeg({
           progressive: true,
-          quality: 80,
+          quality: resolvedQuality,
         })
       }
     }


### PR DESCRIPTION
- feat(assets): accept quality param to control the quality of the resized image (defaults to 80)
- feat(www): adapt AssetImage to correctly pass 'quality' to the assets-server
