### PR TITLE
fix: added check before removing member role granted by perks

### DIFF
--- a/packages/backend-modules/access/lib/grants.js
+++ b/packages/backend-modules/access/lib/grants.js
@@ -97,6 +97,7 @@ const revokePerks = (grant, recipient, campaign, pgdb) =>
       recipient,
       settings,
       pgdb,
+      findByRecipient,
     )
 
     debug('revokePerks', {

--- a/packages/backend-modules/access/lib/perks/accessWithRole.js
+++ b/packages/backend-modules/access/lib/perks/accessWithRole.js
@@ -23,17 +23,10 @@ const give = async (campaign, grant, recipient, settings, t, pgdb) => {
 }
 
 const revoke = async (grant, recipient, settings, pgdb) => {
-  let isRoleRevoked = false
-  if (settings.role === MEMBER_ROLE) {
-    isRoleRevoked = await removeMemberRole(
-      grant,
-      recipient,
-      findByRecipient,
-      pgdb,
-    )
-  } else {
-    isRoleRevoked = await removeRole(grant, recipient, pgdb, settings.role)
-  }
+  const isRoleRevoked =
+    settings.role === MEMBER_ROLE
+      ? await removeMemberRole(grant, recipient, findByRecipient, pgdb)
+      : await removeRole(grant, recipient, pgdb, settings.role)
   if (isRoleRevoked) {
     debug('revoke', {
       recipient: recipient.id,

--- a/packages/backend-modules/access/lib/perks/accessWithRole.js
+++ b/packages/backend-modules/access/lib/perks/accessWithRole.js
@@ -1,6 +1,5 @@
 const debug = require('debug')('access:lib:perks:accessWithRole')
 
-const { findByRecipient } = require('../grants')
 const { addRole, removeRole, removeMemberRole } = require('../memberships')
 const MEMBER_ROLE = 'member'
 
@@ -22,7 +21,7 @@ const give = async (campaign, grant, recipient, settings, t, pgdb) => {
   return {}
 }
 
-const revoke = async (grant, recipient, settings, pgdb) => {
+const revoke = async (grant, recipient, settings, pgdb, findByRecipient) => {
   const isRoleRevoked =
     settings.role === MEMBER_ROLE
       ? await removeMemberRole(grant, recipient, findByRecipient, pgdb)

--- a/packages/backend-modules/access/lib/perks/accessWithRole.js
+++ b/packages/backend-modules/access/lib/perks/accessWithRole.js
@@ -2,7 +2,7 @@ const debug = require('debug')('access:lib:perks:accessWithRole')
 
 const { findByRecipient } = require('../grants')
 const { addRole, removeRole, removeMemberRole } = require('../memberships')
-const memberRole = 'member'
+const MEMBER_ROLE = 'member'
 
 const give = async (campaign, grant, recipient, settings, t, pgdb) => {
   const isRoleAdded = await addRole(grant, recipient, pgdb, settings.role)

--- a/packages/backend-modules/access/lib/perks/accessWithRole.js
+++ b/packages/backend-modules/access/lib/perks/accessWithRole.js
@@ -1,6 +1,8 @@
 const debug = require('debug')('access:lib:perks:accessWithRole')
 
-const { addRole, removeRole } = require('../memberships')
+const { findByRecipient } = require('../grants')
+const { addRole, removeRole, removeMemberRole } = require('../memberships')
+const memberRole = 'member'
 
 const give = async (campaign, grant, recipient, settings, t, pgdb) => {
   const isRoleAdded = await addRole(grant, recipient, pgdb, settings.role)
@@ -21,7 +23,17 @@ const give = async (campaign, grant, recipient, settings, t, pgdb) => {
 }
 
 const revoke = async (grant, recipient, settings, pgdb) => {
-  const isRoleRevoked = await removeRole(grant, recipient, pgdb, settings.role)
+  let isRoleRevoked = false
+  if (settings.role === memberRole) {
+    isRoleRevoked = await removeMemberRole(
+      grant,
+      recipient,
+      findByRecipient,
+      pgdb,
+    )
+  } else {
+    isRoleRevoked = await removeRole(grant, recipient, pgdb, settings.role)
+  }
   if (isRoleRevoked) {
     debug('revoke', {
       recipient: recipient.id,

--- a/packages/backend-modules/access/lib/perks/accessWithRole.js
+++ b/packages/backend-modules/access/lib/perks/accessWithRole.js
@@ -24,7 +24,7 @@ const give = async (campaign, grant, recipient, settings, t, pgdb) => {
 
 const revoke = async (grant, recipient, settings, pgdb) => {
   let isRoleRevoked = false
-  if (settings.role === memberRole) {
+  if (settings.role === MEMBER_ROLE) {
     isRoleRevoked = await removeMemberRole(
       grant,
       recipient,


### PR DESCRIPTION
Added check if the user was already a member before the grant of the role by a perk, if so the member role is not removed with the end of the perk