### PR TITLE
Calculate finance data for YEARLY_ABO

### DIFF
--- a/packages/backend-modules/republik/script/finance/calculateKpis.js
+++ b/packages/backend-modules/republik/script/finance/calculateKpis.js
@@ -1,8 +1,11 @@
 require('@orbiting/backend-modules-env').config()
 const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
-const moment = require('moment')
+const dayjs = require('dayjs')
+const duration = require('dayjs/plugin/duration')
 const _ = require('lodash')
 const yargs = require('yargs')
+
+dayjs.extend(duration)
 
 const argv = yargs
   .option('company', {
@@ -13,14 +16,14 @@ const argv = yargs
   .option('begin', {
     alias: 'b',
     describe: '(day in) first month e.g. 2019-02-01',
-    coerce: moment,
-    default: moment().subtract(1, 'month'),
+    coerce: dayjs,
+    default: dayjs().subtract(1, 'month'),
   })
   .option('end', {
     alias: 'e',
     describe: '(day in) last month e.g. 2019-03-01',
-    coerce: moment,
-    default: moment().subtract(1, 'month'),
+    coerce: dayjs,
+    default: dayjs().subtract(1, 'month'),
   })
   .help()
   .version().argv

--- a/packages/backend-modules/republik/script/finance/calculateKpis.js
+++ b/packages/backend-modules/republik/script/finance/calculateKpis.js
@@ -30,7 +30,7 @@ const argv = yargs
 
 const METHODS = ['PAYMENTSLIP', 'STRIPE', 'POSTFINANCECARD', 'PAYPAL']
 
-const currency = new Intl.NumberFormat('de-DE', {
+const currency = new Intl.NumberFormat('de-CH', {
   minimumFractionDigits: 2,
   useGrouping: false,
 })


### PR DESCRIPTION
This Pull Requests extends script to calculate finance data with `YEARLY_ABO`.

Different to other products, we've to split pledge total into current fiscal year and transitory liabilities (aktuelles Geschäftsjahr und transitorische Passive).

We devide total amount to 365 parts. Amount of days left in fiscal year wander into `JahresabonnementsAktuellesGeschaeftsjahr` and rest wanders into `JahresabonnementsTransitorischePassive`.