### PR TITLE
feat: allow reporting user profiles

### DIFF
--- a/apps/www/components/Profile/Page.js
+++ b/apps/www/components/Profile/Page.js
@@ -387,19 +387,31 @@ const LoadedProfile = (props) => {
     }
     if (reportReason.length === 0) {
       alert(t('profile/report/provideReason'))
-    } else {
-      try {
-        await reportUserMutation({
-          variables: {
-            userId: user.id,
-            reason: reportReason,
-          },
-        })
-        alert(t('profile/report/success'))
-      } catch (e) {
-        console.warn(e)
-        alert(t('profile/report/error'))
-      }
+      return
+    }
+    const maxLength = 500
+    if (reportReason.length > maxLength) {
+      alert(
+        t('profile/report/tooLong', {
+          max: maxLength,
+          input: reportReason.slice(0, maxLength) + '…',
+          br: '\n',
+        }),
+      )
+      return
+    }
+
+    try {
+      await reportUserMutation({
+        variables: {
+          userId: user.id,
+          reason: reportReason,
+        },
+      })
+      alert(t('profile/report/success'))
+    } catch (e) {
+      console.warn(e)
+      alert(t('profile/report/error'))
     }
   }
 

--- a/apps/www/components/Profile/Page.js
+++ b/apps/www/components/Profile/Page.js
@@ -4,7 +4,7 @@ import { graphql } from '@apollo/client/react/hoc'
 import { gql } from '@apollo/client'
 import { css } from 'glamor'
 import { withRouter } from 'next/router'
-
+import { IconButton, ReportIcon } from '@project-r/styleguide'
 import withT, { t } from '../../lib/withT'
 import withMe from '../../lib/apollo/withMe'
 
@@ -43,6 +43,7 @@ import ElectionBallotRow from '../Vote/ElectionBallotRow'
 import { documentListQueryFragment } from '../Feed/DocumentListContainer'
 import Link from 'next/link'
 import { InnerPaynote } from '../Article/PayNote'
+import { useReportUserMutation } from './graphql/useReportUserMutation'
 
 const SIDEBAR_TOP = 20
 const PORTRAIT_SIZE_M = TESTIMONIAL_IMAGE_SIZE
