### PR TITLE
fix(discussions): check member role separatly

### DIFF
--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -3,7 +3,7 @@ const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
 /**
  * User can comment when either:
- * - a) it has a role which is allowed to comment (discussion.allowedRoles)
+ * - a) they have a role which is allowed to comment (discussion.allowedRoles)
  * - b) it has member role and either debater role or an active membership
  */
 module.exports = async (discussion, _, context) => {

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -4,7 +4,7 @@ const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 /**
  * User can comment when either:
  * - a) they have a role which is allowed to comment (discussion.allowedRoles)
- * - b) it has member role and either debater role or an active membership
+ * - b) they have the member role and either debater role or an active membership
  */
 module.exports = async (discussion, _, context) => {
   const { closed } = discussion

--- a/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/Discussion/userCanComment.js
@@ -1,35 +1,33 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
-const DEFAULT_ROLES = ['member']
-
+/**
+ * User can comment when either:
+ * - a) it has a role which is allowed to comment (discussion.allowedRoles)
+ * - b) it has member role and either debater role or an active membership
+ */
 module.exports = async (discussion, _, context) => {
   const { closed } = discussion
   const { user, pgdb } = context
 
+  // User can not comment, if discussion is closed
   if (closed) {
     return false
   }
 
-  const additionalAllowedRoles = discussion.allowedRoles.filter(
-    (role) => ![DEFAULT_ROLES].includes(role),
-  )
-  const isInAllowedRoles =
-    additionalAllowedRoles.length > 0 &&
-    Roles.userIsInRoles(user, discussion.allowedRoles)
-
-  if (isInAllowedRoles) {
+  // a) User can comment, if it has some of the allowed roles but member
+  const allowedRoles = discussion.allowedRoles.filter((r) => r !== 'member')
+  if (Roles.userIsInRoles(user, allowedRoles)) {
     return true
   }
 
+  // b) User can comment, if discussion allows member role, user has member role
+  // and either debater role or an active membership.
+  const isMemberAllowed = !!discussion.allowedRoles.find((r) => r === 'member')
   const isMember = Roles.userIsInRoles(user, ['member'])
-  if (!isMember) {
-    return false
-  }
-
   const isDebater = Roles.userIsInRoles(user, ['debater'])
   const hasActiveMembership =
     !!user && (await hasUserActiveMembership(user, pgdb))
 
-  return hasActiveMembership || isDebater
+  return isMemberAllowed && isMember && (isDebater || hasActiveMembership)
 }


### PR DESCRIPTION
This Pull Request revises `Discussion.userCanComment` prop.

It primarly checks if user has a role which is listed in `discussions.allowedRoles` (a). It wilfully ignores `member` role. `member` requires an additional check (b): user has to either have `debater` role or an active membership.

Revision fixes bug which allowed users with only `member` role to comment (without membership or `debater` role). Likely caused because array `DEFAULT_ROLES` was wrapped in array for filter (`![DEFAULT_ROLES].includes(role)`).
