### PR TITLE
fix(Popover): limit height to 100dvh

### DIFF
--- a/apps/www/components/Frame/Popover/index.js
+++ b/apps/www/components/Frame/Popover/index.js
@@ -28,12 +28,18 @@ const Popover = ({ expanded, id, children }) => {
     <div
       {...css({
         top: HEADER_HEIGHT_MOBILE,
-        height: `calc(100vh - ${HEADER_HEIGHT_MOBILE}px)`,
+        height: [
+          `calc(100dvh - ${HEADER_HEIGHT_MOBILE}px)`,
+          `calc(100vh - ${HEADER_HEIGHT_MOBILE}px)`,
+        ],
         borderTopWidth: 1,
         borderTopStyle: 'solid',
         [mediaQueries.mUp]: {
           top: HEADER_HEIGHT,
-          height: `calc(100vh - ${HEADER_HEIGHT}px)`,
+          height: [
+            `calc(100dvh - ${HEADER_HEIGHT}px)`,
+            `calc(100vh - ${HEADER_HEIGHT}px)`,
+          ],
         },
       })}
       {...colorScheme.set('borderColor', 'divider')}


### PR DESCRIPTION
Ensure that even when we have lots of items in the popover the bottom part remains accessible and not hidden behind the browser toolbar.