### PR TITLE
TS Setup improvements

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -80,7 +80,6 @@
     "gsheets": "^2.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "nodemon": "^2.0.6",
-    "typescript": "^4.7.2"
+    "nodemon": "^2.0.6"
   }
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -54,8 +54,7 @@
     "gsheets": "^3.0.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "nodemon": "^2.0.15",
-    "typescript": "^4.7.2"
+    "nodemon": "^2.0.15"
   },
   "dependencies": {
     "@apollo/client": "~3.5.10",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lint-staged": "^12.3.3",
     "prettier": "^2.5.1",
     "turbo": "^1.10.3",
+    "typescript": "^5.1.6",
     "yaproxy": "^1.0.2"
   },
   "cacheDirectories": [

--- a/packages/backend-modules/types/package.json
+++ b/packages/backend-modules/types/package.json
@@ -19,9 +19,7 @@
     "link": "yarn link"
   },
   "dependencies": {},
-  "devDependencies": {
-    "typescript": "^4.7.2"
-  },
+  "devDependencies": {},
   "files": [
     "tsconfig-backend.json"
   ]

--- a/packages/backend-modules/utils/package.json
+++ b/packages/backend-modules/utils/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@orbiting/backend-modules-types": "*",
-    "@types/validator": "^13.7.4",
-    "typescript": "^4.7.3"
+    "@types/validator": "^13.7.4"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@svgr/cli": "^6.1.2",
     "@vitejs/plugin-react": "^3.1.0",
-    "typescript": "^4.7.2",
     "vite": "^4.1.0",
     "vite-plugin-dts": "^1.7.3"
   },

--- a/packages/mdast/mdast-react-render/package.json
+++ b/packages/mdast/mdast-react-render/package.json
@@ -25,8 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ts-jest": "^29.1.0",
-    "tsup": "^6.7.0",
-    "typescript": "^4.7.2"
+    "tsup": "^6.7.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/mdast/remark-preset/package.json
+++ b/packages/mdast/remark-preset/package.json
@@ -22,8 +22,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
-    "tsup": "^6.7.0",
-    "typescript": "^4.7.2"
+    "tsup": "^6.7.0"
   },
   "dependencies": {
     "js-yaml": "^3.10.0",

--- a/packages/mdast/slate-mdast-serializer/package.json
+++ b/packages/mdast/slate-mdast-serializer/package.json
@@ -26,8 +26,7 @@
     "react-dom": "^18.2.0",
     "slate": "~0.31",
     "ts-jest": "^29.1.0",
-    "tsup": "^6.7.0",
-    "typescript": "^4.7.2"
+    "tsup": "^6.7.0"
   },
   "peerDependencies": {
     "slate": "~0.31"

--- a/packages/nextjs-apollo-client/package.json
+++ b/packages/nextjs-apollo-client/package.json
@@ -27,7 +27,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.7.2",
     "uuid": "^3.4.0"
   },
   "peerDependencies": {

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -96,7 +96,6 @@
     "scroll-into-view": "1.15.0",
     "semantic-release": "^17.1.1",
     "topojson": "^3.0.2",
-    "typescript": "^4.7.2",
     "validate-commit-msg": "^2.14.0"
   },
   "peerDependencies": {

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -14,17 +10,11 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -10,7 +10,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18171,10 +18171,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.4.3, typescript@^4.6.4, typescript@^4.7.2, typescript@^4.7.3:
+typescript@^4.4.3, typescript@^4.6.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 typescript@~4.8.4:
   version "4.8.4"


### PR DESCRIPTION
- Define `moduleResolution` as [`nodenext`](https://www.typescriptlang.org/tsconfig#moduleResolution) (should be `bundler` but that's only supported by Next.js 13+), so the package.json `exports` field is correctly supported (instead of using `main`, `module` etc.).
- Upgrade TypeScript to v5
- Move the TypeScript dependency out of individual packages and into the root of the project (fewer moving parts and dependencies to manage)