### PR TITLE
fix: suggested price comes from correct pledge now

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/lib/CustomPackages/index.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/CustomPackages/index.js
@@ -406,6 +406,7 @@ const getCustomOptions = async (package_) => {
   }
 
   const suggestedTotal = filteredAndSortedOptions
+    .filter((option) => option.defaultAmount > 0)
     .map((option) => option.suggestedPrice)
     .filter(Boolean)
     .find((price) => !!price)


### PR DESCRIPTION
All pledges and membership package options are taken into account for choosing a suggestedPrice at the moment, but only the latest pledge for your own membership should be used. Hence the filter by defaultAmount, which is greater than 0 for the right membership and package option (defaultAmount for gift memberships is 0).