### PR TITLE
Fix Publikator Crashing on Extra Title Content

### DIFF
--- a/apps/publikator/components/editor/modules/title/index.js
+++ b/apps/publikator/components/editor/modules/title/index.js
@@ -147,7 +147,7 @@ export default ({ rule, subModules, TYPE }) => {
                 }
                 if (reason === 'child_unknown') {
                   if (index >= subModules.length) {
-                    change.unwrapNodeByKey(child.key)
+                    change.removeNodeByKey(child.key)
                   }
                 }
               },


### PR DESCRIPTION
When extra paragraphs are in the title section (e.g. when adding one through editing the source), normalization tries to [unwrap](https://github.com/ianstormtaylor/slate/blob/slate%400.31.8/docs/reference/slate/change.md#unwrapnodebykey) extra nodes which results in a invalid document that throws the editor into an infinite loop.

[Removing](https://github.com/ianstormtaylor/slate/blob/slate%400.31.8/docs/reference/slate/change.md#removenodebykey) extra nodes solves this. However, content (e.g. a valid credits paragraph) will be lost. Maybe there's a better solution like removing extra paragraphs _before_ the last one.