### PR TITLE
Feat climatelab counter

### DIFF
--- a/apps/www/components/Climatelab/Counter.js
+++ b/apps/www/components/Climatelab/Counter.js
@@ -5,26 +5,70 @@ import { css } from 'glamor'
 import {
   mediaQueries,
   fontStyles,
-  P,
   Loader,
   useColorContext,
+  convertStyleToRem,
+  Label,
+  Editorial,
+  createFormatter,
 } from '@project-r/styleguide'
 
 import { gql } from '@apollo/client'
-import { countFormat } from '../../lib/utils/format'
+import { countFormat, swissNumbers } from '../../lib/utils/format'
 
 const styles = {
-  container: css({}),
+  container: css({
+    marginTop: '20px',
+  }),
+  primaryNumberContainer: css({
+    marginBottom: -20,
+    [mediaQueries.mUp]: {
+      marginBottom: 0,
+    },
+  }),
   primaryNumber: css({
     display: 'block',
-    marginBottom: -6,
-    fontSize: 80,
+    marginBottom: -15,
+    fontSize: 90,
     ...fontStyles.serifTitle,
     lineHeight: 1,
     [mediaQueries.mUp]: {
-      fontSize: 164,
-      marginBottom: -8,
+      fontSize: 120,
+      marginBottom: -25,
     },
+  }),
+  secondaryNumbersWrapper: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    marginTop: '20px',
+  }),
+  secondaryNumbersContainer: css({
+    paddingRight: '20px',
+    marginTop: '20px',
+    flexGrow: 1,
+    [mediaQueries.mUp]: {
+      flex: '1 1 0px',
+    },
+  }),
+  secondaryNumber: css({
+    display: 'block',
+    fontSize: 30,
+    marginBottom: -5,
+    ...fontStyles.serifTitle,
+    lineHeight: 1,
+    [mediaQueries.mUp]: {
+      fontSize: 60,
+      marginBottom: -10,
+    },
+  }),
+  description: css({
+    ...convertStyleToRem(fontStyles.sansSerifRegular18),
+    [mediaQueries.mUp]: {
+      ...convertStyleToRem(fontStyles.sansSerifRegular23),
+    },
+  }),
+  footnoteContainer: css({
+    marginTop: 20,
   }),
 }
 
@@ -36,8 +80,16 @@ const query = gql`
   }
 `
 
