### PR TITLE
fix(mdast/remark-preset/span): harden data attribute value parsing

### DIFF
--- a/packages/mdast/remark-preset/src/span.js
+++ b/packages/mdast/remark-preset/src/span.js
@@ -4,7 +4,7 @@ import decodeEntities from 'parse-entities'
 import encodeEntities from 'stringify-entities'
 
 export const collapse = zone.collapse({
-  test: ({type, value}) => {
+  test: ({ type, value }) => {
     if (type !== 'html') {
       return
     }
@@ -18,38 +18,45 @@ export const collapse = zone.collapse({
   mutate: (start, nodes, end) => {
     const data = {}
     const dataAttrs = start.value.match(/data-([^=]+)="([^"]+)"/g) || []
-    dataAttrs.forEach(d => {
-      const [key, value] = d.split('=')
-      data[
-        decodeEntities(key.replace(/^data-/, ''))
-      ] = decodeEntities(value.slice(1, -1))
+    dataAttrs.forEach((d) => {
+      const [, key, value] = d.match(/^data-(.+?)="(.+)"/)
+      data[decodeEntities(key)] = decodeEntities(value)
     })
     return {
       type: 'span',
       data,
-      children: nodes
+      children: nodes,
     }
-  }
+  },
 })
 
 export const expand = zone.expand({
-  test: ({type}) => type === 'span',
-  mutate: node => [
+  test: ({ type }) => type === 'span',
+  mutate: (node) => [
     {
       type: 'html',
-      value: `<span${node.data
-        ? ' ' + Object.keys(node.data).map(key => {
-          if (typeof node.data[key] !== 'string') {
-            throw new Error('mdast span: only stings are supported, you may use JSON.stringify')
-          }
-          return `data-${encodeEntities(key)}="${encodeEntities(node.data[key])}"`
-        }).join(' ')
-        : ''}>`
+      value: `<span${
+        node.data
+          ? ' ' +
+            Object.keys(node.data)
+              .map((key) => {
+                if (typeof node.data[key] !== 'string') {
+                  throw new Error(
+                    'mdast span: only stings are supported, you may use JSON.stringify',
+                  )
+                }
+                return `data-${encodeEntities(key)}="${encodeEntities(
+                  node.data[key],
+                )}"`
+              })
+              .join(' ')
+          : ''
+      }>`,
     },
     ...node.children,
     {
       type: 'html',
-      value: '</span>'
-    }
-  ]
+      value: '</span>',
+    },
+  ],
 })

--- a/packages/mdast/remark-preset/test/span.test.ts
+++ b/packages/mdast/remark-preset/test/span.test.ts
@@ -46,4 +46,32 @@ describe('spans', () => {
       stringify(rootNode)
     }).toThrow()
   })
+
+  test('span data contains equal sign', () => {
+    const md = '<span data-attr="foo=bar">child</span>\n'
+    const rootNode = parse(md)
+
+    const { data } = rootNode.children[0].children[0]
+
+    expect(data.attr).toEqual('foo=bar')
+  })
+
+  test('span data contains multiple equal signs', () => {
+    const md = '<span data-attr="foo=bar, fizz=buzz">child</span>\n'
+    const rootNode = parse(md)
+
+    const { data } = rootNode.children[0].children[0]
+
+    expect(data.attr).toEqual('foo=bar, fizz=buzz')
+  })
+
+  test('span data contains data attribute resembling data', () => {
+    const md =
+      '<span data-attr="data-hero=&#x22;Spiderman&#x22;">child</span>\n'
+    const rootNode = parse(md)
+
+    const { data } = rootNode.children[0].children[0]
+
+    expect(data.attr).toEqual('data-hero="Spiderman"')
+  })
 })


### PR DESCRIPTION
<img width="916" alt="CleanShot 2023-06-21 at 10 25 46@2x" src="https://github.com/republik/plattform/assets/30313631/b1c42d87-3cf6-45e8-ab67-3807de5b03ac">

(These changes are from a non merged pr in the remark-preset package in the mdast repo. [see #7 in orbiting/mdasst](https://github.com/orbiting/mdast/pull/7))
