### PR TITLE
feat(web): add compiler option to remove all but 'error' and 'warn' console-logs from production build

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -39,6 +39,14 @@ module.exports = withTM(
     eslint: {
       ignoreDuringBuilds: true,
     },
+    compiler: {
+      removeConsole:
+        process.env.NODE_ENV === 'production'
+          ? {
+              exclude: ['error', 'warn'],
+            }
+          : false,
+    },
     async rewrites() {
       return {
         beforeFiles: [


### PR DESCRIPTION
## Description

Using the 'compiler' option in the Next.js config it's possible to eliminate all or only certain log-levels from a next.js build.

I updated our config to remove all log-levels but 'warn' & 'error' in the production build of our website.

(Blog showcasing this option: https://reacthustle.com/blog/nextjs-remove-console-log-production)