-const Counter = ({ data }) => {
+const Counter = ({
+  data,
+  smallNumbers,
+  translations,
+  linkHref,
+  linkText,
+  extended,
+}) => {
   const [colorScheme] = useColorContext()
+  const t = createFormatter(translations)
   return (
     <Loader
       loading={data.loading}
@@ -47,11 +99,43 @@ const Counter = ({ data }) => {
 
         return (
           <div {...styles.container}>
-            <P {...colorScheme.set('color', 'text')}>
+            <div {...styles.primaryNumberContainer}>
               <span {...styles.primaryNumber}>
                 {countFormat(numberClimateUsers)}
               </span>
-            </P>
+              <span
+                {...colorScheme.set('color', 'textSoft')}
+                {...styles.description}
+              >
+                Menschen machen im Klimalabor mit
+              </span>
+            </div>
+            {extended && (
+              <>
+                <div {...styles.secondaryNumbersWrapper}>
+                  {smallNumbers.map((d, i) => (
+                    <div key={i} {...styles.secondaryNumbersContainer}>
+                      <span {...styles.secondaryNumber}>
+                        {swissNumbers.format('.0%')(d.number)}
+                      </span>
+                      <span
+                        {...colorScheme.set('color', 'textSoft')}
+                        {...styles.description}
+                      >
+                        {d.label}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div {...styles.footnoteContainer}>
+                  <Label>
+                    {t.elements('footnote', {
+                      link: <Link href={linkHref} text={linkText} />,
+                    })}
+                  </Label>
+                </div>
+              </>
+            )}
           </div>
         )
       }}
@@ -66,3 +150,8 @@ export default compose(
     }),
   }),
 )(Counter)
+
+const Link = (props) => {
+  const { href, text } = props
+  return <Editorial.A href={href}>{text}</Editorial.A>
+}

--- a/apps/www/components/Climatelab/Counter.js
+++ b/apps/www/components/Climatelab/Counter.js
@@ -77,11 +77,11 @@ const query = gql`
 
 const Counter = ({
   data,
-  smallNumbers,
+  demographics,
   translations = [],
   linkHref,
   linkText,
-  extended,
+  showDemographics,
 }) => {
   const [colorScheme] = useColorContext()
   const t = createFormatter(translations)
@@ -102,13 +102,13 @@ const Counter = ({
                 {...colorScheme.set('color', 'textSoft')}
                 {...styles.description}
               >
-                Menschen machen im Klimalabor mit
+                {t('primaryNumber')}
               </span>
             </div>
-            {extended && (
+            {showDemographics && (
               <>
                 <div {...styles.secondaryNumbersWrapper}>
-                  {smallNumbers.map((d, i) => (
+                  {demographics.map((d, i) => (
                     <div key={i} {...styles.secondaryNumbersContainer}>
                       <span {...styles.secondaryNumber}>
                         {swissNumbers.format('.0%')(d.number)}

--- a/apps/www/components/Climatelab/Counter.js
+++ b/apps/www/components/Climatelab/Counter.js
@@ -78,7 +78,7 @@ const query = gql`
 const Counter = ({
   data,
   smallNumbers,
-  translations,
+  translations = [],
   linkHref,
   linkText,
   extended,

--- a/apps/www/components/Climatelab/Counter.js
+++ b/apps/www/components/Climatelab/Counter.js
@@ -34,7 +34,7 @@ const styles = {
     lineHeight: 1,
     [mediaQueries.mUp]: {
       fontSize: 120,
-      marginBottom: -25,
+      marginBottom: -20,
     },
   }),
   secondaryNumbersWrapper: css({
@@ -43,7 +43,6 @@ const styles = {
     marginTop: '20px',
   }),
   secondaryNumbersContainer: css({
-    paddingRight: '20px',
     marginTop: '20px',
     flexGrow: 1,
     [mediaQueries.mUp]: {
@@ -52,20 +51,16 @@ const styles = {
   }),
   secondaryNumber: css({
     display: 'block',
-    fontSize: 30,
+    fontSize: 40,
     marginBottom: -5,
     ...fontStyles.serifTitle,
     lineHeight: 1,
     [mediaQueries.mUp]: {
       fontSize: 60,
-      marginBottom: -10,
     },
   }),
   description: css({
     ...convertStyleToRem(fontStyles.sansSerifRegular18),
-    [mediaQueries.mUp]: {
-      ...convertStyleToRem(fontStyles.sansSerifRegular23),
-    },
   }),
   footnoteContainer: css({
     marginTop: 20,

--- a/apps/www/components/Climatelab/LandingPage/Page.tsx
+++ b/apps/www/components/Climatelab/LandingPage/Page.tsx
@@ -75,10 +75,14 @@ const LandingPage = () => {
           <section
             {...css({ marginTop: 111, [mediaQueries.mUp]: { marginTop: 162 } })}
           >
-            <Counter />
-            {/* <p {...styles.text}>
-              {t('ClimateLandingPage/content/counterText')}
-            </p> */}
+            <Counter
+              translations={[
+                {
+                  key: 'primaryNumber',
+                  value: 'Menschen machen im Klimalabor mit',
+                },
+              ]}
+            />
           </section>
           <section
             {...css({ marginTop: 111, [mediaQueries.mUp]: { marginTop: 162 } })}

--- a/apps/www/components/Climatelab/LandingPage/Page.tsx
+++ b/apps/www/components/Climatelab/LandingPage/Page.tsx
@@ -76,9 +76,9 @@ const LandingPage = () => {
             {...css({ marginTop: 111, [mediaQueries.mUp]: { marginTop: 162 } })}
           >
             <Counter />
-            <p {...styles.text}>
+            {/* <p {...styles.text}>
               {t('ClimateLandingPage/content/counterText')}
-            </p>
+            </p> */}
           </section>
           <section
             {...css({ marginTop: 111, [mediaQueries.mUp]: { marginTop: 162 } })}

--- a/apps/www/components/Climatelab/config.js
+++ b/apps/www/components/Climatelab/config.js
@@ -2,6 +2,7 @@ export const climateColors = {
   light: {
     default: '#5A47E1',
     text: '#FFFFFF',
+    textSoft: '#FFFFFF',
     primary: '#FEFD67',
     primaryHover: '#F8F702',
     primaryText: '#000000',


### PR DESCRIPTION
Add small numbers to climate lab counter, the small numbers are added through the props. There is an bool extended which hides the small numbers on the climate lab landing page.

<img width="1301" alt="Bildschirmfoto 2023-01-30 um 09 50 57" src="https://user-images.githubusercontent.com/11921821/215430375-420fc3b7-d609-4742-b9f2-b30dae1193e9.png">

<img width="696" alt="Bildschirmfoto 2023-01-30 um 09 51 22" src="https://user-images.githubusercontent.com/11921821/215430442-88d42e10-a915-4158-bdf3-933381a445a9.png">

