### PR TITLE
fix(ClimateLabInlineTeaser): add hideForMembers option

### DIFF
--- a/apps/www/components/Climatelab/InlineTeaser/ClimateLabInlineTeaser.tsx
+++ b/apps/www/components/Climatelab/InlineTeaser/ClimateLabInlineTeaser.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from 'next/link'
 import {
   InfoBox,
@@ -15,10 +16,14 @@ import {
 import { useMe } from '../../../lib/context/MeContext'
 import ClimateLabLogo from '../shared/ClimateLabLogo'
 
-const ClimateLabInlineTeaser = () => {
+const ClimateLabInlineTeaser: React.FC<{ hideForMembers?: boolean }> = ({
+  hideForMembers = false,
+}) => {
   const { t } = useTranslation()
   const { me } = useMe()
   const isClimateLabMember = me?.roles?.includes(CLIMATE_LAB_ROLE)
+
+  if (isClimateLabMember && hideForMembers) return null
 
   return (
     <InfoBox figureSize='XXS'>


### PR DESCRIPTION
Add hideForMembers flag to, well, hide the inline teaser when reader is already a member.

Why? So we can embed the inline teaser on /klimalabor as well (some of the readers of this page might not be members already). Fyi: discussed with David.

Obligatory picture:

<img width="831" alt="Screen Shot 2023-03-14 at 10 57 59" src="https://user-images.githubusercontent.com/3907984/224964740-49953f84-a1d5-4c45-9031-fcbc3af8c4a1.png">

