### PR TITLE
fix(publikator): use already resolved meta docs

### DIFF
--- a/packages/backend-modules/search/lib/Documents.js
+++ b/packages/backend-modules/search/lib/Documents.js
@@ -842,13 +842,7 @@ const findTemplates = async function (elastic, template, repoId) {
     ...indexRef,
     size: 10000,
     body: {
-      _source: [
-        'meta.repoId',
-        'meta.title',
-        'meta.description',
-        'meta.kind',
-        'meta.template',
-      ],
+      _source: ['meta'],
       query: {
         bool: {
           must: {


### PR DESCRIPTION
This Pull Request avoids querying docs linked in meta (e.g. format) twice.