### PR TITLE
Discussion respecing allowed roles

### DIFF
--- a/apps/publikator/components/editor/modules/meta/ui.js
+++ b/apps/publikator/components/editor/modules/meta/ui.js
@@ -272,6 +272,31 @@ const MetaData = ({
           black
           getWidth={() => '50%'}
         />
+        {['article', 'discussion'].includes(titleData.meta.template) && (
+          <>
+            <Checkbox
+              checked={node.data
+                .get('discussionAllowedRoles')
+                ?.includes('climate')}
+              onChange={(_, checked) => {
+                let newData = node.data
+                editor.change((change) => {
+                  change.setNodeByKey(node.key, {
+                    data: checked
+                      ? newData.set('discussionAllowedRoles', ['climate'])
+                      : newData.remove('discussionAllowedRoles'),
+                  })
+                })
+              }}
+              black
+            >
+              {t('metaData/discussionAllowedRoles')}
+            </Checkbox>
+            <br />
+            <br />
+            <br />
+          </>
+        )}
         {!!series && (
           <SeriesForm
             repoId={titleData.repoId}

--- a/apps/publikator/components/editor/modules/meta/ui.js
+++ b/apps/publikator/components/editor/modules/meta/ui.js
@@ -272,8 +272,8 @@ const MetaData = ({
           black
           getWidth={() => '50%'}
         />
-        {['article', 'discussion'].includes(titleData.meta.template) && (
-          <>
+        {!node.data.get('discussion') &&
+          ['article', 'discussion'].includes(titleData.meta.template) && (
             <Checkbox
               checked={node.data
                 .get('discussionAllowedRoles')
@@ -292,11 +292,9 @@ const MetaData = ({
             >
               {t('metaData/discussionAllowedRoles')}
             </Checkbox>
-            <br />
-            <br />
-            <br />
-          </>
-        )}
+          )}
+        <br />
+        <br />
         {!!series && (
           <SeriesForm
             repoId={titleData.repoId}

--- a/apps/publikator/lib/translations.json
+++ b/apps/publikator/lib/translations.json
@@ -961,6 +961,10 @@
       "value": "Die Publikation ist für {date} geplant."
     },
     {
+      "key": "metaData/discussionAllowedRoles",
+      "value": "Diskussion für Klimalabor-User öffnen"
+    },
+    {
       "key": "colorPicker/contrastInfo/title",
       "value": "Farbkontrast"
     },

--- a/apps/www/components/Access/Grants.js
+++ b/apps/www/components/Access/Grants.js
@@ -17,7 +17,10 @@ const getAccessGrants = (accessGrants, type) => {
   return (
     accessGrants.length > 0 &&
     accessGrants.filter((grant) => {
-      return grant.campaign.type === type
+      return (
+        grant.campaign.type === type &&
+        grant.campaign.id === 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2'
+      )
     })
   )
 }
@@ -32,13 +35,15 @@ const AccessGrants = ({ accessGrants, inNativeIOSApp, t }) => {
       new Date(),
     )
 
-  /* TODO: Special solution for CLIMATE lab, we know here that atm there is only 
-  one reduced campaign. 
-  As soon as we have the new access model we should revise this */
+  /* TODO: Special solution for CLIMATE lab, should be removed later */
   const reducedAccessGrants = getAccessGrants(accessGrants, 'REDUCED')
-  const currentReducedAccessGrant =
-    reducedAccessGrants.length > 0 && reducedAccessGrants[0]
-  const beginAtReduced = new Date(currentReducedAccessGrant.beginAt)
+  const reducedMaxEndAt =
+    reducedAccessGrants.length > 0 &&
+    reducedAccessGrants.reduce(
+      (acc, grant) =>
+        new Date(grant.endAt) > acc ? new Date(grant.endAt) : acc,
+      new Date(),
+    )
 
   return maxEndAt ? (
     <P>
@@ -56,17 +61,11 @@ const AccessGrants = ({ accessGrants, inNativeIOSApp, t }) => {
         </>
       )}
     </P>
-  ) : currentReducedAccessGrant ? (
+  ) : reducedMaxEndAt ? (
     <P>
       {t.elements('Account/Access/Grants/REDUCED/message/claimed', {
-        campaignTitle: currentReducedAccessGrant.campaign.title,
-        maxEndAt: (
-          <span>
-            {dayFormat(
-              new Date(beginAtReduced.setMonth(beginAtReduced.getMonth() + 1)),
-            )}
-          </span>
-        ),
+        campaignTitle: 'Klimalabor',
+        maxEndAt: <span>{dayFormat(new Date(reducedMaxEndAt))}</span>,
       })}
       {!inNativeIOSApp && (
         <>

--- a/apps/www/components/Access/Grants.js
+++ b/apps/www/components/Access/Grants.js
@@ -17,10 +17,7 @@ const getAccessGrants = (accessGrants, type) => {
   return (
     accessGrants.length > 0 &&
     accessGrants.filter((grant) => {
-      return (
-        grant.campaign.type === type &&
-        grant.campaign.id === 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2'
-      )
+      return grant.campaign.type === type
     })
   )
 }
@@ -37,13 +34,27 @@ const AccessGrants = ({ accessGrants, inNativeIOSApp, t }) => {
 
   /* TODO: Special solution for CLIMATE lab, should be removed later */
   const reducedAccessGrants = getAccessGrants(accessGrants, 'REDUCED')
-  const reducedMaxEndAt =
-    reducedAccessGrants.length > 0 &&
-    reducedAccessGrants.reduce(
-      (acc, grant) =>
-        new Date(grant.endAt) > acc ? new Date(grant.endAt) : acc,
-      new Date(),
-    )
+
+  const climateLabTrials = reducedAccessGrants.filter(
+    (grant) => grant.campaign.id === 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2',
+  )
+  const climateLab = reducedAccessGrants.filter(
+    (grant) => grant.campaign.id === '3684f324-b694-4930-ad1a-d00a2e00934b',
+  )
+  const climateLabBeginDate = climateLab.length
+    ? new Date(climateLab[0].beginAt)
+    : null
+
+  const reducedMaxEndAt = climateLabTrials.length
+    ? climateLabTrials.reduce(
+        (acc, grant) =>
+          new Date(grant.endAt) > acc ? new Date(grant.endAt) : acc,
+        new Date(),
+      )
+    : climateLabBeginDate &&
+      new Date(climateLabBeginDate.setMonth(climateLabBeginDate.getMonth() + 1))
+
+  /* End special solution */
 
   return maxEndAt ? (
     <P>
@@ -61,7 +72,8 @@ const AccessGrants = ({ accessGrants, inNativeIOSApp, t }) => {
         </>
       )}
     </P>
-  ) : reducedMaxEndAt ? (
+  ) : /* TODO: special solution for CLIMATE lab, should be removed later on */
+  reducedMaxEndAt ? (
     <P>
       {t.elements('Account/Access/Grants/REDUCED/message/claimed', {
         campaignTitle: 'Klimalabor',
@@ -77,7 +89,7 @@ const AccessGrants = ({ accessGrants, inNativeIOSApp, t }) => {
           </Link>
         </>
       )}
-    </P>
+    </P> /* End special */
   ) : null
 }
 

--- a/apps/www/components/Account/belongingsQuery.js
+++ b/apps/www/components/Account/belongingsQuery.js
@@ -51,6 +51,7 @@ export default gql`
         endAt
         beginAt
         campaign {
+          id
           title
           description
           type

--- a/apps/www/pages/dialog.js
+++ b/apps/www/pages/dialog.js
@@ -77,7 +77,6 @@ const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
   const { t } = useTranslation()
   const { query } = useRouter()
   const [colorScheme] = useColorContext()
-
   const discussionContext = useDiscussion()
 
   if (
@@ -156,27 +155,29 @@ const DialogContent = ({ tab, activeDiscussionId, serverContext }) => {
               <ActionBar discussion={activeDiscussionId} fontSize />
             </div>
           )}
-          <WithoutAccess
-            render={() => (
-              <>
-                <UnauthorizedMessage
-                  unauthorizedTexts={{
-                    title: ' ',
-                    description: t.elements('feedback/unauthorized', {
-                      buyLink: (
-                        <Link href='/angebote' passHref>
-                          <A>{t('feedback/unauthorized/buyText')}</A>
-                        </Link>
-                      ),
-                    }),
-                  }}
-                />
-                <br />
-                <br />
-                <br />
-              </>
-            )}
-          />
+          {!discussionContext?.discussion?.userCanComment && (
+            <WithoutAccess
+              render={() => (
+                <>
+                  <UnauthorizedMessage
+                    unauthorizedTexts={{
+                      title: ' ',
+                      description: t.elements('feedback/unauthorized', {
+                        buyLink: (
+                          <Link href='/angebote' passHref>
+                            <A>{t('feedback/unauthorized/buyText')}</A>
+                          </Link>
+                        ),
+                      }),
+                    }}
+                  />
+                  <br />
+                  <br />
+                  <br />
+                </>
+              )}
+            />
+          )}
           {!tab && (
             <>
               <H3>{t('marketing/community/title/plain')}</H3>

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -9,8 +9,16 @@ module.exports = async (discussion, _, context) => {
     return false
   }
 
+  /* TODO: das geht aber noch besser, jetzt ist's so hin und her */
+  const additionalAllowedRoles = discussion.allowedRoles.filter(
+    (role) => !['member', 'debater'].includes(role),
+  )
+  const isInAllowedRoles =
+    additionalAllowedRoles.length > 0 &&
+    Roles.userIsInRoles(user, discussion.allowedRoles)
+
   const isMember = Roles.userIsInRoles(user, ['member'])
-  if (!isMember) {
+  if (!isMember && !isInAllowedRoles) {
     return false
   }
 
@@ -18,5 +26,5 @@ module.exports = async (discussion, _, context) => {
   const hasActiveMembership =
     !!user && (await hasUserActiveMembership(user, pgdb))
 
-  return hasActiveMembership || isDebater
+  return hasActiveMembership || isDebater || isInAllowedRoles
 }

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -1,6 +1,8 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
+const DEFAULT_ROLES = ['member']
+
 module.exports = async (discussion, _, context) => {
   const { closed } = discussion
   const { user, pgdb } = context
@@ -9,16 +11,19 @@ module.exports = async (discussion, _, context) => {
     return false
   }
 
-  /* TODO: das geht aber noch besser, jetzt ist's so hin und her */
   const additionalAllowedRoles = discussion.allowedRoles.filter(
-    (role) => !['member', 'debater'].includes(role),
+    (role) => ![DEFAULT_ROLES].includes(role),
   )
   const isInAllowedRoles =
     additionalAllowedRoles.length > 0 &&
     Roles.userIsInRoles(user, discussion.allowedRoles)
 
+  if (isInAllowedRoles) {
+    return true
+  }
+
   const isMember = Roles.userIsInRoles(user, ['member'])
-  if (!isMember && !isInAllowedRoles) {
+  if (!isMember) {
     return false
   }
 
@@ -26,5 +31,5 @@ module.exports = async (discussion, _, context) => {
   const hasActiveMembership =
     !!user && (await hasUserActiveMembership(user, pgdb))
 
-  return hasActiveMembership || isDebater || isInAllowedRoles
+  return hasActiveMembership || isDebater
 }

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/downvoteComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/downvoteComment.js
@@ -1,8 +1,6 @@
-const { Roles } = require('@orbiting/backend-modules-auth')
 const voteComment = require('../../../lib/voteComment')
 
 module.exports = async (_, args, { pgdb, user, t, pubsub, loaders }) => {
-  Roles.ensureUserHasRole(user, 'member')
   const { id } = args
   const vote = -1
   return voteComment(id, vote, pgdb, user, t, pubsub, loaders)

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/editComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/editComment.js
@@ -8,27 +8,24 @@ module.exports = async (_, args, context) => {
   const { pgdb, user, t, pubsub, loaders } = context
   const { id, content, tags } = args
 
-  Roles.ensureUserHasRole(user, 'member')
-
-  if (!content || !content.trim().length) {
-    throw new Error(t('api/comment/empty'))
-  }
-
-  let discussion
-  let comment
-  let newComment
   const transaction = await pgdb.transactionBegin()
   try {
     // ensure comment exists and belongs to user
-    comment = await transaction.public.comments.findOne({ id })
+    const comment = await transaction.public.comments.findOne({ id })
     if (!comment) {
       throw new Error(t('api/comment/404'))
     }
+
+    const discussion = await loaders.Discussion.byId.load(comment.discussionId)
+    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
+
+    if (!content || !content.trim().length) {
+      throw new Error(t('api/comment/empty'))
+    }
+
     if (!comment.userId || comment.userId !== user.id) {
       throw new Error(t('api/comment/notYours'))
     }
-
-    discussion = await loaders.Discussion.byId.load(comment.discussionId)
 
     if (discussion.closed) {
       throw new Error(t('api/comment/closed'))
@@ -52,31 +49,31 @@ module.exports = async (_, args, context) => {
       )
     }
 
-    newComment = await transaction.public.comments.updateAndGetOne(
+    const newComment = await transaction.public.comments.updateAndGetOne(
       { id: comment.id },
       unsavedComment,
     )
 
     await transaction.transactionCommit()
+
+    if (newComment) {
+      await Promise.all([
+        loaders.Comment.byId.clear(comment.id),
+        pubsub.publish('comment', {
+          comment: {
+            mutation: 'UPDATED',
+            node: newComment,
+          },
+        }),
+        slack.publishCommentUpdate(newComment, comment, discussion, context),
+      ]).catch((e) => {
+        console.error(e)
+      })
+    }
+
+    return newComment
   } catch (e) {
     await transaction.transactionRollback()
     throw e
   }
-
-  if (newComment) {
-    await Promise.all([
-      loaders.Comment.byId.clear(comment.id),
-      pubsub.publish('comment', {
-        comment: {
-          mutation: 'UPDATED',
-          node: newComment,
-        },
-      }),
-      slack.publishCommentUpdate(newComment, comment, discussion, context),
-    ]).catch((e) => {
-      console.error(e)
-    })
-  }
-
-  return newComment
 }

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/setDiscussionPreferences.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/setDiscussionPreferences.js
@@ -4,8 +4,6 @@ const {
 } = require('../../../lib/discussionPreferences')
 
 module.exports = async (_, args, { pgdb, user, t, loaders }) => {
-  Roles.ensureUserHasRole(user, 'member')
-
   const { id, discussionPreferences } = args
 
   const transaction = await pgdb.transactionBegin()
@@ -16,6 +14,8 @@ module.exports = async (_, args, { pgdb, user, t, loaders }) => {
     if (!discussion) {
       throw new Error(t('api/discussion/404'))
     }
+
+    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
 
     await setDiscussionPreferences({
       discussionPreferences,

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/submitComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/submitComment.js
@@ -15,7 +15,6 @@ const { submitComment: notify } = require('../../../lib/Notifications')
 
 module.exports = async (_, args, context) => {
   const { pgdb, loaders, user: me, t, pubsub } = context
-  Roles.ensureUserHasRole(me, 'member')
 
   const { id, discussionId, parentId, content, discussionPreferences, tags } =
     args
@@ -28,6 +27,8 @@ module.exports = async (_, args, context) => {
   if (!discussion) {
     throw new Error(t('api/discussion/404'))
   }
+
+  Roles.ensureUserIsInRoles(me, discussion.allowedRoles)
 
   // check if client-side generated ID already exists
   if (id && !!(await loaders.Comment.byId.load(id))) {

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/unpublishComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/unpublishComment.js
@@ -5,8 +5,6 @@ module.exports = async (_, args, context) => {
   const { id } = args
   const { pgdb, user, t, pubsub } = context
 
-  Roles.ensureUserHasRole(user, 'member')
-
   const transaction = await pgdb.transactionBegin()
   try {
     // ensure comment exists and belongs to user
@@ -21,6 +19,12 @@ module.exports = async (_, args, context) => {
     ) {
       throw new Error(t('api/comment/notYours'))
     }
+
+    const discussion = await pgdb.public.discussions.findOne({
+      id: comment.discussionId,
+    })
+
+    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
 
     const update =
       comment.userId === user.id
@@ -41,10 +45,6 @@ module.exports = async (_, args, context) => {
         mutation: 'UPDATED',
         node: updatedComment,
       },
-    })
-
-    const discussion = await pgdb.public.discussions.findOne({
-      id: comment.discussionId,
     })
 
     await slack.publishCommentUnpublish(

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/unvoteComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/unvoteComment.js
@@ -1,7 +1,5 @@
-const { Roles } = require('@orbiting/backend-modules-auth')
 const voteComment = require('../../../lib/voteComment')
 
 module.exports = async (_, args, { pgdb, user, t, pubsub, loaders }) => {
-  Roles.ensureUserHasRole(user, 'member')
   return voteComment(args.id, 0, pgdb, user, t, pubsub, loaders)
 }

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/upvoteComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/upvoteComment.js
@@ -1,8 +1,6 @@
-const { Roles } = require('@orbiting/backend-modules-auth')
 const voteComment = require('../../../lib/voteComment')
 
 module.exports = async (_, args, { pgdb, user, t, pubsub, loaders }) => {
-  Roles.ensureUserHasRole(user, 'member')
   const { id } = args
   const vote = 1
   return voteComment(id, vote, pgdb, user, t, pubsub, loaders)

--- a/packages/backend-modules/discussions/graphql/schema-types.js
+++ b/packages/backend-modules/discussions/graphql/schema-types.js
@@ -58,6 +58,7 @@ type DiscussionRules {
   minInterval: Int
   anonymity: Permission!
   disableTopLevelComments: Boolean
+  allowedRoles: [String!]!
 }
 
 type DiscussionPreferences {

--- a/packages/backend-modules/discussions/lib/Discussion.js
+++ b/packages/backend-modules/discussions/lib/Discussion.js
@@ -32,6 +32,7 @@ const upsert = async (
       await loaders.Discussion.clear(legacyDiscussionId)
     }
   } else {
+    console.log(`meta roles ${settings.allowedRoles}`)
     if (
       (settings.title && settings.title !== discussion.title) ||
       (settings.maxLength && settings.maxLength !== discussion.maxLength) ||
@@ -51,6 +52,8 @@ const upsert = async (
       (settings.tagRequired !== undefined &&
         settings.tagRequired !== discussion.tagRequired) ||
       (settings.tags && settings.tags !== (discussion.tags || []).join(',')) ||
+      (settings.allowedRoles &&
+        settings.allowedRoles !== (discussion.allowedRoles || []).join(',')) ||
       (!discussion.repoId && id && !idIsUUID && legacyDiscussionId) // to save repoId to existing discussions
     ) {
       discussion = await pgdb.public.discussions.updateAndGetOne(

--- a/packages/backend-modules/discussions/lib/discussionPreferences.js
+++ b/packages/backend-modules/discussions/lib/discussionPreferences.js
@@ -112,7 +112,6 @@ const ensureAnonymousDifferentiator = async ({
   t,
   loaders,
 }) => {
-  // const discussionId = discussion.id
   const discussionId = discussion.id
   const findQuery = {
     userId,

--- a/packages/backend-modules/discussions/lib/voteComment.js
+++ b/packages/backend-modules/discussions/lib/voteComment.js
@@ -1,4 +1,5 @@
 const hotness = require('./hotness')
+const { Roles } = require('@orbiting/backend-modules-auth')
 
 module.exports = async (commentId, vote, pgdb, user, t, pubsub, loaders) => {
   if (![-1, 0, 1].includes(vote)) {
@@ -24,6 +25,9 @@ module.exports = async (commentId, vote, pgdb, user, t, pubsub, loaders) => {
     if (!comment) {
       throw new Error(t('api/comment/404'))
     }
+
+    const discussion = await loaders.Discussion.byId.load(comment.discussionId)
+    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
 
     const existingUserVote = comment.votes.find(
       (vote) => vote.userId === user.id,

--- a/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-down.sql
+++ b/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "discussions"
+  DROP COLUMN IF EXISTS "allowedRoles"
+;

--- a/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-up.sql
+++ b/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "discussions"
+  ADD COLUMN "allowedRoles" jsonb NOT NULL DEFAULT '["member", "debater"]'::jsonb
+;

--- a/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-up.sql
+++ b/packages/backend-modules/discussions/migrations/sqls/20230123153633-discussion-allowedRoles-up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "discussions"
-  ADD COLUMN "allowedRoles" jsonb NOT NULL DEFAULT '["member", "debater"]'::jsonb
+  ADD COLUMN "allowedRoles" jsonb NOT NULL DEFAULT '["member"]'::jsonb
 ;

--- a/packages/backend-modules/mail/script/generateClimateAccessGrants.js
+++ b/packages/backend-modules/mail/script/generateClimateAccessGrants.js
@@ -1,0 +1,78 @@
+require('@orbiting/backend-modules-env').config()
+const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
+const Promise = require('bluebird')
+const dayjs = require('dayjs')
+const yargs = require('yargs')
+
+const argv = yargs.options('dry-run', { default: true }).argv
+
+PgDb.connect()
+  .then(async (pgdb) => {
+    const { dryRun } = argv
+
+    console.log(
+      'running script to add temporary 1 month access grants for each climate lab user...',
+    )
+
+    const climateAccessGrants = await pgdb.public.accessGrants.find({
+      accessCampaignId: '3684f324-b694-4930-ad1a-d00a2e00934b',
+      invalidatedAt: null,
+    })
+
+    console.log(`${climateAccessGrants.length} climate access grants found...`)
+
+    if (dryRun) {
+      console.log('dryRun: will not insert rows')
+      console.log(`rows will look like this: `)
+      const grant = climateAccessGrants[0]
+
+      console.log({
+        accessCampaignId: 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2', // temporary campaign
+        granterUserId: grant.granterUserId,
+        recipientUserId: grant.recipientUserId,
+        beginAt: grant.beginAt,
+        endAt: dayjs(grant.beginAt).add(1, 'month'), // +1 month
+        beginBefore: grant.beginBefore,
+      })
+    } else {
+      await Promise.map(
+        climateAccessGrants,
+        async (grant) => {
+          const existingGrant = await pgdb.public.accessGrants.findFirst({
+            accessCampaignId: 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2', // temporary campaign
+            granterUserId: grant.granterUserId,
+            recipientUserId: grant.recipientUserId,
+            beginAt: grant.beginAt,
+          })
+
+          if (!existingGrant) {
+            const result = await pgdb.public.accessGrants.insertAndGet({
+              accessCampaignId: 'f35c2fcf-c254-482e-b4fb-5c51a48a13d2', // temporary campaign
+              granterUserId: grant.granterUserId,
+              recipientUserId: grant.recipientUserId,
+              beginAt: grant.beginAt,
+              endAt: dayjs(grant.beginAt).add(1, 'month'), // +1 month
+              beginBefore: grant.beginBefore,
+            })
+            console.log(
+              `row ${result.id} inserted for user ${result.recipientUserId}`,
+            )
+          } else {
+            console.log(
+              `record for user ${grant.recipientUserId} already found. No row inserted`,
+            )
+          }
+        },
+        { concurrency: 20 },
+      )
+    }
+
+    console.log('finished!')
+  })
+  .then(() => {
+    process.exit()
+  })
+  .catch((e) => {
+    console.log(e)
+    process.exit(1)
+  })

--- a/packages/backend-modules/mail/templates/access_recipient_expired_klimalabor.html
+++ b/packages/backend-modules/mail/templates/access_recipient_expired_klimalabor.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>
+                      Das Klimalabor ist unterwegs mit einem klaren Ziel:
+                      Journalismus, der uns in der Klimakrise wirklich
+                      weiterbringt. Der in seiner Dringlichkeit und Ambition der
+                      Klimakrise gerecht wird. Der aufklärt, begeistert und
+                      nützlich ist.
+                    </p>
+                    <p>
+                      Sie und über 5000 andere Menschen unterstützen uns dabei —
+                      mit Ihrem Interesse, Ihren Ideen, Ihrer Expertise. Dafür
+                      sind wir sehr dankbar.
+                    </p>
+                    <p>
+                      Wir müssen aber auch ehrlich sein: Ohne nachhaltige
+                      Finanzierung geht es nicht. Wenn wir den Journalismus zur
+                      Klimakrise bei der Republik stärken wollen, dann brauchen
+                      wir zusätzliche Menschen, die mit einer Mitgliedschaft an
+                      Bord kommen.
+                    </p>
+                    <p>Was Sie dafür bekommen:</p>
+                    <ul
+                      style="color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <li>
+                        Unser Versprechen, dass wir im Klimalabor weiter mit
+                        voller Energie daran arbeiten, Journalismus für die
+                        Klimakrise neu zu denken.
+                      </li>
+                      <li>
+                        Weiterhin vollen Zugriff auf das komplette Angebot der
+                        Republik. Ein digitales Magazin für Politik, Wirtschaft,
+                        Gesellschaft und Kultur, in dem die Klimakrise eine
+                        immer wichtigere Rolle einnimmt. (Sie hatten bis jetzt
+                        einen Probezugriff als Dankeschön für Ihre Anmeldung zum
+                        Klimalabor.)
+                      </li>
+                      <li>
+                        Die Republik ist werbefrei und wird von ihren Leserinnen
+                        und Lesern finanziert. Ihre Investition in
+                        Klimajournalismus ist eine Investition in unabhängigen
+                        Qualitätsjournalismus.
+                      </li>
+                    </ul>
+                    <p>
+                      Zur Erinnerung ein paar Highlights der vergangenen Wochen
+                      aus der Republik:
+                      <a
+                        href="{{frontend_base_url}}/2023/01/14/serie-do-not-feed-the-google"
+                        >Die grosse Serie «Do not feed the Google»</a
+                      >, Rebecca Solnits Essay
+                      <a
+                        href="{{frontend_base_url}}/2023/01/16/wir-haben-kein-recht-vor-der-klimakrise-zu-kapitulieren"
+                        >«Wir haben kein Recht, vor der Klima­krise zu
+                        kapitulieren»</a
+                      >, das Treffen mit dem ukrainischen Schriftsteller­ehepaar
+                      Iryna Tsilyk und Artem Tschech:
+                      <a
+                        href="{{frontend_base_url}}/2023/01/21/iryna-tsilyk-und-artem-tschech-es-ist-unsere-aufgabe-voll-und-ganz-zu-leben"
+                        >«Es ist unsere Aufgabe, voll und ganz zu leben»</a
+                      >, die Bildkolumne Panamericana:
+                      <a
+                        href="{{frontend_base_url}}/2023/01/31/panamericana-leben-im-rhythmus-der-extreme"
+                        >«Leben im Rhythmus der Extreme»</a
+                      >.
+                    </p>
+                    <p>
+                      Es kommt auf jede einzelne Person an. Deshalb würden wir
+                      uns sehr freuen, Sie als Teil unserer Verlagsetage und
+                      Mitglied der Republik-Community willkommen zu heissen.
+                    </p>
+
+                    <p>Sie haben hierfür verschiedene Möglichkeiten:</p>
+
+                    <ol
+                      style="color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <li>
+                        <a href="{{link_offer_abo}}"
+                          >Die Jahresmitgliedschaft</a
+                        >
+                        für CHF 240.–/Jahr
+                        <p
+                          style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                        >
+                          Mit dieser Mitgliedschaft erhalten Sie unabhängigen
+                          und werbefreien Qualitätsjournalismus und sind Teil
+                          der Republik-Community. Gleichzeitig sind Sie Mitglied
+                          der Project R Genossenschaft – und damit Mitbesitzerin
+                          der Republik.
+                        </p>
+                      </li>
+                      <li>
+                        <a href="{{link_offer_monthly_abo}}"
+                          >Das Monatsabonnement</a
+                        >
+                        für CHF 22.–/Monat
+                        <p
+                          style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                        >
+                          Mit diesem Abo erhalten Sie Zugang zum Magazin und zum
+                          Dialog – ohne dass Sie Teil unserer Genossenschaft
+                          werden. Das Abonnement verlängert sich automatisch,
+                          kann aber jederzeit und ohne Frist gekündigt werden.
+                        </p>
+                      </li>
+                      <li>
+                        <a href="{{link_offer_benefactor}}"
+                          >Die Gönnermitgliedschaft</a
+                        >
+                        ab CHF 1000.–/Jahr
+                        <p
+                          style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                        >
+                          Mit der Gönnermitgliedschaft erhalten Sie Zugang zum
+                          vollständigen Republik-Angebot, ein Extra-Dankeschön
+                          und die Gewissheit, einen sehr wichtigen Beitrag zur
+                          Erhaltung einer freien, demokratischen Öffentlichkeit
+                          geleistet zu haben – denn Ihre Grosszügigkeit
+                          ermöglicht es, die Republik auch Personen zugänglich
+                          zu machen, die sich eine volle Mitgliedschaft nicht
+                          leisten könnten. Zudem sind Sie Teil der
+                          Republik-Community und Mitglied der Project R
+                          Genossenschaft.
+                        </p>
+                      </li>
+                      <li>
+                        <a href="{{link_offer_reduced_ausbildung}}"
+                          >Die Ausbildungsmitgliedschaft</a
+                        >
+                        für CHF 140.–/Jahr
+                        <p
+                          style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                        >
+                          Mit dieser Mitgliedschaft erhalten alle Auszubildenden
+                          und Studierenden Zugang zum vollständigen
+                          Republik-Angebot inklusive
+                          Genossenschafts-Mitgliedschaft – zu einem
+                          vergünstigten Preis.
+                        </p>
+                      </li>
+                      <li>
+                        Sie unterstützen uns weiterhin durch Ihre Mitwirkung im
+                        Klimalabor ohne Mitgliedschaft bei der Republik. Sie
+                        haben weiterhin Zugriff auf alles, was im Klimalabor
+                        läuft, nicht aber auf das Magazin der Republik.
+                      </li>
+                    </ol>
+                    <p>Sind Sie dabei?</p>
+                    <p>
+                      Bei Fragen helfen wir Ihnen unter
+                      <a href="mailto:klimalabor@republik.ch"
+                        >klimalabor@republik.ch</a
+                      >
+                      gerne weiter.
+                    </p>
+                    <p>
+                      Herzlich<br />
+                      Ihre Klimalabor-Crew: David Bauer, Elia Blülle, Theresa
+                      Leisgang
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/backend-modules/mail/templates/access_recipient_expired_klimalabor.txt
+++ b/packages/backend-modules/mail/templates/access_recipient_expired_klimalabor.txt
@@ -1,0 +1,88 @@
+Guten Tag
+
+Das Klimalabor ist unterwegs mit einem klaren Ziel: Journalismus, der uns in der
+Klimakrise wirklich weiterbringt. Der in seiner Dringlichkeit und Ambition der
+Klimakrise gerecht wird. Der aufklärt, begeistert und nützlich ist.
+
+Sie und über 5000 andere Menschen unterstützen uns dabei — mit Ihrem Interesse,
+Ihren Ideen, Ihrer Expertise. Dafür sind wir sehr dankbar.
+
+Wir müssen aber auch ehrlich sein: Ohne nachhaltige Finanzierung geht es nicht.
+Wenn wir den Journalismus zur Klimakrise bei der Republik stärken wollen, dann
+brauchen wir zusätzliche Menschen, die mit einer Mitgliedschaft an Bord kommen.
+
+Was Sie dafür bekommen:
+
+ * Unser Versprechen, dass wir im Klimalabor weiter mit voller Energie daran
+   arbeiten, Journalismus für die Klimakrise neu zu denken.
+ * Weiterhin vollen Zugriff auf das komplette Angebot der Republik. Ein
+   digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur, in dem
+   die Klimakrise eine immer wichtigere Rolle einnimmt. (Sie hatten bis jetzt
+   einen Probezugriff als Dankeschön für Ihre Anmeldung zum Klimalabor.)
+ * Die Republik ist werbefrei und wird von ihren Leserinnen und Lesern
+   finanziert. Ihre Investition in Klimajournalismus ist eine Investition in
+   unabhängigen Qualitätsjournalismus.
+
+Zur Erinnerung ein paar Highlights der vergangenen Wochen aus der Republik: Die
+grosse Serie «Do not feed the Google»
+{{frontend_base_url}}/2023/01/14/serie-do-not-feed-the-google , Rebecca Solnits
+Essay «Wir haben kein Recht, vor der Klima­krise zu kapitulieren»
+{{frontend_base_url}}/2023/01/16/wir-haben-kein-recht-vor-der-klimakrise-zu-kapitulieren
+, das Treffen mit dem ukrainischen Schriftsteller­ehepaar Iryna Tsilyk und Artem
+Tschech: «Es ist unsere Aufgabe, voll und ganz zu leben»
+{{frontend_base_url}}/2023/01/21/iryna-tsilyk-und-artem-tschech-es-ist-unsere-aufgabe-voll-und-ganz-zu-leben
+, die Bildkolumne Panamericana: «Leben im Rhythmus der Extreme»
+{{frontend_base_url}}/2023/01/31/panamericana-leben-im-rhythmus-der-extreme .
+
+Es kommt auf jede einzelne Person an. Deshalb würden wir uns sehr freuen, Sie
+als Teil unserer Verlagsetage und Mitglied der Republik-Community willkommen zu
+heissen.
+
+Sie haben hierfür verschiedene Möglichkeiten:
+
+ 1. Die Jahresmitgliedschaft {{link_offer_abo}} für CHF 240.–/Jahr
+    
+    Mit dieser Mitgliedschaft erhalten Sie unabhängigen und werbefreien
+    Qualitätsjournalismus und sind Teil der Republik-Community. Gleichzeitig
+    sind Sie Mitglied der Project R Genossenschaft – und damit Mitbesitzerin der
+    Republik.
+
+ 2. Das Monatsabonnement {{link_offer_monthly_abo}} für CHF 22.–/Monat
+    
+    Mit diesem Abo erhalten Sie Zugang zum Magazin und zum Dialog – ohne dass
+    Sie Teil unserer Genossenschaft werden. Das Abonnement verlängert sich
+    automatisch, kann aber jederzeit und ohne Frist gekündigt werden.
+
+ 3. Die Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
+    
+    Mit der Gönnermitgliedschaft erhalten Sie Zugang zum vollständigen
+    Republik-Angebot, ein Extra-Dankeschön und die Gewissheit, einen sehr
+    wichtigen Beitrag zur Erhaltung einer freien, demokratischen Öffentlichkeit
+    geleistet zu haben – denn Ihre Grosszügigkeit ermöglicht es, die Republik
+    auch Personen zugänglich zu machen, die sich eine volle Mitgliedschaft nicht
+    leisten könnten. Zudem sind Sie Teil der Republik-Community und Mitglied der
+    Project R Genossenschaft.
+
+ 4. Die Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} für CHF
+    140.–/Jahr
+    
+    Mit dieser Mitgliedschaft erhalten alle Auszubildenden und Studierenden
+    Zugang zum vollständigen Republik-Angebot inklusive
+    Genossenschafts-Mitgliedschaft – zu einem vergünstigten Preis.
+
+ 5. Sie unterstützen uns weiterhin durch Ihre Mitwirkung im Klimalabor ohne
+    Mitgliedschaft bei der Republik. Sie haben weiterhin Zugriff auf alles, was
+    im Klimalabor läuft, nicht aber auf das Magazin der Republik.
+
+Sind Sie dabei?
+
+Bei Fragen helfen wir Ihnen unter klimalabor@republik.ch gerne weiter.
+
+Herzlich
+Ihre Klimalabor-Crew: David Bauer, Elia Blülle, Theresa Leisgang
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/backend-modules/mail/templates/access_recipient_onboarding_klimalabor.html
+++ b/packages/backend-modules/mail/templates/access_recipient_onboarding_klimalabor.html
@@ -96,18 +96,6 @@
                           stehen und wie Sie sich einbringen können.
                         </p>
                       </li>
-                      {{#unless RECIPIENT_HAS_MEMBERSHIPS}}
-                      <li>
-                        <p>
-                          Damit Sie die Republik auch über das Klimalabor hinaus
-                          kennenlernen können, erhalten Sie als kleines
-                          Dankeschön für Ihre Mitwirkung für einen Monat Zugriff
-                          <a href="{{frontend_base_url}}"
-                            >auf sämtliche Inhalte der Republik</a
-                          >.
-                        </p>
-                      </li>
-                      {{/unless}}
                     </ul>
 
                     <p>

--- a/packages/backend-modules/mail/templates/access_recipient_onboarding_klimalabor.txt
+++ b/packages/backend-modules/mail/templates/access_recipient_onboarding_klimalabor.txt
@@ -20,14 +20,6 @@ Gut zu wissen:
  * Etwa alle ein bis zwei Wochen melden wir uns per Newsletter bei Ihnen und
    informieren Sie, wo wir stehen und wie Sie sich einbringen können.
 
-   {{#unless RECIPIENT_HAS_MEMBERSHIPS}}
-
- * Damit Sie die Republik auch über das Klimalabor hinaus kennenlernen können,
-   erhalten Sie als kleines Dankeschön für Ihre Mitwirkung für einen Monat
-   Zugriff auf sämtliche Inhalte der Republik {{frontend_base_url}} .
-
-   {{/unless}}
-
 Wie Sie sich gleich zu Beginn einbringen können:
 
  * Machen Sie mit uns eine Zeitreise und zeigen Sie uns, wie Sie in die Zukunft

--- a/packages/backend-modules/migrations/migrations/20230123153633-discussion-allowedRoles.js
+++ b/packages/backend-modules/migrations/migrations/20230123153633-discussion-allowedRoles.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/discussions/migrations/sqls'
+const file = '20230123153633-discussion-allowedRoles'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/publikator/lib/Discussion.js
+++ b/packages/backend-modules/publikator/lib/Discussion.js
@@ -17,7 +17,7 @@ const upsert = async (docMeta, context, legacyDiscussionId) => {
     board = null,
     tags,
     tagRequired,
-    discussionAllowedRoles = null,
+    discussionAllowedRoles,
     template,
   } = docMeta
 
@@ -42,8 +42,8 @@ const upsert = async (docMeta, context, legacyDiscussionId) => {
     tags: tags ? tags.trim().split(',') : null,
     tagRequired: !!tagRequired,
     allowedRoles: discussionAllowedRoles
-      ? discussionAllowedRoles.trim().split(',').concat(DEFAULT_ROLES)
-      : null,
+      ? discussionAllowedRoles.concat(DEFAULT_ROLES)
+      : DEFAULT_ROLES,
   }
 
   return upsertDiscussion(repoId, settings, context, legacyDiscussionId)

--- a/packages/backend-modules/publikator/lib/Discussion.js
+++ b/packages/backend-modules/publikator/lib/Discussion.js
@@ -2,6 +2,8 @@ const {
   Discussion: { upsert: upsertDiscussion },
 } = require('@orbiting/backend-modules-discussions')
 
+const DEFAULT_ROLES = ['member']
+
 const upsert = async (docMeta, context, legacyDiscussionId) => {
   const {
     title,
@@ -15,6 +17,7 @@ const upsert = async (docMeta, context, legacyDiscussionId) => {
     board = null,
     tags,
     tagRequired,
+    discussionAllowedRoles = null,
     template,
   } = docMeta
 
@@ -38,6 +41,9 @@ const upsert = async (docMeta, context, legacyDiscussionId) => {
     ...(board !== null ? { isBoard: !!board } : {}),
     tags: tags ? tags.trim().split(',') : null,
     tagRequired: !!tagRequired,
+    allowedRoles: discussionAllowedRoles
+      ? discussionAllowedRoles.trim().split(',').concat(DEFAULT_ROLES)
+      : null,
   }
 
   return upsertDiscussion(repoId, settings, context, legacyDiscussionId)

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -1217,6 +1217,10 @@
       "value": "Ihre Reise ist beendet"
     },
     {
+      "key": "api/access/email/recipient/expired_klimalabor/subject",
+      "value": "Machen Sie es wie wir: Investieren Sie in Klimajournalismus"
+    },
+    {
       "key": "api/access/email/recipient/followup/subject",
       "value": "Zeit für eine Entscheidung"
     },

--- a/packages/styleguide/src/templates/Article/index.js
+++ b/packages/styleguide/src/templates/Article/index.js
@@ -141,10 +141,6 @@ const createSchema = ({
       ref: 'bool',
     },
     {
-      label: 'Rollen (kommasepariert)',
-      key: 'discussionAllowedRoles',
-    },
-    {
       label: 'Format',
       key: 'format',
       ref: 'repo',

--- a/packages/styleguide/src/templates/Article/index.js
+++ b/packages/styleguide/src/templates/Article/index.js
@@ -141,6 +141,10 @@ const createSchema = ({
       ref: 'bool',
     },
     {
+      label: 'Rollen (kommasepariert)',
+      key: 'discussionAllowedRoles',
+    },
+    {
       label: 'Format',
       key: 'format',
       ref: 'repo',

--- a/packages/styleguide/src/templates/Discussion/index.js
+++ b/packages/styleguide/src/templates/Discussion/index.js
@@ -68,6 +68,10 @@ const createDiscussionSchema = ({
         label: 'Tags (kommasepariert)',
         key: 'tags',
       },
+      {
+        label: 'Rollen (kommasepariert)',
+        key: 'discussionAllowedRoles',
+      },
       ...customMetaFields,
     ],
     ...args,

--- a/packages/styleguide/src/templates/Discussion/index.js
+++ b/packages/styleguide/src/templates/Discussion/index.js
@@ -68,10 +68,6 @@ const createDiscussionSchema = ({
         label: 'Tags (kommasepariert)',
         key: 'tags',
       },
-      {
-        label: 'Rollen (kommasepariert)',
-        key: 'discussionAllowedRoles',
-      },
       ...customMetaFields,
     ],
     ...args,


### PR DESCRIPTION
This PR:

- adds option in meta section of publikator to open up discussion (article or discussion) for climate users
- adds handling of allowedRoles when document is published
- adds script to add new access grant to all climate users which handles expiring of trial
- changes edit and voting mutations on discussions so that users with specified roles are allowed to do these actions
- changes special handling for box on account page

Can be tested on love:
- if you subscribe now to Klimalabor you should only get `climate` role
- e.g. in this discusssion you should be able to comment, vote, ... https://www.republik.love/2023/01/31/mit-voller-kraft-gegen-die-klimakrise-diskutieren-sie-mit/diskussion and and here you should not be able: https://www.republik.love/dialog?t=article&id=69ea384b-1cd9-4e83-876b-e721e0e82e09
- can be changed in publikator for each discussion