### PR TITLE
fix(SpecialCharJournal): fix bug that prevents display of characters …

### DIFF
--- a/packages/styleguide/src/components/Editor/Core/SpecialChars.tsx
+++ b/packages/styleguide/src/components/Editor/Core/SpecialChars.tsx
@@ -64,8 +64,17 @@ export const CharButton: React.FC<{
   )
 }
 
+const getChar = (children) => {
+  if (!children) return
+  if (children?.props?.leaf) return children?.props?.leaf?.text
+  // normally only single characters are marked as "invisible"
+  // if we have more marks on that segment though, the leaf could be a few levels down
+  if (children?.props?.children) return getChar(children?.props?.children)
+  return
+}
+
 export const Invisible = ({ children, attributes, ...props }) => {
-  const char = children?.props?.leaf?.text
+  const char = getChar(children)
   const config = char && charConfig.find((c) => c.insert === char)
   const displayAs = config?.render
   const invisibleRule = useMemo(


### PR DESCRIPTION
Problem: when the text is bold or italics, the display of "invisible" special characters (e.g. nbsp or shy) doesn't work.
<img width="577" alt="Screen Shot 2023-01-23 at 14 16 16" src="https://user-images.githubusercontent.com/3907984/214048989-75a20275-f3e4-42dc-a1aa-12a1e0871078.png">

Cause: due to nesting of nodes, sometimes you need to go further down the tree to find the special character that's being rendered.

Fix: when the current node isn't a leaf, we try and dig deeper, until we find the leaf.

