### PR TITLE
fix(www): nav-toggle regression

### DIFF
--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -22,7 +22,7 @@ import Popover from './Popover'
 import UserNavPopover from './Popover/UserNav'
 import LoadingBar from './LoadingBar'
 import Pullable from './Pullable'
-import AudioToggle from './Toggle'
+import Toggle from './Toggle'
 import SecondaryNav from './SecondaryNav'
 import CallToAction from './CallToAction'
 
@@ -243,7 +243,7 @@ const Header = ({
             <div {...styles.rightBarItem}>
               {!showToggle && (
                 <div data-show-if-me='true'>
-                  <AudioToggle
+                  <Toggle
                     expanded={isAnyNavExpanded}
                     title={t(
                       `header/nav/${
@@ -254,7 +254,7 @@ const Header = ({
                 </div>
               )}
               {showToggle ? (
-                <AudioToggle
+                <Toggle
                   expanded={isAnyNavExpanded}
                   title={t(
                     `header/nav/${

--- a/apps/www/components/Frame/Toggle.js
+++ b/apps/www/components/Frame/Toggle.js
@@ -23,7 +23,7 @@ const SIZE = 28
 const PADDING_MOBILE = Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)
 const PADDING_DESKTOP = Math.floor((HEADER_HEIGHT - SIZE) / 2)
 
-const AudioToggle = ({ expanded, closeOverlay, ...props }) => {
+const Toggle = ({ expanded, closeOverlay, ...props }) => {
   const [colorScheme] = useColorContext()
   const { audioQueue, isAudioQueueAvailable } = useAudioQueue()
   const {
@@ -125,4 +125,4 @@ const styles = {
   }),
 }
 
-export default AudioToggle
+export default Toggle

--- a/apps/www/components/Frame/Toggle.js
+++ b/apps/www/components/Frame/Toggle.js
@@ -23,6 +23,11 @@ const SIZE = 28
 const PADDING_MOBILE = Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)
 const PADDING_DESKTOP = Math.floor((HEADER_HEIGHT - SIZE) / 2)
 
+/**
+ * Component to render the toggle element in the top right corner of the frame on top of the nav.
+ * If a sub-navigation is expaned, it renders a close button.
+ * Otherwise it renders the audio player toggle.
+ */
 const Toggle = ({ expanded, closeOverlay, ...props }) => {
   const [colorScheme] = useColorContext()
   const { audioQueue, isAudioQueueAvailable } = useAudioQueue()

--- a/apps/www/components/Frame/Toggle.js
+++ b/apps/www/components/Frame/Toggle.js
@@ -60,16 +60,18 @@ const AudioToggle = ({ expanded, closeOverlay, ...props }) => {
 
   return expanded || isAudioQueueAvailable ? (
     <button {...styles.menuToggle} onClick={onClick} {...props}>
-      <MicIcon {...colorScheme.set('fill', 'text')} size={SIZE} />
-      {!!audioItemsCount && (
-        <span
-          {...colorScheme.set('background', 'default')}
-          {...colorScheme.set('color', 'text')}
-          {...styles.audioCount}
-        >
-          {audioItemsCount}
-        </span>
-      )}
+      <div style={{ opacity: !expanded ? 1 : 0 }} {...styles.audioButton}>
+        <MicIcon {...colorScheme.set('fill', 'text')} size={SIZE} />
+        {!!audioItemsCount && (
+          <span
+            {...colorScheme.set('background', 'default')}
+            {...colorScheme.set('color', 'text')}
+            {...styles.audioCount}
+          >
+            {audioItemsCount}
+          </span>
+        )}
+      </div>
       <CloseIcon
         style={{ opacity: expanded ? 1 : 0 }}
         {...styles.closeButton}
@@ -107,6 +109,9 @@ const styles = {
       top: 22,
       left: 36,
     },
+  }),
+  audioButton: css({
+    transition: `opacity ${TRANSITION_MS}ms ease-out`,
   }),
   closeButton: css({
     position: 'absolute',


### PR DESCRIPTION
## Description

I accidentally introduced a bug with #412, that caused the nav-close and audio-toggle button to be rendered on top of each other.
This pr ensures that audio-toggle button is not visible when a nav is expanded (same as previous behavior)

## Buggy behavior

https://user-images.githubusercontent.com/30313631/228080494-4edcbccc-1a10-4a49-a3d1-498893b15289.mov

## Fixed behavior


https://user-images.githubusercontent.com/30313631/228080694-afb038a1-b4c6-4196-9445-785f55449c2b.mov


