### PR TITLE
feat(voting): add filter to query value char length for Text questions

### DIFF
--- a/packages/backend-modules/search/lib/indices/questionnaireSubmissions.js
+++ b/packages/backend-modules/search/lib/indices/questionnaireSubmissions.js
@@ -28,6 +28,7 @@ module.exports = {
         resolved: {
           properties: {
             answers: {
+              type: 'nested',
               properties: {
                 questionId: {
                   type: 'keyword',

--- a/packages/backend-modules/search/lib/indices/questionnaireSubmissions.js
+++ b/packages/backend-modules/search/lib/indices/questionnaireSubmissions.js
@@ -59,6 +59,9 @@ module.exports = {
                           type: 'text',
                           analyzer: 'german',
                         },
+                        length: {
+                          type: 'integer',
+                        },
                       },
                     },
                     question: {

--- a/packages/backend-modules/search/lib/inserts/questionnairesubmission.js
+++ b/packages/backend-modules/search/lib/inserts/questionnairesubmission.js
@@ -32,11 +32,15 @@ async function transform(row) {
             )) ||
           answer.payload?.value
 
+        const length =
+          type === 'Text' && typeValue?.length ? typeValue.length : undefined
+
         return {
           ...answer,
           resolved: {
             value: {
               [type]: typeValue,
+              length,
             },
             question: {
               id,

--- a/packages/backend-modules/voting/graphql/schema-types.js
+++ b/packages/backend-modules/voting/graphql/schema-types.js
@@ -249,9 +249,12 @@ type Questionnaire {
   turnout: QuestionnaireTurnout
 
   submissions(
+    "Find search term in answer values"
     search: String
+    "Find specific value in answers"
     value: String
     first: Int
+    "Filter submissions"
     filters: SubmissionsFilterInput
     sort: SubmissionsSortInput
     before: String
@@ -260,22 +263,36 @@ type Questionnaire {
 }
 
 input SubmissionsFilterInput {
+  "Return only submission with this ID"
   id: ID
+
+  "Omit submission with this ID"
   not: ID
 
+  "Return only submissions with these IDs"
   submissionIds: [ID!]
+
+  "Omit submissions with these IDs"
   notSubmissionIds: [ID!]
 
+  "Return only submissions with these answered question IDs"
   answeredQuestionIds: [ID!] @deprecated(reason: "use \`answers\` instead")
+
+  "Return only submissions with one or more answers" 
   hasAnswers: Boolean @deprecated(reason: "use \`answers\` instead")
 
+  "Return only submissions with these answered questions"
   answers: [SubmissionFilterAnswer]
   
+  "Return submission by these user IDs"
   userIds: [ID!]
 }
 
 input SubmissionFilterAnswer {
+  "Question wich must be answered"
   questionId: ID!
+
+  "Expected amount of characters in answer given"
   valueLength: SubmissionFilterAnswerValueLength
 }
 

--- a/packages/backend-modules/voting/graphql/schema-types.js
+++ b/packages/backend-modules/voting/graphql/schema-types.js
@@ -266,15 +266,20 @@ input SubmissionsFilterInput {
   submissionIds: [ID!]
   notSubmissionIds: [ID!]
 
-  answeredQuestionIds: [ID!]
-  hasAnswers: Boolean @deprecated(reason: "use \`answeredQuestionIds\` instead")
+  answeredQuestionIds: [ID!] @deprecated(reason: "use \`answers\` instead")
+  hasAnswers: Boolean @deprecated(reason: "use \`answers\` instead")
 
-  valueLength: SubmissionsInputValueLength
+  answers: [SubmissionFilterAnswer]
   
   userIds: [ID!]
 }
 
-input SubmissionsInputValueLength {
+input SubmissionFilterAnswer {
+  questionId: ID!
+  valueLength: SubmissionFilterAnswerValueLength
+}
+
+input SubmissionFilterAnswerValueLength {
   gte: Int
   lte: Int
 }

--- a/packages/backend-modules/voting/graphql/schema-types.js
+++ b/packages/backend-modules/voting/graphql/schema-types.js
@@ -268,8 +268,15 @@ input SubmissionsFilterInput {
 
   answeredQuestionIds: [ID!]
   hasAnswers: Boolean @deprecated(reason: "use \`answeredQuestionIds\` instead")
+
+  valueLength: SubmissionsInputValueLength
   
   userIds: [ID!]
+}
+
+input SubmissionsInputValueLength {
+  gte: Int
+  lte: Int
 }
 
 input SubmissionsSortInput {

--- a/packages/backend-modules/voting/graphql/schema-types.js
+++ b/packages/backend-modules/voting/graphql/schema-types.js
@@ -280,8 +280,10 @@ input SubmissionFilterAnswer {
 }
 
 input SubmissionFilterAnswerValueLength {
-  gte: Int
-  lte: Int
+  "Expect a minimum amount of characters in answer given"
+  min: Int
+  "Expect a maximum amount of characters in answer given"
+  max: Int
 }
 
 input SubmissionsSortInput {

--- a/packages/backend-modules/voting/lib/Submission.js
+++ b/packages/backend-modules/voting/lib/Submission.js
@@ -163,8 +163,8 @@ const createSubmissionsQuery = ({
                   valueLength && {
                     range: {
                       'resolved.answers.resolved.value.length': {
-                        gte: Math.max(0, valueLength.gte) || 0,
-                        lte: valueLength.lte || null,
+                        gte: Math.max(1, valueLength.min) || 1,
+                        lte: valueLength.max || undefined,
                       },
                     },
                   },

--- a/packages/backend-modules/voting/lib/Submission.js
+++ b/packages/backend-modules/voting/lib/Submission.js
@@ -135,6 +135,14 @@ const createSubmissionsQuery = ({
       })),
     },
   }
+  const mustValueLength = filters?.valueLength && {
+    range: {
+      'resolved.answers.resolved.value.length': {
+        gte: Math.max(0, filters.valueLength.gte),
+        lte: filters.valueLength.lte || null,
+      },
+    },
+  }
 
   const query = {
     bool: {
@@ -149,6 +157,7 @@ const createSubmissionsQuery = ({
         mustSubmissionId,
         mustSubmissionIds,
         mustAnsweredQuestionIds,
+        mustValueLength,
       ].filter(Boolean),
       must_not: [mustNotSubmissionId, mustNotSubmissionIds].filter(Boolean),
     },

--- a/packages/backend-modules/voting/lib/Submission.js
+++ b/packages/backend-modules/voting/lib/Submission.js
@@ -150,7 +150,7 @@ const createSubmissionsQuery = ({
     }))
     .concat(filters?.answers || [])
 
-  const mustHaveAnswers = expectedAnswers && {
+  const mustHaveAnswers = expectedAnswers?.length && {
     bool: {
       must: expectedAnswers.map(({ questionId, valueLength }) => {
         return {


### PR DESCRIPTION
This Pull Request allows querying for length of Text answers.

To achieve this, we populate and index `resolved.answers.resolved.value.length` with char length if question type is `Text`.

We then convert array with objects `resolved.answers` to [nested documents](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) which gives us the power to query multiple props at once: `questionId` _and_ `length`.

Now, we need to extend our GraphQL schema with a filter interface:

```gql
input SubmissionsFilterInput {
  ...
  answers: [
    { questionId: ID!, valueLength: { min: Int, max: Int } }
  ]
  ...
}
```

It will then query `questionId` and look for `valueLength.min` and  `valueLength.max`.
