### PR TITLE
chore(republik): drop table cashPayments

### DIFF
--- a/packages/backend-modules/migrations/migrations/20230316094520-drop-cash-payments.js
+++ b/packages/backend-modules/migrations/migrations/20230316094520-drop-cash-payments.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/republik/migrations/sqls'
+const file = '20230316094520-drop-cash-payments'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/republik/migrations/sqls/20230316094520-drop-cash-payments-down.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230316094520-drop-cash-payments-down.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "cashPayments" (
+  "id"              uuid primary key not null default uuid_generate_v4(),
+  "hrid"            text not null,
+  "matched"         boolean not null default false,
+  "createdAt"       timestamptz default now(),
+  "updatedAt"       timestamptz default now(),
+  unique ("hrid")
+) ;

--- a/packages/backend-modules/republik/migrations/sqls/20230316094520-drop-cash-payments-up.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20230316094520-drop-cash-payments-up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "cashPayments" ;


### PR DESCRIPTION
This Pull Requests drop table `cashPayments`.

Table is not in use anymore and data is available in `payments`, too.