### PR TITLE
Fix YouTube spelling

### DIFF
--- a/apps/publikator/lib/translations.json
+++ b/apps/publikator/lib/translations.json
@@ -1378,7 +1378,7 @@
     },
     {
       "key": "styleguide/video/dnt/player/youtube",
-      "value": "Youtube"
+      "value": "YouTube"
     },
     {
       "key": "styleguide/video/dnt/player/vimeo",

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -4338,7 +4338,7 @@
     },
     {
       "key": "styleguide/video/dnt/player/youtube",
-      "value": "Youtube"
+      "value": "YouTube"
     },
     {
       "key": "styleguide/video/dnt/player/vimeo",

--- a/packages/styleguide/src/lib/translations.json
+++ b/packages/styleguide/src/lib/translations.json
@@ -271,7 +271,7 @@
     },
     {
       "key": "styleguide/video/dnt/player/youtube",
-      "value": "Youtube"
+      "value": "YouTube"
     },
     {
       "key": "styleguide/video/dnt/player/vimeo",


### PR DESCRIPTION
Youtube => YouTube.

That's the correct way to spell the platform, as you can e.g. see here: https://www.youtube.com/howyoutubeworks/resources/brand-resources/#logos-icons-and-colors
