### PR TITLE
fix(Front): headline margins

### DIFF
--- a/packages/styleguide/src/components/TeaserFront/ImageHeadline.js
+++ b/packages/styleguide/src/components/TeaserFront/ImageHeadline.js
@@ -14,7 +14,7 @@ const baseSize = {
 
 const styles = {
   base: css({
-    margin: '0 0 15px 0',
+    margin: '18px 0 15px 0',
     [mUp]: {
       marginBottom: '30px',
     },

--- a/packages/styleguide/src/components/TeaserFront/SplitHeadline.js
+++ b/packages/styleguide/src/components/TeaserFront/SplitHeadline.js
@@ -75,9 +75,9 @@ const sizes = {
 
 const styles = {
   base: css({
-    margin: '0 0 15px 0',
+    margin: '18px 0 15px 0',
     [mUp]: {
-      marginBottom: '30px',
+      marginTop: '0px',
     },
   }),
   editorial: css({

--- a/packages/styleguide/src/components/TeaserFront/TypoHeadline.js
+++ b/packages/styleguide/src/components/TeaserFront/TypoHeadline.js
@@ -82,8 +82,9 @@ const sansSerifSizes = {
 
 const styles = {
   base: css({
-    margin: '0 0 15px 0',
+    margin: '18px 0 15px 0',
     [mUp]: {
+      marginTop: '30px',
       marginBottom: '30px',
     },
   }),


### PR DESCRIPTION
Add top margins on some Front headlines, so they don't appear glued to the top of the box if there's no text above them.