### PR TITLE
Fix Server-Client Hydration Errors

### DIFF
--- a/apps/publikator/components/Repo/Add.js
+++ b/apps/publikator/components/Repo/Add.js
@@ -104,6 +104,7 @@ const TemplatePicker = compose(
   withRouter,
   graphql(getTemplateRepos, {
     options: () => ({
+      ssr: false, // Disable SSR because of React hydration error
       fetchPolicy: 'network-only',
     }),
     skip: ({ isTemplate }) => isTemplate,

--- a/apps/publikator/components/Repo/Table.js
+++ b/apps/publikator/components/Repo/Table.js
@@ -238,7 +238,7 @@ const RepoList = ({
         <PhaseFilter phases={data.phasesAgg?.phases} />
       )}
 
-      <Table style={{ marginTop: !showPhases && -15 }}>
+      <Table style={{ marginTop: showPhases ? 0 : -15 }}>
         <thead>
           <Tr>
             <Th style={{ width: '28%' }}>{t('repo/table/col/title')}</Th>

--- a/apps/publikator/components/Repo/Table.js
+++ b/apps/publikator/components/Repo/Table.js
@@ -229,6 +229,8 @@ const RepoList = ({
     ? activeOrderField.accessor
     : orderFields[0].accessor
 
+  const colsCount = orderFields.length + 4
+
   return (
     <>
       <DebouncedSearch />
@@ -268,7 +270,7 @@ const RepoList = ({
             data.repos &&
             data.repos.nodes.length === 0 && (
               <Tr>
-                <Td colSpan='8'>{t('repo/search/noResults')}</Td>
+                <Td colSpan={colsCount}>{t('repo/search/noResults')}</Td>
               </Tr>
             )}
           {!showLoader &&
@@ -280,7 +282,7 @@ const RepoList = ({
               ))}
           {(data.loading || data.error) && (
             <tr>
-              <td colSpan='8'>
+              <td colSpan={colsCount}>
                 <Loader loading={data.loading} error={data.error} />
               </td>
             </tr>

--- a/apps/publikator/components/editor/modules/meta/AudioForm.js
+++ b/apps/publikator/components/editor/modules/meta/AudioForm.js
@@ -69,7 +69,7 @@ export default withT(({ t, editor, node, onInputChange, format }) => {
             black
             label={t('metaData/audio/source/kind')}
             items={audioSourceKinds}
-            value={audioSourceKind || null}
+            value={audioSourceKind || ''}
             onChange={({ value }) => {
               editor.change((change) => {
                 if (!value) {
@@ -122,7 +122,7 @@ export default withT(({ t, editor, node, onInputChange, format }) => {
             black
             label='Position'
             items={audioCoverAnchors}
-            value={audioCover ? audioCover.anchor : null}
+            value={audioCover ? audioCover.anchor : ''}
             onChange={({ value }) =>
               onChange('audioCover')(
                 value && {

--- a/apps/publikator/pages/repo/[owner]/[repo]/raw.js
+++ b/apps/publikator/pages/repo/[owner]/[repo]/raw.js
@@ -228,29 +228,31 @@ export default withDefaultSSR(
                 {t('pages/raw/metadata')}
               </Checkbox>
             </div>
-            <CodeMirror
-              value={md}
-              options={{
-                mode: 'markdown',
-                theme: 'neo',
-                lineNumbers: true,
-                lineWrapping: true,
-                smartIndent: false,
-                viewportMargin: Infinity,
-                foldGutter: foldCode,
-                gutters: [
-                  'CodeMirror-linenumbers',
-                  foldCode && 'CodeMirror-foldgutter',
-                ].filter(Boolean),
-                foldOptions: process.browser &&
-                  foldCode && {
-                    rangeFinder: require('codemirror').fold.xml,
-                  },
-              }}
-              onBeforeChange={(editor, data, value) => {
-                setMd(value)
-              }}
-            />
+            {md !== '' ? (
+              <CodeMirror
+                value={md}
+                options={{
+                  mode: 'markdown',
+                  theme: 'neo',
+                  lineNumbers: true,
+                  lineWrapping: true,
+                  smartIndent: false,
+                  viewportMargin: Infinity,
+                  foldGutter: foldCode,
+                  gutters: [
+                    'CodeMirror-linenumbers',
+                    foldCode && 'CodeMirror-foldgutter',
+                  ].filter(Boolean),
+                  foldOptions: process.browser &&
+                    foldCode && {
+                      rangeFinder: require('codemirror').fold.xml,
+                    },
+                }}
+                onBeforeChange={(editor, data, value) => {
+                  setMd(value)
+                }}
+              />
+            ) : null}
           </div>
         </Frame.Body>
       </Frame>

--- a/apps/www/components/ActionBar/Audio/Info.js
+++ b/apps/www/components/ActionBar/Audio/Info.js
@@ -1,6 +1,6 @@
 import { css } from 'glamor'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { Fragment, useMemo } from 'react'
 
 import {
   Editorial,
@@ -39,15 +39,17 @@ const Contributors = ({ contributors }) => {
   const { t } = useTranslation()
 
   const names = intersperse(
-    contributors.map((s) =>
-      s.user?.slug ? (
-        <Link href={`/~${s.user.slug}`} passHref>
-          <Editorial.A>{s?.user?.name || s.name}</Editorial.A>
-        </Link>
-      ) : (
-        s.name
-      ),
-    ),
+    contributors.map((s) => (
+      <Fragment key={s.user?.slug ?? s.name}>
+        {s.user?.slug ? (
+          <Link href={`/~${s.user.slug}`} passHref>
+            <Editorial.A>{s?.user?.name || s.name}</Editorial.A>
+          </Link>
+        ) : (
+          s.name
+        )}
+      </Fragment>
+    )),
     (_, i) => <span key={i}>, </span>,
   )
 
@@ -172,20 +174,21 @@ const Info = ({ document, handlePlay }) => {
       {intersperse(
         [
           kind === 'readAloud' && !!mp3 && (
-            <Contributors contributors={contributorsVoice} />
+            <Contributors contributors={contributorsVoice} key='contributors' />
           ),
           kind === 'syntheticReadAloud' &&
             !!mp3 &&
             (!willBeReadAloud || !readAloudSubscription) && (
-              <PlaySyntheticReadAloud onPlay={handlePlay} />
+              <PlaySyntheticReadAloud onPlay={handlePlay} key='synthetic' />
             ),
           (kind !== 'readAloud' || !mp3) &&
             !!willBeReadAloud &&
             readAloudSubscription && (
-              <span {...colorScheme.set('color', 'textSoft')}>
+              <span {...colorScheme.set('color', 'textSoft')} key='subscribe'>
                 {t.elements('article/actionbar/audio/info/readAloud', {
                   subscribe: (
                     <CalloutMenu
+                      key='subscribe'
                       inline
                       Element={(props) => (
                         <button
@@ -209,12 +212,15 @@ const Info = ({ document, handlePlay }) => {
                   ),
                   synthetic:
                     kind === 'syntheticReadAloud' && !!mp3 ? (
-                      <span>
+                      <span key='synthetic'>
                         {t.elements(
                           'article/actionbar/audio/info/readAloud/synthetic',
                           {
                             action: (
-                              <PlaySyntheticReadAloud onPlay={handlePlay}>
+                              <PlaySyntheticReadAloud
+                                onPlay={handlePlay}
+                                key='syntheticaction'
+                              >
                                 {t(
                                   'article/actionbar/audio/info/readAloud/synthetic/action',
                                 )}

--- a/apps/www/components/Climatelab/Counter.js
+++ b/apps/www/components/Climatelab/Counter.js
@@ -126,7 +126,9 @@ const Counter = ({
                 <div {...styles.footnoteContainer}>
                   <Label>
                     {t.elements('footnote', {
-                      link: <Link href={linkHref} text={linkText} />,
+                      link: (
+                        <Link href={linkHref} text={linkText} key={linkHref} />
+                      ),
                     })}
                   </Label>
                 </div>

--- a/apps/www/components/Events/Detail.js
+++ b/apps/www/components/Events/Detail.js
@@ -127,9 +127,7 @@ const Event = withT(
           {!!where && <Label>{t('events/labels/location')}</Label>}
           {!!where && <P>{location}</P>}
           {!!where && <hr {...styles.hr} {...borderRule} />}
-          <P>
-            <ActionBar share={shareObject} />
-          </P>
+          <ActionBar share={shareObject} />
         </div>
       </div>
     )

--- a/apps/www/components/Search/Form.js
+++ b/apps/www/components/Search/Form.js
@@ -85,7 +85,7 @@ const Form = compose(
           <Field
             name='q'
             label={t('search/input/label')}
-            value={formValue}
+            value={formValue ?? ''}
             onChange={update}
             icon={
               !startState ? (

--- a/apps/www/pages/en.js
+++ b/apps/www/pages/en.js
@@ -217,9 +217,9 @@ const EnPage = ({
 
       <div style={{ textAlign: 'center', marginBottom: SPACE }}>
         <P>Share manifesto</P>
-        <P style={{ marginBottom: SPACE / 2 }}>
+        <div style={{ marginBottom: SPACE / 2 }}>
           <ActionBar isCentered share={shareObject} />
-        </P>
+        </div>
         <P>
           <A href={`${CDN_FRONTEND_BASE_URL}/static/manifesto_en.pdf`}>
             Download PDF

--- a/apps/www/pages/manifest.js
+++ b/apps/www/pages/manifest.js
@@ -201,9 +201,9 @@ ${PUBLIC_BASE_URL}
 
       <div style={{ textAlign: 'center', marginBottom: SPACE }}>
         <P>Manifest teilen</P>
-        <P style={{ marginBottom: SPACE / 2 }}>
+        <div style={{ marginBottom: SPACE / 2 }}>
           <ActionBar isCentered share={shareObject} />
-        </P>
+        </div>
         <P>
           <A href={`${CDN_FRONTEND_BASE_URL}/static/manifest.pdf`}>
             Manifest als PDF herunterladen

--- a/apps/www/pages/wahltindaer/[group]/[[...suffix]].js
+++ b/apps/www/pages/wahltindaer/[group]/[[...suffix]].js
@@ -252,6 +252,7 @@ const Query = compose(
     skip: (props) => !props.me || specialGroups[props.variables.slug],
     options: ({ variables: { slug } }) => ({
       fetchPolicy: 'network-only',
+      ssr: false,
       variables: {
         slug,
       },
@@ -267,6 +268,7 @@ const Query = compose(
   graphql(query, {
     skip: (props) => specialGroups[props.variables.slug],
     options: ({ variables }) => ({
+      ssr: false,
       variables,
     }),
     props: ({ data }) => ({
@@ -304,6 +306,7 @@ const Query = compose(
     skip: (props) => !props.me || !specialGroups[props.variables.slug],
     options: ({ variables: { slug } }) => ({
       fetchPolicy: 'network-only',
+      ssr: false,
       variables: specialGroups[slug].forcedVariables,
     }),
     props: ({ data }) => ({
@@ -317,6 +320,7 @@ const Query = compose(
   graphql(specialQuery, {
     skip: (props) => !specialGroups[props.variables.slug],
     options: ({ variables: { slug, ...variables } }) => ({
+      ssr: false,
       variables: {
         ...variables,
         ...specialGroups[slug].forcedVariables,

--- a/packages/styleguide/src/components/Discussion/DiscussionCommentsWrapper.tsx
+++ b/packages/styleguide/src/components/Discussion/DiscussionCommentsWrapper.tsx
@@ -15,7 +15,10 @@ const styles = {
 }
 
 const propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   t: PropTypes.func.isRequired,
   loadMore: PropTypes.func.isRequired,
   moreAvailableCount: PropTypes.number,

--- a/packages/styleguide/src/components/Figure/SwitchImage.js
+++ b/packages/styleguide/src/components/Figure/SwitchImage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useColorContext } from '../Colors/useColorContext'
 
-const SwitchImage = ({ src, srcSet, dark, alt, ...props }) => {
+const SwitchImage = ({ src, srcSet, dark, alt, maxWidth, ...props }) => {
   const [colorScheme] = useColorContext()
 
   return (
@@ -11,6 +11,7 @@ const SwitchImage = ({ src, srcSet, dark, alt, ...props }) => {
         src={src}
         srcSet={srcSet}
         alt={alt}
+        style={{ ...props.style, maxWidth }}
         {...colorScheme.set('display', dark ? 'displayLight' : 'block')}
       />
       {dark && (
@@ -19,6 +20,7 @@ const SwitchImage = ({ src, srcSet, dark, alt, ...props }) => {
           src={dark.src}
           srcSet={dark.srcSet}
           alt={alt}
+          style={{ ...props.style, maxWidth }}
           {...colorScheme.set('display', 'displayDark')}
         />
       )}

--- a/packages/styleguide/src/components/TeaserFront/Split.js
+++ b/packages/styleguide/src/components/TeaserFront/Split.js
@@ -102,8 +102,8 @@ const Split = ({
   feuilleton,
   audioPlayButton,
 }) => {
-  const background = bgColor || ''
-  const flexDirection = reverse ? 'row-reverse' : ''
+  const background = bgColor
+  const flexDirection = reverse ? 'row-reverse' : undefined
   const bylinePosition = feuilleton
     ? 'belowFeuilleton'
     : portrait

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -170,9 +170,4 @@ Text.propTypes = {
   audioPlayButton: PropTypes.node,
 }
 
-Text.defaultProps = {
-  maxWidth: '',
-  margin: '',
-}
-
 export default Text

--- a/packages/styleguide/src/components/TeaserFront/Tile.js
+++ b/packages/styleguide/src/components/TeaserFront/Tile.js
@@ -89,7 +89,7 @@ const Tile = ({
 }) => {
   const [colorScheme] = useColorContext()
   const justifyContent =
-    align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : ''
+    align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : undefined
   const imageProps =
     image &&
     FigureImage.utils.getResizedSrcs(image, imageDark, IMAGE_SIZE.large, false)


### PR DESCRIPTION
Since the React 18 upgrade, certain hydration errors lead to an actual error in dev mode. Production is not directly affected, since the errors will just be logged to the console but hydration mismatch leads to unnecessary re-rendering of the whole page. Let's fix that.

### Notes
- I mainly checked all main pages of www and publikator, and had a quick look at admin (no issues there).
- Fixed all the critical hydration errors I could find, and some non-critical ones (e.g. style mismatches).
- I did fixed _some_ key warnings but not all of them. They are not critical at this point.
- There's a React key warning on front/TeaserMyMagazine that I can't seem to solve. All items do have unique keys but I still get the warning in the console.
- Probably best to review commit-by-commit