### PR TITLE
Fix permissions comment

### DIFF
--- a/apps/www/components/Discussion/DiscussionComposer/DiscussionComposer.tsx
+++ b/apps/www/components/Discussion/DiscussionComposer/DiscussionComposer.tsx
@@ -117,7 +117,11 @@ const DiscussionComposer = ({
   }
 
   return (
-    <DiscussionComposerBarrier isRoot={isRoot} showPayNotes={showPayNotes}>
+    <DiscussionComposerBarrier
+      isRoot={isRoot}
+      isEditing={!!commentId}
+      showPayNotes={showPayNotes}
+    >
       {active ? (
         <CommentComposer
           t={t}

--- a/apps/www/components/Discussion/DiscussionComposer/DiscussionComposerBarrier.tsx
+++ b/apps/www/components/Discussion/DiscussionComposer/DiscussionComposerBarrier.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from '../../../lib/withT'
 type Props = {
   children: ReactNode
   isRoot?: boolean
+  isEditing?: boolean
   showPayNotes?: boolean
 }
 
@@ -23,12 +24,14 @@ type Props = {
  * Handle rendering of a DiscussionComposer
  * @param children
  * @param isRoot
+ * @param isEditing
  * @param showPayNotes
  * @constructor
  */
 const DiscussionComposerBarrier = ({
   children,
   isRoot,
+  isEditing = false,
   showPayNotes,
 }: Props): ReactElement => {
   const { inNativeIOSApp } = useInNativeApp()
@@ -56,7 +59,7 @@ const DiscussionComposerBarrier = ({
   }
 
   // In case the user can't comment on the discussion, e.g. not signed in or no membership
-  if (!discussion?.userCanComment) {
+  if (!isEditing && !discussion?.userCanComment) {
     if (hidePayNote || hasActiveMembership) {
       return null
     }

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/editComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/editComment.js
@@ -1,4 +1,3 @@
-const { Roles } = require('@orbiting/backend-modules-auth')
 const slack = require('../../../lib/slack')
 const { transform } = require('../../../lib/Comment')
 const { contentLength } = require('../Comment')
@@ -17,7 +16,6 @@ module.exports = async (_, args, context) => {
     }
 
     const discussion = await loaders.Discussion.byId.load(comment.discussionId)
-    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
 
     if (!content || !content.trim().length) {
       throw new Error(t('api/comment/empty'))

--- a/packages/backend-modules/discussions/graphql/resolvers/_mutations/unpublishComment.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/_mutations/unpublishComment.js
@@ -24,8 +24,6 @@ module.exports = async (_, args, context) => {
       id: comment.discussionId,
     })
 
-    Roles.ensureUserIsInRoles(user, discussion.allowedRoles)
-
     const update =
       comment.userId === user.id
         ? { published: false }


### PR DESCRIPTION
Fixes permissions on comments so that logged in users can always edit or unpublish their own comments, no matter if they have a specific role.

Todo:
- [x] Put it on love to test (after klimafragebogen stuff)