### PR TITLE
fix(statistics): add catch-all to ignore unknown char

### DIFF
--- a/packages/backend-modules/statistics/__test__/analyze.u.jest.js
+++ b/packages/backend-modules/statistics/__test__/analyze.u.jest.js
@@ -88,6 +88,21 @@ const cases = [
     ],
     text: 'Von Philipp Albrecht (Text) und Andrea Ventura (Illustration), XY.05.2022',
   },
+  {
+    name: 'ignore undeclared characters',
+    contributors: [],
+    text: '[COUNTER AKTUELLER MITGLIEDERZAHL]',
+  },
+  {
+    name: 'ignore undeclared characters (contains "by" indicator MIT)',
+    contributors: [{ name: 'AKTUELLER MITGLIEDERZAHL', kind: 'Text' }],
+    text: '[COUNTER MIT AKTUELLER MITGLIEDERZAHL]',
+  },
+  {
+    name: 'ignore lingering parenthesis',
+    contributors: [{ name: 'Brigitte Hürlimann', kind: 'Text' }],
+    text: 'Von Brigitte Hürlimann (, 01.04.2023',
+  },
 ]
 
 describe('Analyzer', () => {

--- a/packages/backend-modules/statistics/lib/credits/lexer.ts
+++ b/packages/backend-modules/statistics/lib/credits/lexer.ts
@@ -47,6 +47,10 @@ export class Lexer {
         .rule(/\u00AB?([\p{L}\p{M}/.\u2019-]+)\u00BB?/u, (ctx, match) => {
           ctx.accept(TokenType.WORD, match[1])
         })
+        // catch-all: ignore character
+        .rule(/./, (ctx) => {
+          ctx.ignore()
+        })
     )
   }
 }


### PR DESCRIPTION
Prevents credit string analyzer to throw an error if a character is unknown.

Added tests for these credit strings:
- `[COUNTER AKTUELLER MITGLIEDERZAHL]`
- `Von Brigitte Hürlimann (, 01.04.2023`