### PR TITLE
Journal copy paste

### DIFF
--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -127,9 +127,9 @@
     "body-scroll-lock": "^3.1.5",
     "react-icons": "^4.3.1",
     "serve": "^13.0.2",
-    "slate": "^0.82.1",
-    "slate-history": "^0.66.0",
-    "slate-react": "^0.82.2",
+    "slate": "^0.88.1",
+    "slate-history": "^0.86.0",
+    "slate-react": "^0.88.2",
     "use-memo-one": "^1.1.2"
   },
   "browserslist": [

--- a/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
@@ -7,10 +7,6 @@ import {
   ParagraphElement,
   BreakElement,
   CustomElement,
-  CustomElementsType,
-  CustomNode,
-  CustomAncestor,
-  TemplateType,
   NodeTemplate,
 } from '../../custom-types'
 import {
@@ -21,7 +17,7 @@ import {
   Transforms,
   NodeEntry,
 } from 'slate'
-import { getAncestry, getParent, isDescendant, selectNode } from './tree'
+import { getAncestry, isDescendant } from './tree'
 import { config as elConfig } from '../../config/elements'
 import { intersperse } from '../../../../lib/helpers'
 import { getTemplateType, isCorrect } from './structure'
@@ -153,7 +149,8 @@ const convertNodes = (
 
 // low level blocks are block which don't contain other blocks
 // just text or inlines
-const isLowLevelBlock = (node: CustomElement): boolean => {
+const isLowLevelBlock = (node: CustomDescendant): boolean => {
+  if (Text.isText(node)) return true
   if (!elConfig[node.type]?.attrs?.isInline) {
     const testChild = node.children[0]
     if (
@@ -165,19 +162,10 @@ const isLowLevelBlock = (node: CustomElement): boolean => {
   }
 }
 
-const firstLowLevelBlockSelected = (
-  editor: CustomEditor,
-): NodeEntry<CustomElement> => {
-  let { element: candidateNode } = getAncestry(editor)
-  while (Editor.isInline(editor, candidateNode[0])) {
-    candidateNode = getParent(editor, candidateNode)
-  }
-  return candidateNode
-}
-
 const getStrippedFragment = (
   fragment: CustomDescendant[],
 ): CustomDescendant[] => {
+  console.log('getStrippedFragment', fragment)
   if (
     fragment.length === 1 &&
     SlateElement.isElement(fragment[0]) &&
@@ -200,8 +188,9 @@ export const insertSlateFragment = (
 ): void => {
   const strippedFragment = getStrippedFragment(fragment)
   const copiedRefNode = strippedFragment[0]
-  const selectedRefEntry = firstLowLevelBlockSelected(editor)
-  // case 1
+  const { element: selectedRefEntry } = getAncestry(editor)
+  console.log({ copiedRefNode, template: selectedRefEntry[0].template })
+  // case 1: perfect match
   if (
     SlateElement.isElement(copiedRefNode) &&
     copiedRefNode.type === selectedRefEntry[0].type

--- a/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
@@ -8,6 +8,7 @@ import {
   BreakElement,
   CustomElement,
   NodeTemplate,
+  CustomElementsType,
 } from '../../custom-types'
 import {
   Editor,
@@ -20,7 +21,7 @@ import {
 import { getAncestry, isDescendant } from './tree'
 import { config as elConfig } from '../../config/elements'
 import { intersperse } from '../../../../lib/helpers'
-import { getTemplateType, isCorrect } from './structure'
+import { getTemplateType, isCorrect, setToType } from './structure'
 
 const ELEMENT_TAGS = {
   A: (el): Partial<LinkElement> => ({
@@ -162,6 +163,8 @@ const isLowLevelBlock = (node: CustomDescendant): boolean => {
   }
 }
 
+// better approach (compliant with case 1b: we pass the ref s node and stop iterating if
+// the first child of the fragment matches the allows templates by s
 const getStrippedFragment = (
   fragment: CustomDescendant[],
 ): CustomDescendant[] => {
@@ -195,6 +198,19 @@ export const insertSlateFragment = (
   ) {
     return Editor.insertFragment(editor, strippedFragment)
   }
+  // case 1b: type supported by template, we need to convert the current node first
+  /*else if (isCorrect(copiedRefNode, selectedRefEntry[0].template)) {
+    console.log('here?')
+    return Editor.withoutNormalizing(editor, () => {
+      setToType(
+        editor,
+        {},
+        copiedRefNode.template.type as CustomElementsType,
+        selectedRefEntry[1],
+      )
+      Editor.insertFragment(editor, strippedFragment)
+    })
+  }*/
   // case 2
   else if (
     SlateElement.isElement(copiedRefNode) &&

--- a/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/copy-paste.ts
@@ -165,7 +165,6 @@ const isLowLevelBlock = (node: CustomDescendant): boolean => {
 const getStrippedFragment = (
   fragment: CustomDescendant[],
 ): CustomDescendant[] => {
-  console.log('getStrippedFragment', fragment)
   if (
     fragment.length === 1 &&
     SlateElement.isElement(fragment[0]) &&
@@ -189,7 +188,6 @@ export const insertSlateFragment = (
   const strippedFragment = getStrippedFragment(fragment)
   const copiedRefNode = strippedFragment[0]
   const { element: selectedRefEntry } = getAncestry(editor)
-  console.log({ copiedRefNode, template: selectedRefEntry[0].template })
   // case 1: perfect match
   if (
     SlateElement.isElement(copiedRefNode) &&

--- a/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
@@ -554,6 +554,19 @@ const deleteOnInsert = (
   }
 }
 
+export const setToType = (
+  editor: CustomEditor,
+  node: Partial<CustomElement>,
+  insertType: CustomElementsType,
+  insertAt: number[],
+) => {
+  const insertPartial = {
+    type: insertType,
+    ...node,
+  }
+  Transforms.setNodes(editor, insertPartial, { at: insertAt })
+}
+
 const splitAndInsert = (
   editor: CustomEditor,
   target: NodeEntry<CustomElement>,
@@ -575,6 +588,7 @@ const splitAndInsert = (
       ...insertProps,
     }
     Transforms.setNodes(editor, insertPartial, { at: splitP })
+    setToType(editor, insertProps, insertType, splitP)
     const insertP = inPlace ? targetP : calculateSiblingPath(targetP)
     Transforms.moveNodes(editor, { at: splitP, to: insertP })
     Transforms.select(editor, insertP)

--- a/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
@@ -556,13 +556,13 @@ const deleteOnInsert = (
 
 export const setToType = (
   editor: CustomEditor,
-  node: Partial<CustomElement>,
+  nodeProps: Partial<CustomElement>,
   insertType: CustomElementsType,
   insertAt: number[],
 ) => {
   const insertPartial = {
     type: insertType,
-    ...node,
+    ...nodeProps,
   }
   Transforms.setNodes(editor, insertPartial, { at: insertAt })
 }
@@ -583,11 +583,6 @@ const splitAndInsert = (
     const insertType = getTemplateType(targetN.template)
     const insertConfig = elConfig[insertType]
     const insertProps = getDefaultProps(insertConfig)
-    const insertPartial = {
-      type: insertType,
-      ...insertProps,
-    }
-    Transforms.setNodes(editor, insertPartial, { at: splitP })
     setToType(editor, insertProps, insertType, splitP)
     const insertP = inPlace ? targetP : calculateSiblingPath(targetP)
     Transforms.moveNodes(editor, { at: splitP, to: insertP })

--- a/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
+++ b/packages/styleguide/src/components/Editor/Core/helpers/structure.ts
@@ -72,7 +72,7 @@ export const isCorrect = (
   )
 }
 
-const getTemplateType = (
+export const getTemplateType = (
   template?: NodeTemplate,
 ): CustomElementsType | undefined => {
   if (!template) return

--- a/packages/styleguide/src/components/Editor/__docs__/flyer.md
+++ b/packages/styleguide/src/components/Editor/__docs__/flyer.md
@@ -26,6 +26,82 @@ state: {
       ],
     },
     {
+      type: 'flyerTile',
+      id: '4',
+      children: [
+        {
+          type: 'flyerMetaP',
+          children: [
+            {
+              text: 'Ausserdem hören Sie heute in der Republik die letzte Sprachnotiz von Nicoletta Cimmino. ',
+            },
+            {
+              type: 'link',
+              children: [{ text: 'Sie handelt vom Abschied­nehmen.' }],
+            },
+            {
+              text: ' Und weshalb man das manchmal früher als erhofft tun muss.',
+            },
+          ],
+        },
+        {
+          type: 'flyerTopic',
+          children: [{ text: 'Im Dialog' }],
+        },
+        {
+          type: 'flyerTitle',
+          children: [
+            {
+              text: 'Which Kolumne do you miss?',
+            },
+          ],
+        },
+        {
+          type: 'flyerAuthor',
+          authorId: '123',
+          children: [{ text: '' }],
+        },
+        {
+          type: 'flyerAuthor',
+          authorId: '456',
+          children: [{ text: '' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              text: 'Some of us miss Sybille Berg.',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              text: 'Others will miss Nicoletta Cimino.',
+            },
+          ],
+        },
+        {
+          type: 'pullQuote',
+          children: [
+            {
+              type: 'pullQuoteText',
+              children: [{ text: 'Che tristezza, Nicoletta.' }],
+            },
+            {
+              type: 'pullQuoteSource',
+              children: [
+                { text: 'Zum Beitrag: ' },
+                { type: 'link', children: [{ text: 'Abschiednehmen' }] },
+                { text: '.' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
       type: 'flyerTileClosing',
       children: [
         {

--- a/packages/styleguide/src/components/Editor/test/copy-paste.test.js
+++ b/packages/styleguide/src/components/Editor/test/copy-paste.test.js
@@ -1,0 +1,256 @@
+import { createEditor, Transforms } from 'slate'
+import { cleanupTree } from '../Core/helpers/tree'
+import flyerSchema from '../schema/flyer'
+import mockEditor from './mockEditor'
+import { flyerTile } from './blocks'
+import { insertSlateFragment } from '../Core/helpers/copy-paste'
+
+describe('Slate Editor: insert Slate fragment', () => {
+  window.document.getSelection = jest.fn()
+
+  let value
+
+  async function setup(config) {
+    return await mockEditor(createEditor(), {
+      config,
+      value,
+      setValue: (val) => (value = val),
+    })
+  }
+
+  describe('compatible block types', () => {
+    it('should insert the fragment as is', async () => {
+      value = [flyerTile]
+      const structure = [
+        {
+          type: 'flyerTile',
+          repeat: true,
+        },
+      ]
+      const editor = await setup({ schema: flyerSchema, structure })
+      await Transforms.select(editor, { path: [0, 1, 0], offset: 0 })
+      insertSlateFragment(editor, [
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'flyerTopic',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTitle',
+              children: [
+                {
+                  text: 'Hello darkness',
+                },
+              ],
+            },
+            {
+              type: 'flyerAuthor',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'My old friend.',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+      await new Promise(process.nextTick)
+      expect(cleanupTree(value)).toEqual([
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'flyerMetaP',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTopic',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTitle',
+              children: [
+                {
+                  text: 'Hello darkness',
+                },
+              ],
+            },
+            {
+              type: 'flyerAuthor',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'My old friend.',
+                },
+              ],
+            },
+            {
+              type: 'flyerPunchline',
+              children: [{ text: '' }],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('convertible block types', () => {
+    it('should convert the fragment and insert it', async () => {
+      value = [flyerTile]
+      const structure = [
+        {
+          type: 'flyerTile',
+          repeat: true,
+        },
+      ]
+      const editor = await setup({ schema: flyerSchema, structure })
+      await Transforms.select(editor, { path: [0, 4, 0], offset: 0 })
+      insertSlateFragment(editor, [
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'flyerTopic',
+              children: [
+                {
+                  text: 'Hello darkness',
+                },
+              ],
+            },
+            {
+              type: 'flyerTitle',
+              children: [
+                {
+                  text: 'My old friend.',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+      await new Promise(process.nextTick)
+      expect(cleanupTree(value)).toEqual([
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'flyerMetaP',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTopic',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerTitle',
+              children: [
+                {
+                  text: '',
+                },
+              ],
+            },
+            {
+              type: 'flyerAuthor',
+              children: [{ text: '' }],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'Hello darkness',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'My old friend.',
+                },
+              ],
+            },
+            {
+              type: 'flyerPunchline',
+              children: [{ text: '' }],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('imcompatible copied and selected block types', () => {
+    it('should insert an inline version of the copied element', async () => {
+      value = [flyerTile]
+      const structure = [
+        {
+          type: 'flyerTile',
+          repeat: true,
+        },
+      ]
+      const editor = await setup({ schema: flyerSchema, structure })
+      await Transforms.select(editor, { path: [0, 1, 0], offset: 0 })
+      insertSlateFragment(editor, [
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'Hello',
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  text: 'World',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+      await new Promise(process.nextTick)
+      expect(cleanupTree(value)[0].children[1]).toEqual({
+        children: [
+          {
+            text: 'Hello World',
+          },
+        ],
+        type: 'flyerTopic',
+      })
+    })
+  })
+})

--- a/packages/styleguide/src/components/Editor/test/copy-paste.test.js
+++ b/packages/styleguide/src/components/Editor/test/copy-paste.test.js
@@ -114,8 +114,7 @@ describe('Slate Editor: insert Slate fragment', () => {
       ])
     })
 
-    // TODO: maybe in a next iteration
-    xit('should insert the fragment as is if the type is compatible as per template', async () => {
+    it('should insert the fragment as is if the type is compatible as per template', async () => {
       value = [flyerTile]
       const structure = [
         {
@@ -166,41 +165,36 @@ describe('Slate Editor: insert Slate fragment', () => {
       ])
       await new Promise(process.nextTick)
       expect(cleanupTree(value)[0].children[5]).toEqual({
-        type: 'flyerTile',
         children: [
           {
             children: [
               {
-                children: [
-                  {
-                    text: 'Che tristezza, Nicoletta.',
-                  },
-                ],
-                type: 'pullQuoteText',
+                text: 'Che tristezza, Nicoletta.',
+              },
+            ],
+            type: 'pullQuoteText',
+          },
+          {
+            children: [
+              {
+                text: 'Zum Beitrag: ',
               },
               {
                 children: [
                   {
-                    text: 'Zum Beitrag: ',
-                  },
-                  {
-                    children: [
-                      {
-                        text: 'Abschiednehmen',
-                      },
-                    ],
-                    type: 'link',
-                  },
-                  {
-                    text: '.',
+                    text: 'Abschiednehmen',
                   },
                 ],
-                type: 'pullQuoteSource',
+                type: 'link',
+              },
+              {
+                text: '.',
               },
             ],
-            type: 'pullQuote',
+            type: 'pullQuoteSource',
           },
         ],
+        type: 'pullQuote',
       })
     })
   })

--- a/packages/styleguide/src/components/Editor/test/copy-paste.test.js
+++ b/packages/styleguide/src/components/Editor/test/copy-paste.test.js
@@ -113,6 +113,96 @@ describe('Slate Editor: insert Slate fragment', () => {
         },
       ])
     })
+
+    // TODO: maybe in a next iteration
+    xit('should insert the fragment as is if the type is compatible as per template', async () => {
+      value = [flyerTile]
+      const structure = [
+        {
+          type: 'flyerTile',
+          repeat: true,
+        },
+      ]
+      const editor = await setup({ schema: flyerSchema, structure })
+      await Transforms.select(editor, { path: [0, 5, 0], offset: 0 })
+      insertSlateFragment(editor, [
+        {
+          type: 'flyerTile',
+          children: [
+            {
+              children: [
+                {
+                  children: [
+                    {
+                      text: 'Che tristezza, Nicoletta.',
+                    },
+                  ],
+                  type: 'pullQuoteText',
+                },
+                {
+                  children: [
+                    {
+                      text: 'Zum Beitrag: ',
+                    },
+                    {
+                      children: [
+                        {
+                          text: 'Abschiednehmen',
+                        },
+                      ],
+                      type: 'link',
+                    },
+                    {
+                      text: '.',
+                    },
+                  ],
+                  type: 'pullQuoteSource',
+                },
+              ],
+              type: 'pullQuote',
+            },
+          ],
+        },
+      ])
+      await new Promise(process.nextTick)
+      expect(cleanupTree(value)[0].children[5]).toEqual({
+        type: 'flyerTile',
+        children: [
+          {
+            children: [
+              {
+                children: [
+                  {
+                    text: 'Che tristezza, Nicoletta.',
+                  },
+                ],
+                type: 'pullQuoteText',
+              },
+              {
+                children: [
+                  {
+                    text: 'Zum Beitrag: ',
+                  },
+                  {
+                    children: [
+                      {
+                        text: 'Abschiednehmen',
+                      },
+                    ],
+                    type: 'link',
+                  },
+                  {
+                    text: '.',
+                  },
+                ],
+                type: 'pullQuoteSource',
+              },
+            ],
+            type: 'pullQuote',
+          },
+        ],
+      })
+    })
   })
 
   describe('convertible block types', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20722,10 +20722,10 @@ slate-dev-logger@^0.1.36:
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.43.tgz#77f6ca7207fcbf453a5516f3aa8b19794d1d26dc"
   integrity sha512-GkcPMGzmPVm85AL+jaKnzhIA0UH9ktQDEIDM+FuQtz+TAPcpPCQiRAaZ6I2p2uD0Hq9bImhKSCtHIa0qRxiVGw==
 
-slate-history@^0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.66.0.tgz#ac63fddb903098ceb4c944433e3f75fe63acf940"
-  integrity sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==
+slate-history@^0.86.0:
+  version "0.86.0"
+  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.86.0.tgz#5554612271d2fc1018a7918be3961bb66e620c58"
+  integrity sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==
   dependencies:
     is-plain-object "^5.0.0"
 
@@ -20776,10 +20776,10 @@ slate-react@^0.10.23:
     slate-plain-serializer "^0.4.16"
     slate-prop-types "^0.4.16"
 
-slate-react@^0.82.2:
-  version "0.82.2"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.82.2.tgz#4344ef392e3e51e5cd7c3272d3e5d61483c41823"
-  integrity sha512-lNmSqqNOKQJG1i3Wx4MkggWr6dLhQ43n4exPf5NLmKVBHPBuQSRNaWhAAKm6HOEC36Q6xBfkVONIQWi3GSyIEQ==
+slate-react@^0.88.2:
+  version "0.88.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.88.2.tgz#e072d54980876ec11ca057703a0e386dd290c03e"
+  integrity sha512-r06i+b7c1deP9PH69D3kJLStB2cbwryCVUGC++3phG7G3Ie+qEeJ5AZqogdxtsXd2vZaVGYKEjSASd3bTnj3tw==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -20804,10 +20804,10 @@ slate@^0.31.8:
     slate-dev-logger "^0.1.36"
     type-of "^2.0.1"
 
-slate@^0.82.1:
-  version "0.82.1"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.82.1.tgz#cf43cb828c980734dab01c9bbb517fd4d20892f7"
-  integrity sha512-3mdRdq7U3jSEoyFrGvbeb28hgrvrr4NdFCtJX+IjaNvSFozY0VZd/CGHF0zf/JDx7aEov864xd5uj0HQxxEWTQ==
+slate@^0.88.1:
+  version "0.88.1"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.88.1.tgz#0fc20f33b7baed7ea979fa848232c336e788cc31"
+  integrity sha512-DEj9RpkNwPfdh3zbE9eGpeOVGWdS8BYQt754S0Lk6IvJXOkYaxza7WEZLZl/vnp7vloMdTe24zccyxywA3XK8g==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
This PR improves the copy-paste behaviour in the journal in two ways:

### Copy-paste blocks from one tile to another

The cursor needs to be placed into the same block as the first copied block for this to be triggered (e.g. if you want to copy topic + title into another tile, you should place the cursor inside the topic of the recipient tile).

https://user-images.githubusercontent.com/3907984/214612518-b38a9bd9-cffc-4343-baf9-b65b794966fc.mov

### Copy-paste several blocks into repeat sections

For instance, since there can be more than one paragraph, you could copy the title + topic from another tile, and paste those as paragraphs.

https://user-images.githubusercontent.com/3907984/214612451-f92d230b-5405-487c-897e-f2dae375279a.mov

### Copy-paste a block into a section that supports this block type

For instance, the punchline can be a quote, hence quotes can be paste as-is in the punchline

https://user-images.githubusercontent.com/3907984/215451559-46fa0a66-c18a-4b1b-ae5d-7e03a0f730f6.mov

### Also

Minor update of Slate packages

