### PR TITLE
fix(admin): avoid error if no credential is listed

### DIFF
--- a/apps/admin/components/Users/Dialog/Credentials.js
+++ b/apps/admin/components/Users/Dialog/Credentials.js
@@ -104,22 +104,7 @@ const Credentials = ({ userId }) => {
               const { user } = data
               const { credentials } = user
 
-              if (credentials.length > 0) {
-                return (
-                  <InteractiveSection>
-                    <SectionTitle>Rollen verifizieren</SectionTitle>
-                    {[...credentials]
-                      .sort((a) => (a.isListed ? -1 : 0)) // bubble listed credentials to top
-                      .map((credential) => (
-                        <UpdateCredential
-                          key={`${credential.description}-${credential.verified}`}
-                          user={user}
-                          credential={credential}
-                        />
-                      ))}
-                  </InteractiveSection>
-                )
-              } else {
+              if (!credentials.length) {
                 return (
                   <Section>
                     <SectionTitle>Rollen verifizieren</SectionTitle>
@@ -127,6 +112,21 @@ const Credentials = ({ userId }) => {
                   </Section>
                 )
               }
+
+              return (
+                <InteractiveSection>
+                  <SectionTitle>Rollen verifizieren</SectionTitle>
+                  {[...credentials]
+                    .sort((a) => (a.isListed ? -1 : 0)) // bubble listed credentials to top
+                    .map((credential) => (
+                      <UpdateCredential
+                        key={credential.id}
+                        user={user}
+                        credential={credential}
+                      />
+                    ))}
+                </InteractiveSection>
+              )
             }}
           />
         )

--- a/apps/admin/components/Users/Dialog/Credentials.js
+++ b/apps/admin/components/Users/Dialog/Credentials.js
@@ -103,24 +103,20 @@ const Credentials = ({ userId }) => {
             render={() => {
               const { user } = data
               const { credentials } = user
-              const profileRole = credentials.find(
-                (credential) => credential.isListed,
-              )
 
               if (credentials.length > 0) {
                 return (
                   <InteractiveSection>
                     <SectionTitle>Rollen verifizieren</SectionTitle>
-                    {[
-                      profileRole,
-                      ...credentials.filter((c) => c.id !== profileRole.id),
-                    ].map((credential) => (
-                      <UpdateCredential
-                        key={`${credential.description}-${credential.verified}`}
-                        user={user}
-                        credential={credential}
-                      />
-                    ))}
+                    {[...credentials]
+                      .sort((a) => (a.isListed ? -1 : 0)) // bubble listed credentials to top
+                      .map((credential) => (
+                        <UpdateCredential
+                          key={`${credential.description}-${credential.verified}`}
+                          user={user}
+                          credential={credential}
+                        />
+                      ))}
                   </InteractiveSection>
                 )
               } else {


### PR DESCRIPTION
If no credential was listed, filter failed [since `profileRole.id` was undefined](https://github.com/republik/plattform/compare/pae/fix-admin-credentials?expand=1#diff-7093a7ec393e1533dedcd0a574e05c4647bebbf3d8f415718febbaa8a2d23169L116).

Sort bubbles listed credentials to top if there are any.

Refactor to use guard clause.
