### PR TITLE
fix(ClimateLab): implement amends to design of inline teaser

### DIFF
--- a/apps/www/components/Climatelab/InlineTeaser/ClimateLabInlineTeaser.tsx
+++ b/apps/www/components/Climatelab/InlineTeaser/ClimateLabInlineTeaser.tsx
@@ -1,96 +1,56 @@
-import { css } from 'glamor'
 import Link from 'next/link'
-import { fontStyles, mediaQueries, plainLinkRule } from '@project-r/styleguide'
+import {
+  InfoBox,
+  InfoBoxTitle,
+  InfoBoxText,
+  Figure,
+  Editorial,
+} from '@project-r/styleguide'
 import { useTranslation } from '../../../lib/withT'
 import {
   CLIMATE_LAB_LANDINGPAGE_URL,
   CLIMATE_LAB_ROLE,
   CLIMATE_LAB_URL,
 } from '../constants'
-import { climateColors } from '../config'
-import { useColorContext } from '@project-r/styleguide/src/components/Colors/ColorContext'
 import { useMe } from '../../../lib/context/MeContext'
 import ClimateLabLogo from '../shared/ClimateLabLogo'
 
 const ClimateLabInlineTeaser = () => {
   const { t } = useTranslation()
-  const [colorScheme] = useColorContext()
   const { me } = useMe()
   const isClimateLabMember = me?.roles?.includes(CLIMATE_LAB_ROLE)
 
   return (
-    <section {...styles.root}>
-      <div {...styles.image}>
+    <InfoBox figureSize='XXS'>
+      <InfoBoxTitle>{t('ClimateInlineTeaser/content/title')}</InfoBoxTitle>
+      <Figure>
         <ClimateLabLogo width={80} height={80} hideFigcaption />
-      </div>
-      <div {...styles.textWrapper}>
-        <hr {...styles.hr} />
-        <p {...styles.heading}>{t('ClimateInlineTeaser/content/title')}</p>
-        <p style={{ marginTop: '1rem' }} {...colorScheme.set('color', 'text')}>
-          {isClimateLabMember ? (
-            <>
-              {t('ClimateInlineTeaser/Member/content/text')}{' '}
-              <Link href={CLIMATE_LAB_URL}>
-                <a {...plainLinkRule} {...styles.link}>
-                  {t('ClimateInlineTeaser/Member/content/link')}
-                </a>
-              </Link>
-              {'.'}
-            </>
-          ) : (
-            <>
-              {t('ClimateInlineTeaser/NonMember/content/text')}{' '}
-              <Link href={CLIMATE_LAB_LANDINGPAGE_URL}>
-                <a {...plainLinkRule} {...styles.link}>
-                  {t('ClimateInlineTeaser/NonMember/content/link')}
-                </a>
-              </Link>
-              {'.'}
-            </>
-          )}
-        </p>
-      </div>
-    </section>
+      </Figure>
+      <InfoBoxText>
+        {isClimateLabMember ? (
+          <>
+            {t('ClimateInlineTeaser/Member/content/text')}{' '}
+            <Link href={CLIMATE_LAB_URL}>
+              <Editorial.A>
+                {t('ClimateInlineTeaser/Member/content/link')}
+              </Editorial.A>
+            </Link>
+            {'.'}
+          </>
+        ) : (
+          <>
+            {t('ClimateInlineTeaser/NonMember/content/text')}{' '}
+            <Link href={CLIMATE_LAB_LANDINGPAGE_URL}>
+              <Editorial.A>
+                {t('ClimateInlineTeaser/NonMember/content/link')}
+              </Editorial.A>
+            </Link>
+            {'.'}
+          </>
+        )}
+      </InfoBoxText>
+    </InfoBox>
   )
 }
 
 export default ClimateLabInlineTeaser
-
-const styles = {
-  root: css({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1rem',
-    [mediaQueries.mUp]: {
-      flexDirection: 'row',
-    },
-  }),
-  image: css({
-    position: 'relative',
-    width: 80,
-    height: 80,
-    flexShrink: 0,
-  }),
-  hr: css({
-    borderTop: `1px solid ${climateColors.light.default}`,
-    margin: 0,
-  }),
-  heading: css({
-    ...fontStyles.sansSerifBold,
-    color: climateColors.light.default,
-    fontSize: 24,
-    lineheight: '1.2em',
-    marginTop: '0.25rem',
-  }),
-  textWrapper: css({
-    ...fontStyles.sansSerifRegular,
-    fontSize: 18,
-    lineHeight: '1.6em',
-    '> p': {
-      margin: 0,
-    },
-  }),
-  link: css({
-    textDecoration: 'underline',
-  }),
-}

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -7710,7 +7710,7 @@
     },
     {
       "key": "ClimateInlineTeaser/content/title",
-      "value": "Klimalabor"
+      "value": "Zum Klimalabor"
     },
     {
       "key": "ClimateInlineTeaser/NonMember/content/text",


### PR DESCRIPTION
Upon request from the art direction, the custom inline teaser gets replaced by a vanilla infobox with the climate lab logo.

Before:
<img width="713" alt="Screen Shot 2023-01-10 at 10 53 31" src="https://user-images.githubusercontent.com/3907984/211519156-c72337aa-4777-4a8b-a3ee-ca728ea989ee.png">

Now:
<img width="748" alt="Screen Shot 2023-01-10 at 10 42 34" src="https://user-images.githubusercontent.com/3907984/211519350-4517824c-7c2d-4f93-a869-b1310e0f9af1.png">
