### PR TITLE
feat(Questionnaire): add userIds filter to submissions query

### DIFF
--- a/packages/backend-modules/voting/graphql/schema-types.js
+++ b/packages/backend-modules/voting/graphql/schema-types.js
@@ -268,6 +268,8 @@ input SubmissionsFilterInput {
 
   answeredQuestionIds: [ID!]
   hasAnswers: Boolean @deprecated(reason: "use \`answeredQuestionIds\` instead")
+  
+  userIds: [ID!]
 }
 
 input SubmissionsSortInput {

--- a/packages/backend-modules/voting/lib/Submission.js
+++ b/packages/backend-modules/voting/lib/Submission.js
@@ -76,6 +76,9 @@ const createSubmissionsQuery = ({
     },
   }
   const mustUserId = userId && { term: { userId } }
+  const mustUserIds = filters?.userIds && {
+    terms: { userId: filters?.userIds },
+  }
   const mustQuestionnaireId = questionnaireId && { term: { questionnaireId } }
   const mustSearch = search && {
     bool: {
@@ -139,6 +142,7 @@ const createSubmissionsQuery = ({
         hasAnswers,
         mustBeforeDate,
         mustUserId,
+        mustUserIds,
         mustQuestionnaireId,
         mustSearch,
         mustValue,

--- a/packages/backend-modules/voting/lib/Submission.js
+++ b/packages/backend-modules/voting/lib/Submission.js
@@ -77,7 +77,7 @@ const createSubmissionsQuery = ({
   }
   const mustUserId = userId && { term: { userId } }
   const mustUserIds = filters?.userIds && {
-    terms: { userId: filters?.userIds },
+    terms: { userId: filters.userIds },
   }
   const mustQuestionnaireId = questionnaireId && { term: { questionnaireId } }
   const mustSearch = search && {


### PR DESCRIPTION
We not can request the question of a specific user directly in the submission query.

`submissions(filters: {userIds: ["ca9c46ca-a21b-4f6e-aad3-1010acd419d5"]})`

[Like so.](http://localhost:5010/graphiql/?query=%7B%0A%20%20questionnaire(slug%3A%20%22sommer22%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20submissions(filters%3A%20%7BuserIds%3A%20%5B%22ca9c46ca-a21b-4f6e-aad3-1010acd419d5%22%5D%7D)%20%7B%0A%20%20%20%20%20%20totalCount%0A%20%20%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20createdAt%0A%20%20%20%20%20%20%20%20updatedAt%0A%20%20%20%20%20%20%20%20displayAuthor%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20slug%0A%20%20%20%20%20%20%20%20%20%20profilePicture%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20answers%20%7B%0A%20%20%20%20%20%20%20%20%20%20totalCount%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)

