### PR TITLE
sender rewards for 5 years future campaign

### DIFF
--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     {{#if has_one_slot_filled}}
                     <p>
-                      Vor Kurzem hat {{claimer}} ein Abo bei der Republik
+                      Vor Kurzem hat {{receiver}} ein Abo bei der Republik
                       gekauft, zu einem selbst gewählten Preis. Damit ist die
                       Republik-Community um ein Mitglied gewachsen.
                     </p>

--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#444;font-size:18px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    {{#if has_one_slot_filled}}
+                    <p>
+                      Vor Kurzem hat {{claimer}} ein Abo bei der Republik
+                      gekauft, zu einem selbst gewählten Preis. Damit ist die
+                      Republik-Community um ein Mitglied gewachsen.
+                    </p>
+                    <p>
+                      Möglich gemacht haben das: Sie. Vielen Dank, dass Sie
+                      Verstärkung geholt haben!
+                    </p>
+                    <p>
+                      Ein zusätzliches Mitglied mag sich nach wenig anhören.
+                      Aber für ein Magazin, das sich über seine Leserinnen
+                      finanziert und vom Austausch mit ihnen lebt, kommt es auf
+                      jede einzelne Person an.
+                    </p>
+                    <p>
+                      Deshalb: Schicken Sie
+                      <a href="{{link_sender_page}}"
+                        >Ihren persönlichen Angebotslink</a
+                      >
+                      gerne auch an Ihre Nachbarin, Ihren Kindergartenfreund,
+                      Ihre Arbeits- oder Vereinskollegen.
+                    </p>
+                    <p>
+                      Sie haben noch {{count_open_slots}} Zugänge zu
+                      Mitstreiterinnen-Abos zu vergeben.
+                    </p>
+                    <p>Merci für Ihre Zeit und Ihre Unterstützung!</p>
+                    <p>Herzlich</p>
+                    {{else if has_two_slots_filled}}
+                    <p>
+                      Und schon wieder hat jemand über Ihren Angebotslink ein
+                      Mitstreiter-Abo bei der Republik gekauft!
+                    </p>
+                    <p>
+                      Damit haben Sie noch {{count_open_slots}} Zugänge zu
+                      vergeben.
+                    </p>
+                    <p>
+                      Vielleicht wäre das etwas für Ihren Coiffeur, Ihre
+                      Skilehrerin oder Ihren Hausarzt?
+                    </p>
+                    <p>
+                      Finden Sie es heraus, indem Sie ihnen
+                      <a href="{{link_sender_page}}"
+                        >einen Link zum Angebot schicken</a
+                      >.
+                    </p>
+                    <p>
+                      Unabhängiger Journalismus hat eine Zukunft, mit Ihnen.
+                    </p>
+                    <p>Vorfreudige Grüsse</p>
+                    {{else if has_three_slots_filled}}
+                    <p>
+                      Vor einigen Monaten hatten wir eine kühne Idee: Was wäre,
+                      wenn jede Verlegerin und jeder Verleger ein bis zwei
+                      Personen neu an Bord der Republik holen würde? Die Idee
+                      hörte sich einfach an, aber wir waren skeptisch, ob und
+                      wie das tatsächlich funktionieren würde.
+                    </p>
+                    <p>
+                      Und jetzt sind wir gerade ein bisschen begeistert, weil
+                      wir sehen, dass es Menschen wie Sie gibt: Nicht nur ein
+                      bis zwei, nein, drei Menschen haben über Ihren Zugang
+                      bereits ein neues Abo abgeschlossen. Das ist grossartig!
+                    </p>
+                    <p>Hätten Sie das gedacht?</p>
+                    <p>
+                      Und falls Sie jetzt der Ehrgeiz gepackt hat: Sie haben
+                      noch {{count_open_slots}} Zugänge zu Mitstreiterinnen-Abos
+                      zu vergeben.
+                    </p>
+                    <p>Vielen Dank fürs Dranbleiben und herzliche Grüsse</p>
+                    {{else if has_four_slots_filled}}
+                    <p>
+                      Respekt! Seit Beginn dieser Aktion haben Sie die
+                      Republik-Community schon vier Mal verstärkt. Damit haben
+                      Sie fast alle Zugänge vergeben.
+                    </p>
+                    <p>Fast.</p>
+                    <p>Ein letzter ist noch übrig.</p>
+                    <p>
+                      Und wir fragen uns: Wer ergattert sich Ihren letzten
+                      Zugang zum Mitstreiterinnen-Abo?
+                    </p>
+                    <p>Gespannte Grüsse</p>
+                    {{else if has_five_slots_filled}}
+                    <p>
+                      Herzliche Gratulation: Sie haben 5 Mitstreiter an Bord
+                      geholt!
+                    </p>
+                    <p>
+                      Dank dem Engagement von Menschen wie Ihnen hat
+                      unabhängiger Journalismus eine Zukunft. Wir freuen uns
+                      darauf und werden hart daran arbeiten, die neuen
+                      Mitstreiterinnen nach Ihrer erfolgreichen Vermittlung in
+                      den kommenden 12 Monaten nachhaltig zu begeistern.
+                    </p>
+                    <p>Dankende Grüsse</p>
+                    {{/if}}
+                    <p>Ihre Crew der Republik</p>
+                    {{#if is_donating}}
+                    <p>
+                      PS: Für jede geholte Verstärkung haben wir Ihnen einen
+                      Monat Republik als Gutschrift angeboten. Und Sie haben
+                      angegeben, dass Sie diese Gutschrift lieber der Republik
+                      spenden möchten. Das ist sehr aufmerksam, herzlichen Dank!
+                    </p>
+                    {{#unless has_five_slots_filled}}
+                    <p>
+                      Sollten Sie Ihre Meinung für zukünftige Fälle ändern:
+                      <a href="{{link_sender_page}}">Hier</a>
+                      können Sie die Einstellung jederzeit anpassen.
+                    </p>
+                    {{/unless}} {{else}}
+                    <p>
+                      PS: Wie abgemacht, haben wir Ihnen einen Monat auf Ihre
+                      aktuelle Mitgliedschaft gutgeschrieben, sie läuft neu bis
+                      [End date]
+                    </p>
+                    {{#unless has_five_slots_filled}}
+                    <p>
+                      Möchten Sie zusätzliche Monate künftig lieber der Republik
+                      spenden? Grossartig, vielen Dank!
+                      <a href="{{link_sender_page}}">Hier</a> können Sie die
+                      entsprechende Einstellung jederzeit anpassen.
+                    </p>
+                    {{/unless}} {{/if}}
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.html
@@ -161,7 +161,7 @@
                     <p>
                       PS: Wie abgemacht, haben wir Ihnen einen Monat auf Ihre
                       aktuelle Mitgliedschaft gutgeschrieben, sie läuft neu bis
-                      [End date]
+                      {{membership_period_end_date}}.
                     </p>
                     {{#unless has_five_slots_filled}}
                     <p>

--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
@@ -1,0 +1,117 @@
+Guten Tag
+
+{{#if has_one_slot_filled}}
+
+Vor Kurzem hat {{claimer}} ein Abo bei der Republik gekauft, zu einem selbst
+gewählten Preis. Damit ist die Republik-Community um ein Mitglied gewachsen.
+
+Möglich gemacht haben das: Sie. Vielen Dank, dass Sie Verstärkung geholt haben!
+
+Ein zusätzliches Mitglied mag sich nach wenig anhören. Aber für ein Magazin, das
+sich über seine Leserinnen finanziert und vom Austausch mit ihnen lebt, kommt es
+auf jede einzelne Person an.
+
+Deshalb: Schicken Sie Ihren persönlichen Angebotslink {{link_sender_page}} gerne
+auch an Ihre Nachbarin, Ihren Kindergartenfreund, Ihre Arbeits- oder
+Vereinskollegen.
+
+Sie haben noch {{count_open_slots}} Zugänge zu Mitstreiterinnen-Abos zu
+vergeben.
+
+Merci für Ihre Zeit und Ihre Unterstützung!
+
+Herzlich
+
+{{else if has_two_slots_filled}}
+
+Und schon wieder hat jemand über Ihren Angebotslink ein Mitstreiter-Abo bei der
+Republik gekauft!
+
+Damit haben Sie noch {{count_open_slots}} Zugänge zu vergeben.
+
+Vielleicht wäre das etwas für Ihren Coiffeur, Ihre Skilehrerin oder Ihren
+Hausarzt?
+
+Finden Sie es heraus, indem Sie ihnen einen Link zum Angebot schicken
+{{link_sender_page}} .
+
+Unabhängiger Journalismus hat eine Zukunft, mit Ihnen.
+
+Vorfreudige Grüsse
+
+{{else if has_three_slots_filled}}
+
+Vor einigen Monaten hatten wir eine kühne Idee: Was wäre, wenn jede Verlegerin
+und jeder Verleger ein bis zwei Personen neu an Bord der Republik holen würde?
+Die Idee hörte sich einfach an, aber wir waren skeptisch, ob und wie das
+tatsächlich funktionieren würde.
+
+Und jetzt sind wir gerade ein bisschen begeistert, weil wir sehen, dass es
+Menschen wie Sie gibt: Nicht nur ein bis zwei, nein, drei Menschen haben über
+Ihren Zugang bereits ein neues Abo abgeschlossen. Das ist grossartig!
+
+Hätten Sie das gedacht?
+
+Und falls Sie jetzt der Ehrgeiz gepackt hat: Sie haben noch {{count_open_slots}}
+Zugänge zu Mitstreiterinnen-Abos zu vergeben.
+
+Vielen Dank fürs Dranbleiben und herzliche Grüsse
+
+{{else if has_four_slots_filled}}
+
+Respekt! Seit Beginn dieser Aktion haben Sie die Republik-Community schon vier
+Mal verstärkt. Damit haben Sie fast alle Zugänge vergeben.
+
+Fast.
+
+Ein letzter ist noch übrig.
+
+Und wir fragen uns: Wer ergattert sich Ihren letzten Zugang zum
+Mitstreiterinnen-Abo?
+
+Gespannte Grüsse
+
+{{else if has_five_slots_filled}}
+
+Herzliche Gratulation: Sie haben 5 Mitstreiter an Bord geholt!
+
+Dank dem Engagement von Menschen wie Ihnen hat unabhängiger Journalismus eine
+Zukunft. Wir freuen uns darauf und werden hart daran arbeiten, die neuen
+Mitstreiterinnen nach Ihrer erfolgreichen Vermittlung in den kommenden 12
+Monaten nachhaltig zu begeistern.
+
+Dankende Grüsse
+
+{{/if}}
+
+Ihre Crew der Republik
+
+{{#if is_donating}}
+
+PS: Für jede geholte Verstärkung haben wir Ihnen einen Monat Republik als
+Gutschrift angeboten. Und Sie haben angegeben, dass Sie diese Gutschrift lieber
+der Republik spenden möchten. Das ist sehr aufmerksam, herzlichen Dank!
+
+{{#unless has_five_slots_filled}}
+
+Sollten Sie Ihre Meinung für zukünftige Fälle ändern: Hier {{link_sender_page}}
+können Sie die Einstellung jederzeit anpassen.
+
+{{/unless}} {{else}}
+
+PS: Wie abgemacht, haben wir Ihnen einen Monat auf Ihre aktuelle Mitgliedschaft
+gutgeschrieben, sie läuft neu bis [End date]
+
+{{#unless has_five_slots_filled}}
+
+Möchten Sie zusätzliche Monate künftig lieber der Republik spenden? Grossartig,
+vielen Dank! Hier {{link_sender_page}} können Sie die entsprechende Einstellung
+jederzeit anpassen.
+
+{{/unless}} {{/if}}
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 {{#if has_one_slot_filled}}
 
-Vor Kurzem hat {{claimer}} ein Abo bei der Republik gekauft, zu einem selbst
+Vor Kurzem hat {{receiver}} ein Abo bei der Republik gekauft, zu einem selbst
 gewählten Preis. Damit ist die Republik-Community um ein Mitglied gewachsen.
 
 Möglich gemacht haben das: Sie. Vielen Dank, dass Sie Verstärkung geholt haben!

--- a/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
+++ b/packages/backend-modules/mail/templates/future_campaign_sender_reward.txt
@@ -100,7 +100,7 @@ können Sie die Einstellung jederzeit anpassen.
 {{/unless}} {{else}}
 
 PS: Wie abgemacht, haben wir Ihnen einen Monat auf Ihre aktuelle Mitgliedschaft
-gutgeschrieben, sie läuft neu bis [End date]
+gutgeschrieben, sie läuft neu bis {{membership_period_end_date}}.
 
 {{#unless has_five_slots_filled}}
 

--- a/packages/backend-modules/migrations/migrations/20230203150933-user-attributes.js
+++ b/packages/backend-modules/migrations/migrations/20230203150933-user-attributes.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/republik/migrations/sqls'
+const file = '20230203150933-user-attributes'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/republik-crowdfundings/graphql/resolvers/User.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/resolvers/User.js
@@ -12,7 +12,10 @@ const {
   hasDormantMembership,
   resolveMemberships,
 } = require('../../lib/CustomPackages')
-const { getCustomPackages } = require('../../lib/User')
+const {
+  getCustomPackages,
+  getFutureCampaignAboCount,
+} = require('../../lib/User')
 const { suggest: autoPaySuggest } = require('../../lib/AutoPay')
 const createCache = require('../../lib/cache')
 const { getLastEndDate } = require('../../lib/utils')
@@ -284,5 +287,9 @@ module.exports = {
   async adminNotes(user, args, { pgdb, user: me }) {
     Roles.ensureUserHasRole(me, 'supporter')
     return user.adminNotes || user._raw.adminNotes
+  },
+  async futureCampaignAboCount(user, args, { pgdb, user: me }) {
+    Roles.ensureUserIsMeOrInRoles(user, me, ['admin', 'supporter'])
+    return getFutureCampaignAboCount({ user, pgdb })
   },
 }

--- a/packages/backend-modules/republik-crowdfundings/graphql/schema-types.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/schema-types.js
@@ -26,6 +26,7 @@ extend type User {
   # notes by the support team
   # required role: supporter
   adminNotes: String
+  futureCampaignAboCount: Int
 }
 
 type Crowdfunding {

--- a/packages/backend-modules/republik-crowdfundings/lib/Mail.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/Mail.js
@@ -1152,15 +1152,15 @@ mail.getPledgeMergeVars = async (
   ]
 }
 
-mail.send5YearsRewardsMail = async (
-  { giverUserId, claimerUserId, count, hasGiverConsentedToDonate },
+mail.sendFutureCampaignSenderRewardMail = async (
+  { senderUserId, pledgeUserId, count, hasSenderConsentedToDonate },
   { pgdb, t },
 ) => {
-  const giver = pgdb.public.user.findOne({ id: giverUserId })
-  const safeGiver = transformUser(giver)
+  const sender = await pgdb.public.users.findOne({ id: senderUserId })
+  const safeSender = transformUser(sender)
 
-  const claimer = pgdb.public.user.findOne({ id: claimerUserId })
-  const safeClaimer = transformUser(claimer)
+  const pledger = await pgdb.public.users.findOne({ id: pledgeUserId })
+  const safePledger = transformUser(pledger)
 
   const countNumber = parseInt(count, 10)
 
@@ -1168,7 +1168,7 @@ mail.send5YearsRewardsMail = async (
 
   return sendMailTemplate(
     {
-      to: safeGiver.email,
+      to: safeSender.email,
       fromEmail: process.env.DEFAULT_MAIL_FROM_ADDRESS,
       subject: t(`api/email/${templateName}/${count}/subject`),
       templateName,
@@ -1199,12 +1199,12 @@ mail.send5YearsRewardsMail = async (
           content: 5 - countNumber,
         },
         {
-          name: 'claimer',
-          content: safeClaimer.name ? safeClaimer.name : safeClaimer.email,
+          name: 'receiver',
+          content: safePledger.name ? safePledger.name : safePledger.email,
         },
         {
           name: 'is_donating',
-          content: hasGiverConsentedToDonate,
+          content: hasSenderConsentedToDonate,
         },
         {
           name: 'link_sender_page',

--- a/packages/backend-modules/republik-crowdfundings/lib/Mail.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/Mail.js
@@ -1152,4 +1152,68 @@ mail.getPledgeMergeVars = async (
   ]
 }
 
+mail.send5YearsRewardsMail = async (
+  { giverUserId, claimerUserId, count, hasGiverConsentedToDonate },
+  { pgdb, t },
+) => {
+  const giver = pgdb.public.user.findOne({ id: giverUserId })
+  const safeGiver = transformUser(giver)
+
+  const claimer = pgdb.public.user.findOne({ id: claimerUserId })
+  const safeClaimer = transformUser(claimer)
+
+  const countNumber = parseInt(count, 10)
+
+  const templateName = 'future_campaign_sender_reward'
+
+  return sendMailTemplate(
+    {
+      to: safeGiver.email,
+      fromEmail: process.env.DEFAULT_MAIL_FROM_ADDRESS,
+      subject: t(`api/email/${templateName}/${count}/subject`),
+      templateName,
+      mergeLanguage: 'handlebars',
+      globalMergeVars: [
+        {
+          name: 'has_one_slot_filled',
+          content: countNumber === 1,
+        },
+        {
+          name: 'has_two_slots_filled',
+          content: countNumber === 2,
+        },
+        {
+          name: 'has_three_slots_filled',
+          content: countNumber === 3,
+        },
+        {
+          name: 'has_four_slots_filled',
+          content: countNumber === 4,
+        },
+        {
+          name: 'has_five_slots_filled',
+          content: countNumber === 5,
+        },
+        {
+          name: 'count_open_slots',
+          content: 5 - countNumber,
+        },
+        {
+          name: 'claimer',
+          content: safeClaimer.name ? safeClaimer.name : safeClaimer.email,
+        },
+        {
+          name: 'is_donating',
+          content: hasGiverConsentedToDonate,
+        },
+        {
+          name: 'link_sender_page',
+          content: `${FRONTEND_BASE_URL}/verstaerkung-holen`,
+        },
+      ],
+    },
+    { pgdb },
+  )
+}
+
 module.exports = mail

--- a/packages/backend-modules/republik-crowdfundings/lib/Mail.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/Mail.js
@@ -1153,7 +1153,13 @@ mail.getPledgeMergeVars = async (
 }
 
 mail.sendFutureCampaignSenderRewardMail = async (
-  { senderUserId, pledgeUserId, count, hasSenderConsentedToDonate },
+  {
+    senderUserId,
+    pledgeUserId,
+    count,
+    hasSenderConsentedToDonate,
+    membershipPeriodEndDate,
+  },
   { pgdb, t },
 ) => {
   const sender = await pgdb.public.users.findOne({ id: senderUserId })
@@ -1209,6 +1215,11 @@ mail.sendFutureCampaignSenderRewardMail = async (
         {
           name: 'link_sender_page',
           content: `${FRONTEND_BASE_URL}/verstaerkung-holen`,
+        },
+        {
+          name: 'membership_period_end_date',
+          content:
+            membershipPeriodEndDate && dateFormat(membershipPeriodEndDate),
         },
       ],
     },

--- a/packages/backend-modules/republik-crowdfundings/lib/User.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/User.js
@@ -37,7 +37,7 @@ const getFutureCampaignAboCount = async ({ user, pgdb }) => {
     { orderBy: { createdAt: 'desc' } },
   )
 
-  return currentCount ? parseInt(currentCount.value, 10) : 0 // or should it be currentCount[0]
+  return currentCount ? parseInt(currentCount.value, 10) : 0
 }
 
 module.exports = {

--- a/packages/backend-modules/republik-crowdfundings/lib/User.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/User.js
@@ -31,6 +31,16 @@ const getCustomPackages = async ({ user, crowdfundingName, pgdb }) => {
   ).filter(Boolean)
 }
 
+const getFutureCampaignAboCount = async ({ user, pgdb }) => {
+  const currentCount = await pgdb.public.userAttributes.findFirst(
+    { userId: user.id, name: 'futureCampaignAboCount' },
+    { orderBy: { createdAt: 'desc' } },
+  )
+
+  return currentCount ? parseInt(currentCount.value, 10) : 0 // or should it be currentCount[0]
+}
+
 module.exports = {
   getCustomPackages,
+  getFutureCampaignAboCount,
 }

--- a/packages/backend-modules/republik-crowdfundings/lib/fiveYearsRewards.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/fiveYearsRewards.js
@@ -1,0 +1,82 @@
+const { Consents } = require('@orbiting/backend-modules-auth')
+const dayjs = require('dayjs')
+
+const { send5YearsRewardsMail } = require('@orbiting/backend-modules-mail')
+
+const DONATE_POLICY_NAME = '5YEAR_DONATE_MONTHS'
+
+const rewardSender = async (giverUserId, claimerUserId, context) => {
+  const { pgdb, t } = context
+
+  const transaction = await pgdb.transactionBegin()
+
+  try {
+    // update count of subscribers
+
+    const lastCount = transaction.public.userAttributes.findFirst(
+      { userId: giverUserId, name: 'mitstreiterCount' },
+      { orderBy: { createdAt: 'desc' } },
+    )
+
+    const hasLastCount = lastCount.length
+
+    const newCount = hasLastCount ? parseInt(lastCount[0].value, 10) + 1 : 1
+
+    const count = await transaction.public.userAttributes.insertAndGet({
+      userId: giverUserId,
+      name: 'mitstreiterCount',
+      value: newCount,
+      supersededAt: hasLastCount ? lastCount[0].createdAt : null,
+    })
+
+    // fetch consent of giver if month should be donated
+    const hasUserConsentedToDonate = Consents.statusForPolicyForUser({
+      userId: giverUserId,
+      policy: DONATE_POLICY_NAME,
+      transaction,
+    })
+
+    // if month should not be donated, add to current membership period
+    if (!hasUserConsentedToDonate) {
+      const activeMembership = await transaction.public.memberships.findOne({
+        userId: giverUserId,
+        active: true,
+      })
+
+      const currentMembershipPeriod =
+        await transaction.public.membershipPeriods.findFirst(
+          {
+            membershipId: activeMembership.id,
+            pledgeId: activeMembership.pledgeId,
+          },
+          { orderBy: { endDate: 'asc' } },
+        )
+
+      const endDate = dayjs(currentMembershipPeriod.endDate)
+
+      await transaction.public.membershipPeriods.updateAndGet(
+        {
+          id: currentMembershipPeriod.id,
+          membershipId: activeMembership.id,
+          pledgeId: activeMembership.pledgeId,
+        },
+        {
+          endDate: endDate.add(1, 'month'),
+        },
+      )
+    }
+
+    // send email to giver
+    await send5YearsRewardsMail(
+      { giverUserId, claimerUserId, count, hasUserConsentedToDonate },
+      { transaction, t },
+    )
+    // TODO slack message?
+    await transaction.transactionCommit()
+  } catch (e) {
+    await transaction.transactionRollback()
+    throw new Error(t('')) // TODO: Fehlermeldung
+  }
+}
+
+module.exports = { rewardSender }

--- a/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
@@ -5,7 +5,6 @@ const DONATE_POLICY_NAME = '5YEAR_DONATE_MONTHS'
 
 const rewardSender = async (senderUserId, pledgeUserId, context) => {
   const { pgdb, t, mail } = context
-  console.log('rewarding')
 
   const transaction = await pgdb.transactionBegin()
 
@@ -72,7 +71,8 @@ const rewardSender = async (senderUserId, pledgeUserId, context) => {
             },
           )
 
-        rewardMailData.membershipPeriodEndDate = updatedMembershipPeriod.endDate
+        rewardMailData.membershipPeriodEndDate =
+          updatedMembershipPeriod[0]?.endDate
       }
 
       // send email to campaign sender without new membership period end date

--- a/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
@@ -69,7 +69,7 @@ const rewardSender = async (senderUserId, pledgeUserId, context) => {
             kind: 'BONUS',
           })
 
-        rewardMailData.membershipPeriodEndDate = newMembershipPeriod[0]?.endDate
+        rewardMailData.membershipPeriodEndDate = newMembershipPeriod?.endDate
       }
 
       // send email to campaign sender without new membership period end date

--- a/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/futureCampaignSenderReward.js
@@ -19,66 +19,75 @@ const rewardSender = async (senderUserId, pledgeUserId, context) => {
 
     const newCount = lastCount ? parseInt(lastCount.value, 10) + 1 : 1
 
-    const count = await transaction.public.userAttributes.insertAndGet({
-      userId: senderUserId,
-      name: 'futureCampaignAboCount',
-      value: newCount,
-      supersededAt: lastCount ? lastCount.createdAt : null,
-    })
-
-    const currentCount = count?.value
-    // fetch consent of campaign sender if month should be donated
-    const hasUserConsentedToDonate = await Consents.statusForPolicyForUser({
-      userId: senderUserId,
-      policy: DONATE_POLICY_NAME,
-      pgdb,
-    })
-
-    // if month should not be donated, add to current membership period
-    if (!hasUserConsentedToDonate) {
-      const activeMembership = await transaction.public.memberships.findOne({
+    if (newCount <= 5) {
+      const count = await transaction.public.userAttributes.insertAndGet({
         userId: senderUserId,
-        active: true,
+        name: 'futureCampaignAboCount',
+        value: newCount,
+        supersededAt: lastCount ? lastCount.createdAt : null,
       })
 
-      const currentMembershipPeriod =
-        await transaction.public.membershipPeriods.findFirst(
-          {
-            membershipId: activeMembership.id,
-            pledgeId: activeMembership.pledgeId,
-          },
-          { orderBy: { endDate: 'asc' } },
-        )
+      const currentCount = count?.value
+      // fetch consent of campaign sender if month should be donated
+      const hasDonateConsent = await Consents.statusForPolicyForUser({
+        userId: senderUserId,
+        policy: DONATE_POLICY_NAME,
+        pgdb,
+      })
 
-      const endDate = dayjs(currentMembershipPeriod.endDate)
-
-      await transaction.public.membershipPeriods.updateAndGet(
-        {
-          id: currentMembershipPeriod.id,
-          membershipId: activeMembership.id,
-          pledgeId: activeMembership.pledgeId,
-        },
-        {
-          endDate: endDate.add(1, 'month'),
-        },
-      )
-    }
-
-    // send email to campaign sender
-    await mail.sendFutureCampaignSenderRewardMail(
-      {
+      const rewardMailData = {
         senderUserId,
         pledgeUserId,
         count: currentCount,
-        hasUserConsentedToDonate,
-      },
-      { pgdb, t },
-    )
-    // TODO slack message?
-    await transaction.transactionCommit()
+        hasSenderConsentedToDonate: hasDonateConsent,
+      }
+
+      // if month should not be donated, add to current membership period
+      if (!hasDonateConsent) {
+        const activeMembership = await transaction.public.memberships.findOne({
+          userId: senderUserId,
+          active: true,
+        })
+
+        const currentMembershipPeriod =
+          await transaction.public.membershipPeriods.findFirst(
+            {
+              membershipId: activeMembership.id,
+              pledgeId: activeMembership.pledgeId,
+            },
+            { orderBy: { endDate: 'asc' } },
+          )
+
+        const endDate = dayjs(currentMembershipPeriod.endDate)
+
+        const updatedMembershipPeriod =
+          await transaction.public.membershipPeriods.updateAndGet(
+            {
+              id: currentMembershipPeriod.id,
+              membershipId: activeMembership.id,
+              pledgeId: activeMembership.pledgeId,
+            },
+            {
+              endDate: endDate.add(1, 'month'),
+            },
+          )
+
+        rewardMailData.membershipPeriodEndDate = updatedMembershipPeriod.endDate
+      }
+
+      // send email to campaign sender without new membership period end date
+      await mail.sendFutureCampaignSenderRewardMail(
+        { ...rewardMailData },
+        { pgdb, t },
+      )
+
+      // TODO slack message?
+      await transaction.transactionCommit()
+    }
   } catch (e) {
     await transaction.transactionRollback()
-    throw new Error(e) // TODO: Fehlermeldung
+    console.error(e)
+    throw new Error(t('')) // TODO: Fehlermeldung
   }
 }
 

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/Pledge.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/Pledge.js
@@ -80,8 +80,6 @@ const afterChange = async ({ pledge }, context) => {
     }
   }
 
-  console.log('B')
-
   return Promise.all([
     sendPledgeConfirmations({ userId: pledge.userId, pgdb, t }),
     pledge.status === 'SUCCESSFUL' && refreshPotForPledgeId(pledge.id, context),

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/Pledge.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/Pledge.js
@@ -3,6 +3,7 @@ const { sendPledgeConfirmations } = require('../Mail')
 const slack = require('@orbiting/backend-modules-republik/lib/slack')
 const { refreshPotForPledgeId } = require('../membershipPot')
 const getClients = require('./stripe/clients')
+const { rewardSender } = require('../fiveYearsReward')
 
 const forUpdate = async ({ pledgeId, fn, pgdb }) => {
   const transaction = await pgdb.transactionBegin()
@@ -68,6 +69,13 @@ const afterChange = async ({ pledge }, context) => {
   let user
   if (pledge.status === 'PAID_INVESTIGATE') {
     user = await pgdb.public.users.findOne({ id: pledge.userId })
+  }
+
+  if (pledge.payload && pledge.payload.utm_campaign === '5Years') {
+    // campaign is just a mock
+    // find sender in payload and put its id in giverUserId
+    const giverUserId = ''
+    await rewardSender(giverUserId, pledge.userId, context)
   }
 
   return Promise.all([

--- a/packages/backend-modules/republik-crowdfundings/package.json
+++ b/packages/backend-modules/republik-crowdfundings/package.json
@@ -25,6 +25,7 @@
     "apollo-modules-node": "*",
     "d3-array": "^2.4.0",
     "d3-dsv": "^1.2.0",
+    "dayjs": "^1.11.7",
     "debug": "^4.1.1",
     "fast-xml-parser": "^3.17.4",
     "graphql": "^15.3.0",

--- a/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-down.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS "user_attributes_user_id_idx";
+DROP INDEX IF EXISTS "user_attributes_name_idx";
+DROP INDEX IF EXISTS "user_attributes_value_idx";
+
+DROP TABLE IF EXISTS "userAttributes";

--- a/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-down.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-down.sql
@@ -1,5 +1,6 @@
 DROP INDEX IF EXISTS "user_attributes_user_id_idx";
 DROP INDEX IF EXISTS "user_attributes_name_idx";
 DROP INDEX IF EXISTS "user_attributes_value_idx";
+DROP INDEX IF EXISTS "user_attributes_user_id_name_idx";
 
 DROP TABLE IF EXISTS "userAttributes";

--- a/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-up.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-up.sql
@@ -3,11 +3,11 @@ CREATE TABLE "userAttributes" (
   "userId"          uuid references "users" on update cascade on delete set null,
   "name"            text not null,
   "value"           text,
-  "createdAt"       timestamp with time zone default now(),
-  "supersededAt"    timestamp with time zone
+  "createdAt"       timestamp with time zone default now()
 );
 
 
 CREATE INDEX IF NOT EXISTS "user_attributes_user_id_idx" ON "userAttributes" ("userId");
 CREATE INDEX IF NOT EXISTS "user_attributes_name_idx" ON "userAttributes" ("name");
 CREATE INDEX IF NOT EXISTS "user_attributes_value_idx" ON "userAttributes" ("value");
+CREATE INDEX IF NOT EXISTS "user_attributes_user_id_name_idx" ON "userAttributes" ("userId", "name");

--- a/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-up.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230203150933-user-attributes-up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "userAttributes" (
+  "id"              uuid primary key not null default uuid_generate_v4(),
+  "userId"          uuid references "users" on update cascade on delete set null,
+  "name"            text not null,
+  "value"           text,
+  "createdAt"       timestamp with time zone default now(),
+  "supersededAt"    timestamp with time zone
+);
+
+
+CREATE INDEX IF NOT EXISTS "user_attributes_user_id_idx" ON "userAttributes" ("userId");
+CREATE INDEX IF NOT EXISTS "user_attributes_name_idx" ON "userAttributes" ("name");
+CREATE INDEX IF NOT EXISTS "user_attributes_value_idx" ON "userAttributes" ("value");

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -677,8 +677,32 @@
       "value": "Ihr Republik-Abonnement wurde deaktiviert"
     },
     {
+      "key": "api/email/membership_deactivated_yearly_abo_uncancelled/subject",
+      "value": "TODO: api/email/membership_deactivated_yearly_abo_uncancelled/subject"
+    },
+    {
       "key": "api/email/membership_deactivated/subject",
       "value": "Ihre Mitgliedschaft wurde deaktiviert"
+    },
+    {
+      "key": "api/email/future_campaign_sender_reward/1/subject",
+      "value": "Sie haben Verstärkung geholt!"
+    },
+    {
+      "key": "api/email/future_campaign_sender_reward/2/subject",
+      "value": "Doppelte Verstärkung!"
+    },
+    {
+      "key": "api/email/future_campaign_sender_reward/3/subject",
+      "value": "Mit Ihnen wird die Zukunft greifbar!"
+    },
+    {
+      "key": "api/email/future_campaign_sender_reward/4/subject",
+      "value": "Da war es nur noch eins"
+    },
+    {
+      "key": "api/email/future_campaign_sender_reward/5/subject",
+      "value": "Herzliche Gratulation!"
     },
     {
       "key": "api/discussion/404",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8197,6 +8197,11 @@ dayjs@^1.11.6:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"
   integrity sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 db-migrate-base@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/db-migrate-base/-/db-migrate-base-2.3.1.tgz#97029e230b344f00cf2e4475e2e6027f7b09994c"


### PR DESCRIPTION
This PR:

- adds new prop to `User` indicating how many mitstreiter slots (`futureCampaignAboSlots`) are used 
- adds a new method which is executed if certian utm_params are given in a payload of a pledge. this methods includes
  - updating mitstreiter slot count
  - fetching consent if sender wants to donate month
  - if not donating: fetching current membership period and adding an extra month to this period
  - sending an email with all these information to the sender
- adds mail template to be sent to sender accordingly 
- adds database migration to hold user attributes

TODO:
- [ ] send slack message
- [ ] proper error message if sth. does not go well during reward process
