### PR TITLE
Vercel Previews

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -10,7 +10,7 @@ const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
 
 /**
  * For Vercel Preview Deployments, make sure the PUBLIC_BASE_URL_PATTERN is set
- * and has the pattern `https://project-name-<branch-name>-team-slug.vercel.app`
+ * and has the pattern `https://project-name-git-<branch-name>-team-slug.vercel.app`
  * (<branch-name> will be replaced with the Git commit ref)
  **/
 const PUBLIC_BASE_URL =

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -8,9 +8,19 @@ const withTM = require('next-transpile-modules')([
 
 const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
 
+/**
+ * For Vercel Preview Deployments, make sure the PUBLIC_BASE_URL_PATTERN is set
+ * and has the pattern `https://project-name-<branch-name>-team-slug.vercel.app`
+ * (<branch-name> will be replaced with the Git commit ref)
+ **/
 const PUBLIC_BASE_URL =
   process.env.PUBLIC_BASE_URL ??
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined)
+  (process.env.VERCEL_GIT_COMMIT_REF && process.env.PUBLIC_BASE_URL_PATTERN)
+    ? process.env.PUBLIC_BASE_URL_PATTERN.replace(
+        '<branch-name>',
+        process.env.VERCEL_GIT_COMMIT_REF,
+      )
+    : undefined
 
 const buildId =
   process.env.SOURCE_VERSION?.substring(0, 10) ||

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -15,12 +15,12 @@ const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
  **/
 const PUBLIC_BASE_URL =
   process.env.PUBLIC_BASE_URL ??
-  (process.env.VERCEL_GIT_COMMIT_REF && process.env.PUBLIC_BASE_URL_PATTERN)
+  (process.env.VERCEL_GIT_COMMIT_REF && process.env.PUBLIC_BASE_URL_PATTERN
     ? process.env.PUBLIC_BASE_URL_PATTERN.replace(
         '<branch-name>',
         process.env.VERCEL_GIT_COMMIT_REF,
       )
-    : undefined
+    : undefined)
 
 const buildId =
   process.env.SOURCE_VERSION?.substring(0, 10) ||

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -68,30 +68,30 @@ module.exports = withTM(
             destination: '/~/:slug',
           },
           // Avoid SSG for extract urls used for image rendering
-          {
-            source: '/:path*',
-            destination: '/_ssr/:path*',
-            has: [{ type: 'query', key: 'extract' }],
-          },
-          // Avoid SSG for share urls, e.g. meta.fromQuery
-          {
-            source: '/:path*',
-            destination: '/_ssr/:path*',
-            has: [{ type: 'query', key: 'share' }],
-          },
-          // Rewrite for crawlers when a comment is focused inside a debate on the article-site
-          {
-            source: '/:path*',
-            destination: '/_ssr/:path*',
-            has: [
-              { type: 'query', key: 'focus' },
-              {
-                type: 'header',
-                key: 'User-Agent',
-                value: '.*(Googlebot|facebookexternalhit|Twitterbot).*',
-              },
-            ],
-          },
+          // {
+          //   source: '/:path*',
+          //   destination: '/_ssr/:path*',
+          //   has: [{ type: 'query', key: 'extract' }],
+          // },
+          // // Avoid SSG for share urls, e.g. meta.fromQuery
+          // {
+          //   source: '/:path*',
+          //   destination: '/_ssr/:path*',
+          //   has: [{ type: 'query', key: 'share' }],
+          // },
+          // // Rewrite for crawlers when a comment is focused inside a debate on the article-site
+          // {
+          //   source: '/:path*',
+          //   destination: '/_ssr/:path*',
+          //   has: [
+          //     { type: 'query', key: 'focus' },
+          //     {
+          //       type: 'header',
+          //       key: 'User-Agent',
+          //       value: '.*(Googlebot|facebookexternalhit|Twitterbot).*',
+          //     },
+          //   ],
+          // },
           {
             source: '/pgp/:userSlug',
             destination: '/api/pgp/:userSlug',

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -8,6 +8,10 @@ const withTM = require('next-transpile-modules')([
 
 const { NODE_ENV, CDN_FRONTEND_BASE_URL } = process.env
 
+const PUBLIC_BASE_URL =
+  process.env.PUBLIC_BASE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined)
+
 const buildId =
   process.env.SOURCE_VERSION?.substring(0, 10) ||
   new Date(Date.now()).toISOString()
@@ -18,7 +22,7 @@ const buildId =
 module.exports = withTM(
   withBundleAnalyzer({
     generateBuildId: () => buildId,
-    env: { BUILD_ID: buildId },
+    env: { BUILD_ID: buildId, PUBLIC_BASE_URL },
     webpack: (config) => {
       config.externals = config.externals || {}
       config.externals['lru-cache'] = 'lru-cache'

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -9,8 +9,7 @@
   "main": "server/index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon --watch server --watch .env --watch next.config.js server/index.js",
-    "dev-only-next": "next dev",
-    "start": "node server/index.js",
+    "dev:next": "next dev -p 3010",
     "build": "next build",
     "heroku-postbuild": "npm run build",
     "test": "jest",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -9,6 +9,7 @@
   "main": "server/index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon --watch server --watch .env --watch next.config.js server/index.js",
+    "dev-only-next": "next dev",
     "start": "node server/index.js",
     "build": "next build",
     "heroku-postbuild": "npm run build",


### PR DESCRIPTION
Re-configure www app, so it can be deployed on Vercel. This way we get separate preview deployments for PRs 🎉 

Stretch goal is to remove the complete express.js based server part and handle the routes/middlewares defined server/index.js in either middleware and/or API routes. These are:

- [ ] helmet HSTS and referrerPolicy
- [ ] Setting the header `Permissions-Policy: interest-cohort=()` (to disable [FloC](https://github.blog/changelog/2021-04-27-github-pages-permissions-policy-interest-cohort-header-added-to-all-pages-sites/))
- [ ] Mastodon .well-known redirects
- [ ] iOS .well-known app site association
- [ ] Static .well-known assets
- [ ] 'trust proxy'?
- [ ] Redirect to PUBLIC_BASE_URL if host doesn't match(?)
- [ ] CURTAIN (we may not need it anymore with Vercel previews)
- [ ] BASIC_AUTH_PASS (dito)
- [ ] unavailable routes
- [ ] PayPal POST url
- [ ] OPTION requests 400
- [ ] Routes with rate limit

