### PR TITLE
fix(email): do not display tags in the absence of tags

### DIFF
--- a/packages/backend-modules/mail/templates/cf_comment_notification_new.html
+++ b/packages/backend-modules/mail/templates/cf_comment_notification_new.html
@@ -57,17 +57,13 @@
                     >
                     </p>
                     <div
-                      style="background-color:#ebf6e5;padding:10px;color:#696b67;font-size:17px;line-height:24px;{{sg_font_style_serif_regular}}"
-                    >
-                      {{COMMENT_TAGS}}
-                    </div>
-                    <p
-                      style="color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
-                    >
-                    </p>
-                    <div
                       style="background-color:#ebf6e5;padding:10px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_serif_regular}}"
                     >
+                      {{#if COMMENT_TAGS}}
+                      <div style="padding-bottom:24px;">
+                        {{COMMENT_TAGS}}
+                      </div>
+                      {{/if}}
                       {{{CONTENT_HTML}}}
                     </div>
                     <p

--- a/packages/backend-modules/mail/templates/cf_comment_notification_new.txt
+++ b/packages/backend-modules/mail/templates/cf_comment_notification_new.txt
@@ -2,11 +2,9 @@
 
 
 
+{{#if COMMENT_TAGS}}
 {{COMMENT_TAGS}}
-
-
-
-{{{CONTENT_HTML}}}
+{{/if}} {{{CONTENT_HTML}}}
 
 {{URL}} . Dort können Sie antworten und weiter debattieren.
 


### PR DESCRIPTION
comments without a tag don't display a line for the tags in the email notification.

before:
<img width="649" alt="Screenshot 2023-06-20 at 10 44 01" src="https://github.com/republik/plattform/assets/3907984/1833da05-3f14-4f31-a283-bd699a8e5cc3">

after:
<img width="630" alt="Screenshot 2023-06-20 at 11 57 29" src="https://github.com/republik/plattform/assets/3907984/632b7fef-e750-4bb3-9a19-70fb4a59391e">

and with tag:
<img width="628" alt="Screenshot 2023-06-20 at 11 57 54" src="https://github.com/republik/plattform/assets/3907984/5eacf8a8-01d5-42c9-b2aa-493b0271c04f">
