### PR TITLE
fix(auth): check if user is deleted when resolving token

### DIFF
--- a/packages/backend-modules/auth/lib/AccessToken.js
+++ b/packages/backend-modules/auth/lib/AccessToken.js
@@ -139,7 +139,7 @@ const resolve = async (token, { pgdb }) => {
   if (userId && scope && expiresAt && hmac) {
     const payload = getPayload({ userId, scope, expiresAt })
     const userRecord = await pgdb.public.users.findOne({ id: userId })
-    if (userRecord.revokedAt) {
+    if (userRecord.deletedAt) {
       return null
     }
     const key = userRecord.accessKey

--- a/packages/backend-modules/auth/lib/AccessToken.js
+++ b/packages/backend-modules/auth/lib/AccessToken.js
@@ -142,7 +142,6 @@ const resolve = async (token, { pgdb }) => {
       { id: userId, deletedAt: null },
       'accessKey',
     )
-    console.log(key)
     if (key && getHmac(payload, key) === hmac) {
       const scopeConfig = getScopeConfig(scope)
       return { userId, scope, scopeConfig, expiresAt: moment(expiresAt), hmac }

--- a/packages/backend-modules/auth/lib/AccessToken.js
+++ b/packages/backend-modules/auth/lib/AccessToken.js
@@ -142,6 +142,7 @@ const resolve = async (token, { pgdb }) => {
       { id: userId, deletedAt: null },
       'accessKey',
     )
+    console.log(key)
     if (key && getHmac(payload, key) === hmac) {
       const scopeConfig = getScopeConfig(scope)
       return { userId, scope, scopeConfig, expiresAt: moment(expiresAt), hmac }


### PR DESCRIPTION
When an access token of any type is resolved, it checks if the user has been deleted (for the cases where the user record has to be kept after deletion for administrative reasons).