### PR TITLE
Let Editor Crash More Gracefully

### DIFF
--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -727,10 +727,21 @@ export class EditorPage extends Component {
     const { router } = this.props
     const { commitId, schema, template } = router.query
     const repoId = getRepoIdFromQuery(router.query)
-    const { editorState } = this.state
-    const serializedState = this.editor.serializer.serialize(editorState)
-    this.beginChanges()
-    this.store.set('editorState', serializedState)
+
+    // When an error happens inside the editor, its state can't be serialized anymore.
+    // This is okay, we just redirect to the raw editor anyway, so the user can fix whatever caused the problem.
+    try {
+      const { editorState } = this.state
+      const serializedState = this.editor.serializer.serialize(editorState)
+      this.beginChanges()
+      this.store.set('editorState', serializedState)
+    } catch (e) {
+      console.error(
+        'Could not set new editorState, going to raw editor anyway.',
+        e,
+      )
+    }
+
     this.props.router.push({
       pathname: `/repo/${repoId}/raw`,
       query: {

--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -43,6 +43,7 @@ import * as fragments from '../../lib/graphql/fragments'
 import {
   ColorContextProvider,
   colors,
+  ErrorBoundary,
   plainButtonRule,
 } from '@project-r/styleguide'
 import SettingsIcon from 'react-icons/lib/fa/cogs'
@@ -907,17 +908,22 @@ export class EditorPage extends Component {
                       darkmode={this.state.previewDarkmode}
                     />
                   ) : null}
-                  <Editor
-                    ref={this.editorRef}
-                    schema={schema}
-                    isTemplate={isTemplate}
-                    meta={meta}
-                    value={editorState}
-                    onChange={this.changeHandler}
-                    onDocumentChange={this.documentChangeHandler}
-                    readOnly={readOnly}
-                    hide={showPreview}
-                  />
+                  <ErrorBoundary
+                    failureMessage='Ein Fehler trat im Editor auf. Bitte den Quellcode bearbeiten.'
+                    showException
+                  >
+                    <Editor
+                      ref={this.editorRef}
+                      schema={schema}
+                      isTemplate={isTemplate}
+                      meta={meta}
+                      value={editorState}
+                      onChange={this.changeHandler}
+                      onDocumentChange={this.documentChangeHandler}
+                      readOnly={readOnly}
+                      hide={showPreview}
+                    />
+                  </ErrorBoundary>
                 </ColorContextProvider>
               </div>
             )}

--- a/packages/styleguide/src/lib.ts
+++ b/packages/styleguide/src/lib.ts
@@ -203,3 +203,4 @@ export { RenderContextProvider } from './components/Editor/Render/Context'
 
 export { FlyerTile, FlyerTileMeta } from './components/Flyer'
 export { FlyerDate } from './components/Flyer/Date'
+export { default as ErrorBoundary } from './components/ErrorBoundary'


### PR DESCRIPTION
Adds an ErrorBoundary to the main editor, and ensures that the user can still edit the raw source of an article in case the editor crashes.