### PR TITLE
Allow optional bg query string to (audio cover) image URL

### DIFF
--- a/packages/backend-modules/assets/lib/returnImage.js
+++ b/packages/backend-modules/assets/lib/returnImage.js
@@ -6,6 +6,7 @@ const { PassThrough, Readable } = require('stream')
 const toArray = require('stream-to-array')
 const debug = require('debug')('assets:returnImage')
 const { parse: parsePath } = require('path')
+const colorString = require('color-string')
 
 const { SHARP_NO_CACHE } = process.env
 
@@ -58,6 +59,7 @@ module.exports = async ({
     crop,
     size,
     quality,
+    bg, // background color-string
   } = options
   const qualityInt = parseInt(quality, 10)
   const resolvedQuality =
@@ -230,6 +232,11 @@ module.exports = async ({
             `inline; filename="${parsePath(path).name}.${format}"`,
           )
         }
+
+        if (bg && colorString.get(bg)) {
+          pipeline.flatten({ background: bg })
+        }
+
         pipeline.toFormat(format, {
           // avoid interlaced pngs
           // - not supported in pdfkit

--- a/packages/backend-modules/assets/package.json
+++ b/packages/backend-modules/assets/package.json
@@ -23,6 +23,7 @@
     "aws-sdk": "^2.899.0",
     "bluebird": "^3.7.2",
     "check-env": "^1.3.0",
+    "color-string": "^1.9.0",
     "d3-array": "^2.4.0",
     "debug": "^4.1.1",
     "file-type-stream2": "^1.0.2",

--- a/packages/backend-modules/documents/lib/common/meta.js
+++ b/packages/backend-modules/documents/lib/common/meta.js
@@ -88,6 +88,9 @@ const getAudioCover = (meta, args) => {
   // desired output format
   const format = properties?.format
 
+  // optional background color
+  const bg = properties?.bg
+
   // optional postfix
   const postfix = properties?.postfix
 
@@ -103,6 +106,7 @@ const getAudioCover = (meta, args) => {
     url.searchParams.set('resize', resize)
     url.searchParams.set('bw', bw ? '1' : '')
     url.searchParams.set('format', format || 'auto')
+    bg && url.searchParams.set('bg', bg)
     postfix && url.searchParams.set('postfix', postfix)
 
     return url.toString()

--- a/packages/backend-modules/publikator/lib/auphonic/index.ts
+++ b/packages/backend-modules/publikator/lib/auphonic/index.ts
@@ -243,6 +243,7 @@ export const upsert = async (
         height: 1400,
         width: 1400,
         format: 'jpeg',
+        bg: 'white',
         postfix: '.jpeg',
       },
     },


### PR DESCRIPTION
This Pull Request allows for a `bg` option to provide a default background color and replaces transparency (alpha channel) with decalred color. It further sets default audio cover background color to white.

Usage example:

http://localhost:5020/s3/republik-assets/repos/republik/format-am-gericht/images/d9d9981cc634153530bb57e0ccabc8d68cfbe726.png?resize=300x300&format=jpeg&bg=red