### PR TITLE
Increase commit line lengths

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,8 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [0, 'always', 100],
+    'body-max-line-length': [0, 'always', 100],
+    'footer-max-line-length': [0, 'always', 100],
+  },
+}

--- a/package.json
+++ b/package.json
@@ -88,9 +88,7 @@
   ],
   "config": {
     "commitizen": {
-      "path": "cz-conventional-changelog",
-      "maxHeaderWidth": 2500,
-      "maxLineWidth": 2500
+      "path": "cz-conventional-changelog"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
   ],
   "config": {
     "commitizen": {
-      "path": "cz-conventional-changelog"
+      "path": "cz-conventional-changelog",
+      "maxHeaderWidth": 2500,
+      "maxLineWidth": 2500
     }
   },
   "lint-staged": {


### PR DESCRIPTION
It's 2023. All tools we use can do line breaks automatically. Even the Journal allows for 2500 characters. There's no reason not to do this. Please approve.