### PR TITLE
Add access token scope NOW_YOU_SEE_ME, query user w/ an access token

### DIFF
--- a/packages/backend-modules/auth/graphql/resolvers/_queries/user.js
+++ b/packages/backend-modules/auth/graphql/resolvers/_queries/user.js
@@ -1,11 +1,19 @@
-const transformUser = require('../../../lib/transformUser')
+const { getUserByAccessToken } = require('../../../lib/AccessToken')
 const { resolveUser } = require('../../../lib/Users')
 const Roles = require('../../../lib/Roles')
+const transformUser = require('../../../lib/transformUser')
 
-module.exports = async (_, { slug }, { user: me, pgdb }) => {
+module.exports = async (_, { slug, accessToken }, context) => {
+  // use access token to return user
+  if (!slug && accessToken) {
+    return getUserByAccessToken(accessToken, context)
+  }
+
   if (!slug) {
     return null
   }
+
+  const { user: me, pgdb } = context
 
   const user = await resolveUser({ slug, pgdb })
 

--- a/packages/backend-modules/auth/graphql/schema-types.js
+++ b/packages/backend-modules/auth/graphql/schema-types.js
@@ -113,7 +113,7 @@ enum AccessTokenScope {
   CUSTOM_PLEDGE_EXTENDED
   "A token to use mutation claimCard (TTL: 90 days)"
   CLAIM_CARD
-  "A token authorize a session (TTL: n days)"
+  "A token authorize a session (TTL: 5 days)"
   AUTHORIZE_SESSION
   "A token access a invoices (TTL: 5 days)"
   INVOICE

--- a/packages/backend-modules/auth/graphql/schema-types.js
+++ b/packages/backend-modules/auth/graphql/schema-types.js
@@ -105,11 +105,19 @@ type SignInNotification {
   expiresAt: DateTime!
 }
 
+"Scope of an access token"
 enum AccessTokenScope {
+  "A token to access me.customPackages (TTL: 90 days)"
   CUSTOM_PLEDGE
+  "A token to access me.customPackages (TTL: 120 days)"
   CUSTOM_PLEDGE_EXTENDED
+  "A token to use mutation claimCard (TTL: 90 days)"
   CLAIM_CARD
+  "A token authorize a session (TTL: n days)"
   AUTHORIZE_SESSION
+  "A token access a invoices (TTL: 5 days)"
   INVOICE
+  "A token to access a users name and portrait (TTL: 30 days)"
+  NOW_YOU_SEE_ME
 }
 `

--- a/packages/backend-modules/auth/graphql/schema.js
+++ b/packages/backend-modules/auth/graphql/schema.js
@@ -13,9 +13,12 @@ type queries {
   # ensures signed in
   checkUsername(username: String): Boolean
 
-  # get user by slug—a id or username
-  # only returns users with a public profile
-  user(slug: String): User
+  # Get a user by slug, username or an access token.
+  # If slug is provieded, accessToken is ignored.
+  user(
+    slug: String
+    accessToken: ID
+  ): User
 
   # search for users
   # required role: editor

--- a/packages/backend-modules/auth/lib/AccessToken.js
+++ b/packages/backend-modules/auth/lib/AccessToken.js
@@ -63,6 +63,10 @@ const scopeConfigs = {
     ],
     ttlDays: 5,
   },
+  NOW_YOU_SEE_ME: {
+    exposeFields: ['firstName', 'lastName', 'portrait'],
+    ttlDays: 30,
+  },
 }
 
 const getScopeConfig = (scope) => {


### PR DESCRIPTION
This Pull Request allows users to issue an access token with scope `NOW_YOU_SEE_ME`. [See example query](http://localhost:5010/graphiql/?query=query%20getNowYouSeeMeToken%20%7B%0A%20%20me%20%7B%0A%20%20%20%20accessToken(scope%3A%20NOW_YOU_SEE_ME)%0A%20%20%7D%0A%7D%0A%0A&operationName=getNowYouSeeMeToken).

Token usable to query a few User props: `firstName`, `lastName`, `portrait`. [See example query](https://api.republik.love/graphiql/?query=query%20tallDarkStranger(%24accessToken%3A%20ID)%20%7B%0A%20%20user(accessToken%3A%20%24accessToken)%20%7B%0A%20%20%20%20id%0A%20%20%20%20email%0A%20%20%20%20portrait%0A%20%20%7D%0A%7D%0A&operationName=tallDarkStranger).

Token will expire after 30 days.

A token can either be issued by user itself or a user with superior roles like "admin" for another user.