@@ -117,6 +118,11 @@ const styles = {
     display: 'flex',
     float: 'right',
     verticalAlign: 'middle',
+  }),
+  headInfoWrapper: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   }),
   badges: css({
     margin: '20px 0 30px 0',
@@ -322,6 +328,7 @@ const LoadedProfile = (props) => {
   const currentRef = useRef({})
   currentRef.current.headerHeight = headerHeight
   currentRef.current.layout = layout
+  const [reportUserMutation] = useReportUserMutation()
 
   useEffect(() => {
     const onScroll = () => {
@@ -371,6 +378,29 @@ const LoadedProfile = (props) => {
       window.removeEventListener('resize', measure)
     }
   }, [])
+
+  const reportUser = async () => {
+    const reportReason = window.prompt(t('profile/report/confirm'))
+    if (reportReason === null) {
+      return
+    }
+    if (reportReason.length === 0) {
+      alert(t('profile/report/provideReason'))
+    } else {
+      try {
+        await reportUserMutation({
+          variables: {
+            userId: user.id,
+            reason: reportReason,
+          },
+        })
+        alert(t('profile/report/success'))
+      } catch (e) {
+        console.warn(e)
+        alert(t('profile/report/error'))
+      }
+    }
+  }
 
   const {
     t,
@@ -533,8 +563,15 @@ const LoadedProfile = (props) => {
                   dirty={dirty}
                   showSupportLink
                 />
-                {!!me && user.subscribedByMe && user.id !== me.id && (
-                  <div style={{ marginTop: 16 }}>
+                <div
+                  style={{
+                    marginTop: 16,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                  }}
+                >
+                  {!!me && user.subscribedByMe && user.id !== me.id && (
                     <SubscribeMenu
                       label={t('SubscribeMenu/title')}
                       labelShort={t('SubscribeMenu/title')}
@@ -542,8 +579,16 @@ const LoadedProfile = (props) => {
                       userHasNoDocuments={!user.documents.totalCount}
                       subscriptions={[user.subscribedByMe]}
                     />
-                  </div>
-                )}
+                  )}
+                  {!isMe && (
+                    <IconButton
+                      Icon={ReportIcon}
+                      title={t('profile/report/label')}
+                      label={t('profile/report/label')}
+                      onClick={() => reportUser(user.id)}
+                    />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/apps/www/components/Profile/Page.js
+++ b/apps/www/components/Profile/Page.js
@@ -119,10 +119,11 @@ const styles = {
     float: 'right',
     verticalAlign: 'middle',
   }),
-  headInfoWrapper: css({
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+  headInfoReportButton: css({
+    marginLeft: 12,
+    [mediaQueries.mUp]: {
+      marginLeft: 24,
+    },
   }),
   badges: css({
     margin: '20px 0 30px 0',
@@ -493,6 +494,16 @@ const LoadedProfile = (props) => {
             {!!user.hasPublicProfile && (
               <span {...styles.headInfoShare}>
                 <ActionBar share={shareObject} download={metaData.image} />
+                {!isMe && (
+                  <div {...styles.headInfoReportButton}>
+                    <IconButton
+                      Icon={ReportIcon}
+                      title={t('profile/report/label')}
+                      onClick={() => reportUser(user.id)}
+                      style={{ margin: 0 }}
+                    />
+                  </div>
+                )}
               </span>
             )}
             {!!user.sequenceNumber && (
@@ -578,14 +589,6 @@ const LoadedProfile = (props) => {
                       showAuthorFilter
                       userHasNoDocuments={!user.documents.totalCount}
                       subscriptions={[user.subscribedByMe]}
-                    />
-                  )}
-                  {!isMe && (
-                    <IconButton
-                      Icon={ReportIcon}
-                      title={t('profile/report/label')}
-                      label={t('profile/report/label')}
-                      onClick={() => reportUser(user.id)}
                     />
                   )}
                 </div>

--- a/apps/www/components/Profile/graphql/useReportUserMutation.ts
+++ b/apps/www/components/Profile/graphql/useReportUserMutation.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client'
+import { makeMutationHook } from '../../../lib/helpers/AbstractApolloGQLHooks.helper'
+
+const REPORT_USER_MUTATION = gql`
+  mutation reportUser($userId: ID!, $reason: String!) {
+    reportUser(userId: $userId, reason: $reason)
+  }
+`
+
+type ReportUserMutation = {
+  data: {
+    reportUser: boolean
+  }
+  variables: {
+    userId: string
+    reason: string
+  }
+}
+
+export const useReportUserMutation = makeMutationHook<
+  ReportUserMutation['data'],
+  ReportUserMutation['variables']
+>(REPORT_USER_MUTATION)

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -1593,6 +1593,10 @@
       "value": "Beim Senden der Meldung ist ein Fehler aufgetreten."
     },
     {
+      "key": "profile/report/tooLong",
+      "value": "Sie können maximal {max} Zeichen eingeben.{br}Ihre Eingabe: {input}"
+    },
+    {
       "key": "profile/gender",
       "value": "Geschlecht"
     },

--- a/apps/www/lib/translations.json
+++ b/apps/www/lib/translations.json
@@ -1573,6 +1573,26 @@
       "value": "Sie müssen ein Porträtbild hochladen"
     },
     {
+      "key": "profile/report/label",
+      "value": "Benutzer melden"
+    },
+    {
+      "key": "profile/report/confirm",
+      "value": "Sind Sie sicher, dass dieser Benutzer gegen die Etikette verstossen hat und Sie die Moderation herbeirufen möchten? Nennen Sie bitte den Grund für diese Meldung."
+    },
+    {
+      "key": "profile/report/provideReason",
+      "value": "Bitte geben Sie einen Grund an, warum Sie diesen Benutzer melden möchten."
+    },
+    {
+      "key": "profile/report/success",
+      "value": "Wir haben Ihre Meldung erhalten."
+    },
+    {
+      "key": "profile/report/error",
+      "value": "Beim Senden der Meldung ist ein Fehler aufgetreten."
+    },
+    {
       "key": "profile/gender",
       "value": "Geschlecht"
     },

--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
@@ -1,5 +1,7 @@
 const slack = require('../../../lib/slack')
 
+const MAX_REASON_LENGTH = 500
+
 module.exports = async (_, args, context) => {
   const { user: me, t, loaders } = context
   const { userId, reason } = args
@@ -11,6 +13,14 @@ module.exports = async (_, args, context) => {
 
   if (userId === me?.id) {
     throw new Error(t('api/reportUser/self'))
+  }
+
+  if (reason.length > MAX_REASON_LENGTH) {
+    throw new Error(
+      t('api/reportUser/reasonTooLong', {
+        max: MAX_REASON_LENGTH,
+      }),
+    )
   }
 
   await slack.reportUser(me, user, reason)

--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
@@ -9,15 +9,11 @@ module.exports = async (_, args, context) => {
     throw new Error(t('api/reportUser/userNotFound'))
   }
 
-  if (!me) {
-    throw new Error(t('api/signIn'))
-  }
-
-  if (userId === me.id) {
+  if (userId === me?.id) {
     throw new Error(t('api/reportUser/self'))
   }
 
-  await slack.reportUser(me?.name || me?.email || 'Gast', user, reason)
+  await slack.reportUser(me, user, reason)
 
   return true
 }

--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/reportUser.js
@@ -1,0 +1,23 @@
+const slack = require('../../../lib/slack')
+
+module.exports = async (_, args, context) => {
+  const { user: me, t, loaders } = context
+  const { userId, reason } = args
+
+  const user = await loaders.User.byId.load(userId)
+  if (!user) {
+    throw new Error(t('api/reportUser/userNotFound'))
+  }
+
+  if (!me) {
+    throw new Error(t('api/signIn'))
+  }
+
+  if (userId === me.id) {
+    throw new Error(t('api/reportUser/self'))
+  }
+
+  await slack.reportUser(me?.name || me?.email || 'Gast', user, reason)
+
+  return true
+}

--- a/packages/backend-modules/republik/graphql/schema.js
+++ b/packages/backend-modules/republik/graphql/schema.js
@@ -112,6 +112,8 @@ type mutations {
     name: NewsletterName!
     context: String!
   ): Boolean!
+
+  reportUser(userId: ID!, reason: String!): Boolean!
 }
 
 type subscriptions {

--- a/packages/backend-modules/republik/graphql/schema.js
+++ b/packages/backend-modules/republik/graphql/schema.js
@@ -113,7 +113,11 @@ type mutations {
     context: String!
   ): Boolean!
 
-  reportUser(userId: ID!, reason: String!): Boolean!
+  reportUser(
+    userId: ID!,
+    """Reason for reporting the user. Max 500 characters."""
+    reason: String!
+  ): Boolean!
 }
 
 type subscriptions {

--- a/packages/backend-modules/republik/lib/slack.js
+++ b/packages/backend-modules/republik/lib/slack.js
@@ -80,17 +80,19 @@ exports.publishPledge = async (_user, pledge, action) => {
 }
 
 const getProfileLink = (user) =>
-  `<${FRONTEND_BASE_URL}/~${user.username || user.id}>|${
-    user.username || user.email
-  }>`
+  user.username
+    ? `<${FRONTEND_BASE_URL}/~${user.username || user.id}|${user.name}>`
+    : user.name
 
-exports.reportUser = async (userName, reportedUser, reason) => {
+exports.reportUser = async (user, reportedUser, reason) => {
   try {
     const content = `
-    :bomb: *${userName}* reported  *${getProfileLink(reportedUser)}*: \n
-    Reason: "${reason}"
+    :bomb: *${user ? getProfileLink(user) : 'Gast'}* reported *${getProfileLink(
+      reportedUser,
+    )}*: \n
+    Reason: \n
+    ${reason}
     `
-    console.log('reportUser', content)
 
     return await publish(SLACK_CHANNEL_COMMENTS_ADMIN, content, {
       unfurl_links: true,

--- a/packages/backend-modules/republik/lib/slack.js
+++ b/packages/backend-modules/republik/lib/slack.js
@@ -6,7 +6,9 @@ const {
   SLACK_CHANNEL_IT_MONITOR,
   SLACK_CHANNEL_ADMIN,
   SLACK_CHANNEL_FINANCE,
+  SLACK_CHANNEL_COMMENTS_ADMIN,
   ADMIN_FRONTEND_BASE_URL,
+  FRONTEND_BASE_URL,
 } = process.env
 
 exports.publishScheduler = async (message) => {
@@ -72,6 +74,28 @@ exports.publishPledge = async (_user, pledge, action) => {
     }
     content += `\n${ADMIN_FRONTEND_BASE_URL}/users/${user.id}`
     return await publish(SLACK_CHANNEL_FINANCE, content)
+  } catch (e) {
+    console.warn(e)
+  }
+}
+
+const getProfileLink = (user) =>
+  `<${FRONTEND_BASE_URL}/~${user.username || user.id}>|${
+    user.username || user.email
+  }>`
+
+exports.reportUser = async (userName, reportedUser, reason) => {
+  try {
+    const content = `
+    :bomb: *${userName}* reported  *${getProfileLink(reportedUser)}*: \n
+    Reason: "${reason}"
+    `
+    console.log('reportUser', content)
+
+    return await publish(SLACK_CHANNEL_COMMENTS_ADMIN, content, {
+      unfurl_links: true,
+      unfurl_media: true,
+    })
   } catch (e) {
     console.warn(e)
   }

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -2511,6 +2511,18 @@
     {
       "key": "api/call-to-actions/acknowledge/404",
       "value": "Call-To-Action nicht gefunden"
+    },
+    {
+      "key": "api/reportUser/self",
+      "value": "Das eigene Profil kann nich gemeldet werden"
+    },
+    {
+      "key": "api/reportUser/failed",
+      "value": "Es ist ein Fehler aufgetreten, das Profil konnte nicht gemeldet werden."
+    },
+    {
+      "key": "api/reportUser/userNotFound",
+      "value": "Der gemeldete Benutzer konnte nicht gefunden werden."
     }
   ]
 }

--- a/packages/backend-modules/translate/translations.json
+++ b/packages/backend-modules/translate/translations.json
@@ -2523,6 +2523,10 @@
     {
       "key": "api/reportUser/userNotFound",
       "value": "Der gemeldete Benutzer konnte nicht gefunden werden."
+    },
+    {
+      "key": "api/reportUser/reasonTooLong",
+      "value": "Die Begründung ist zu lange. (Maximal {max} Zeichen)"
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds a report-user functionality. On a user profile next to the share-icon a flag-icon was added that prompts to enter a reason for reporting the user. When a user is reported, it is sent to the internal slack-channel, where previously only reported comments where shown.

### Screenshots

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/30313631/231408491-3dd3c5f6-dc03-4b21-be59-0481c7f51d62.png">
