### PR TITLE
fix(www): check if closeHandler is available

### DIFF
--- a/apps/www/components/Sections/Featured.js
+++ b/apps/www/components/Sections/Featured.js
@@ -105,7 +105,7 @@ const Panel = ({
         .sort((a, b) => ascending(a.meta.title, b.meta.title))
         .map(({ id, meta: formatMeta, linkedDocuments }) => (
           <Link href={formatMeta.path} key={id} passHref>
-            <a {...styles.formatLink} onClick={() => closeHandler()}>
+            <a {...styles.formatLink} onClick={() => closeHandler?.()}>
               <FormatTag
                 color={formatMeta.color || colors[formatMeta.kind]}
                 label={formatMeta.title}


### PR DESCRIPTION
This Pull Request avoid an unhandeled error if `closeHandler` is not available.

Current implementation in www won't provide a `closeHandler` anymore which caused a uncaught error and reload of page.