### PR TITLE
refactor(www): enhance AssetsImage to load static files directly if in dev

### DIFF
--- a/apps/www/lib/images/AssetImage.tsx
+++ b/apps/www/lib/images/AssetImage.tsx
@@ -1,12 +1,32 @@
+import { useMemo } from 'react'
 import Image, { ImageProps } from 'next/image'
 import assetServerImageLoader from './assetServerImageLoader'
+import { isDev } from '../constants'
 
 /**
  * AssetImage is a wrapper around the Next.js Image component
  * that uses the asssets-server image-loader.
  */
-const AssetImage = (props: Omit<ImageProps, 'loader'>) => (
-  <Image {...props} loader={assetServerImageLoader} />
-)
+const AssetImage = (props: Omit<ImageProps, 'loader'>) => {
+  // Local static images that are not yet on the asset-server
+  // can be loaded directly from the local file system while in development.
+  const loadStaticFromLocal = useMemo(() => {
+    if (
+      isDev &&
+      typeof props?.src === 'string' &&
+      props.src.startsWith('/static')
+    ) {
+      return true
+    }
+    return false
+  }, [isDev, props?.src])
+
+  return (
+    <Image
+      {...props}
+      loader={loadStaticFromLocal ? undefined : assetServerImageLoader}
+    />
+  )
+}
 
 export default AssetImage

--- a/apps/www/lib/images/AssetImage.tsx
+++ b/apps/www/lib/images/AssetImage.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from 'react'
-import Image, { ImageProps } from 'next/image'
+import Image, { ImageProps, StaticImageData } from 'next/image'
 import assetServerImageLoader from './assetServerImageLoader'
 import { isDev } from '../constants'
+
+function isStaticImageData(src: ImageProps['src']): src is StaticImageData {
+  return typeof src === 'object' && 'src' in src && typeof src.src === 'string'
+}
 
 /**
  * AssetImage is a wrapper around the Next.js Image component
@@ -11,12 +15,12 @@ const AssetImage = (props: Omit<ImageProps, 'loader'>) => {
   // Local static images that are not yet on the asset-server
   // can be loaded directly from the local file system while in development.
   const loadStaticFromLocal = useMemo(() => {
-    if (
-      isDev &&
-      typeof props?.src === 'string' &&
-      props.src.startsWith('/static')
-    ) {
-      return true
+    if (isDev) {
+      if (typeof props.src === 'string') {
+        return props.src.startsWith('/')
+      } else if (isStaticImageData(props.src)) {
+        return props.src.src.startsWith('/')
+      }
     }
     return false
   }, [isDev, props?.src])


### PR DESCRIPTION
A oversight on my part while creating the asset-image.
As of now, images that are added to the static assets folder, can't be loaded by the AssetImage. (Once deployed to staging or production it works finde however.

With these changes, the AssetImage attempts to load images from the static assets folder directly with the next.js image-loader while in dev-mode. 
