### PR TITLE
fix(publikator): accept vimeo urls with query params

### DIFF
--- a/apps/publikator/components/editor/modules/embed/index.js
+++ b/apps/publikator/components/editor/modules/embed/index.js
@@ -231,7 +231,7 @@ const YOUTUBE_REGEX =
 
 // One capturing group at match[1] that catches the video id
 const VIMEO_REGEX =
-  /^(?:http|https)?:\/\/(?:www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^/]*)\/videos\/|)(\d+)(?:|\/\?)$/
+  /^(?:http|https)?:\/\/(?:www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^/]*)\/videos\/|)(\d+)(?:|\/\?)/
 
 const COMMENT_REGEX = new RegExp(
   `^${FRONTEND_BASE_URL}\\/.+[?&]focus=([a-f\\d-]{36})`,


### PR DESCRIPTION
Pasted Vimeo URLs with query params like https://vimeo.com/825451178?hey=ho&lets=go now also get properly converted to an embed in Publikator.