### PR TITLE
Improve Questionnaire Overview Performance

### DIFF
--- a/apps/www/components/Climatelab/Questionnaire/Overview.js
+++ b/apps/www/components/Climatelab/Questionnaire/Overview.js
@@ -74,6 +74,8 @@ const SubmissionsOverview = ({ slug, extract, share }) => {
             extract={extract}
             share={share}
             questionIds={questionIds}
+            questionColor={questionColor}
+            questions={QUESTIONS}
             personPagePath={PERSON_PAGE_PATH}
             questionnaireBgColor={QUESTIONNAIRE_BG_COLOR}
           />

--- a/apps/www/components/Climatelab/Questionnaire/Person.js
+++ b/apps/www/components/Climatelab/Questionnaire/Person.js
@@ -26,7 +26,7 @@ import { useTranslation } from '../../../lib/withT'
 import Frame from '../../Frame'
 import Meta from '../../Frame/Meta'
 
-import { QUESTIONNAIRE_SUBMISSIONS_QUERY } from '../../Questionnaire/Submissions/graphql'
+import { QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY } from '../../Questionnaire/Submissions/graphql'
 import { LinkToEditQuestionnaire } from '../../Questionnaire/Submissions/QuestionFeatured'
 import { ShareImageSplit } from '../../Questionnaire/Submissions/ShareImageSplit'
 import {
@@ -78,13 +78,16 @@ const Page = () => {
   shareImageUrlObj.searchParams.set('image', true)
   const shareImageUrl = shareImageUrlObj.toString()
 
-  const { loading, error, data } = useQuery(QUESTIONNAIRE_SUBMISSIONS_QUERY, {
-    variables: {
-      slug: QUESTIONNAIRE_SLUG,
-      id,
-      sortBy: 'random',
+  const { loading, error, data } = useQuery(
+    QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
+    {
+      variables: {
+        slug: QUESTIONNAIRE_SLUG,
+        id,
+        sortBy: 'random',
+      },
     },
-  })
+  )
 
   const author = data?.questionnaire?.results?.nodes[0]?.displayAuthor
   const slug = author?.slug

--- a/apps/www/components/PoliticsCommunityQuestionnaire/Person.js
+++ b/apps/www/components/PoliticsCommunityQuestionnaire/Person.js
@@ -25,7 +25,7 @@ import { useTranslation } from '../../lib/withT'
 import Frame from '../Frame'
 import Meta from '../Frame/Meta'
 
-import { QUESTIONNAIRE_SUBMISSIONS_QUERY } from '../Questionnaire/Submissions/graphql'
+import { QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY } from '../Questionnaire/Submissions/graphql'
 import { LinkToEditQuestionnaire } from '../Questionnaire/Submissions/QuestionFeatured'
 import { ShareImageSplit } from '../Questionnaire/Submissions/ShareImageSplit'
 import {
@@ -79,13 +79,16 @@ const Page = () => {
   shareImageUrlObj.searchParams.set('image', true)
   const shareImageUrl = shareImageUrlObj.toString()
 
-  const { loading, error, data } = useQuery(QUESTIONNAIRE_SUBMISSIONS_QUERY, {
-    variables: {
-      slug: QUESTIONNAIRE_SLUG,
-      id,
-      sortBy: 'random',
+  const { loading, error, data } = useQuery(
+    QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
+    {
+      variables: {
+        slug: QUESTIONNAIRE_SLUG,
+        id,
+        sortBy: 'random',
+      },
     },
-  })
+  )
 
   const author = data?.questionnaire?.results?.nodes[0]?.displayAuthor
   const slug = author?.slug

--- a/apps/www/components/Questionnaire/Submissions/AnswersGrid.tsx
+++ b/apps/www/components/Questionnaire/Submissions/AnswersGrid.tsx
@@ -33,11 +33,6 @@ export const AnswersGrid = ({ children }: { children: ReactNode }) => {
   return <div {...styles.grid}>{children}</div>
 }
 
-export const AnswersGridCard = ({
-  children,
-}: {
-  textLength?: number
-  children: ReactNode
-}) => {
+export const AnswersGridCard = ({ children }: { children: ReactNode }) => {
   return <div {...styles.card}>{children}</div>
 }

--- a/apps/www/components/Questionnaire/Submissions/QuestionFeatured.js
+++ b/apps/www/components/Questionnaire/Submissions/QuestionFeatured.js
@@ -21,7 +21,7 @@ import { useMe } from '../../../lib/context/MeContext'
 
 import {
   QUESTIONNAIRE_SUBMISSION_BOOL_QUERY,
-  QUESTIONNAIRE_SUBMISSIONS_QUERY,
+  QUESTIONNAIRE_ONLY_SUBMISSIONS_QUERY,
 } from './graphql'
 import { AnswersGrid, AnswersGridCard } from './AnswersGrid'
 import { QuestionSummaryChart } from './QuestionChart'
@@ -142,19 +142,22 @@ const AnswerGridOverview = ({
   hint,
   personPagePath,
 }) => {
-  const { loading, error, data } = useQuery(QUESTIONNAIRE_SUBMISSIONS_QUERY, {
-    variables: {
-      slug,
-      first: 6,
-      sortBy: 'random',
-      answers: [
-        {
-          questionId: question.id,
-          valueLength,
-        },
-      ],
+  const { loading, error, data } = useQuery(
+    QUESTIONNAIRE_ONLY_SUBMISSIONS_QUERY,
+    {
+      variables: {
+        slug,
+        first: 6,
+        sortBy: 'random',
+        answers: [
+          {
+            questionId: question.id,
+            valueLength,
+          },
+        ],
+      },
     },
-  })
+  )
 
   return (
     <Loader
@@ -185,16 +188,13 @@ const AnswerGridOverview = ({
             >
               <AnswersGrid>
                 {targetedAnswers.map(({ answers, displayAuthor, id }) => (
-                  <AnswersGridCard
-                    key={id}
-                    textLength={answers[0].payload.value.length}
-                  >
+                  <AnswersGridCard key={id}>
                     <SubmissionLink id={id} personPagePath={personPagePath}>
                       <a style={{ textDecoration: 'none' }}>
                         <div {...styles.answerCard}>
                           <div>
                             <Editorial.Question style={{ marginTop: 0 }}>
-                              {inQuotes(answers[0].payload.value)}
+                              {inQuotes(answers[0]?.payload?.value ?? '')}
                             </Editorial.Question>
                             <Editorial.Credit
                               style={{

--- a/apps/www/components/Questionnaire/Submissions/QuestionView.js
+++ b/apps/www/components/Questionnaire/Submissions/QuestionView.js
@@ -26,7 +26,7 @@ import ErrorMessage from '../../ErrorMessage'
 import {
   hasMoreData,
   loadMoreSubmissions,
-  QUESTIONNAIRE_SUBMISSIONS_QUERY,
+  QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
 } from './graphql'
 import AnswerText from './AnswerText'
 import {
@@ -77,7 +77,7 @@ const QuestionView = ({
   const router = useRouter()
   const pathname = router.asPath.split('?')[0]
   const { loading, error, data, fetchMore } = useQuery(
-    QUESTIONNAIRE_SUBMISSIONS_QUERY,
+    QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
     {
       variables: {
         slug,

--- a/apps/www/components/Questionnaire/Submissions/QuestionView.js
+++ b/apps/www/components/Questionnaire/Submissions/QuestionView.js
@@ -208,72 +208,68 @@ const QuestionView = ({
                                 localColorVariables={colors}
                                 colorSchemeKey='light'
                               >
-                                <Editorial.P
-                                  attributes={{ style: { width: '100%' } }}
+                                <div
+                                  {...(!isChoiceQuestion &&
+                                    styles.answerCardContent)}
                                 >
-                                  <div
-                                    {...(!isChoiceQuestion &&
-                                      styles.answerCardContent)}
+                                  {answers.map((answer, idx) => {
+                                    return (
+                                      <div key={answer.id}>
+                                        {isChoiceQuestion && !idx ? (
+                                          <div {...styles.circleLabel}>
+                                            <span {...styles.circle} />
+                                            <AnswerText
+                                              text={answer.payload.text}
+                                              value={answer.payload.value}
+                                              question={currentQuestions[idx]}
+                                              isQuote
+                                            />
+                                          </div>
+                                        ) : (
+                                          <div
+                                            {...(isChoiceQuestion &&
+                                              styles.answerCardContent)}
+                                          >
+                                            <AnswerText
+                                              text={answer.payload.text}
+                                              value={answer.payload.value}
+                                              question={currentQuestions[idx]}
+                                              isQuote
+                                            />
+
+                                            {idx === 0 && twoTextQuestions && (
+                                              <hr
+                                                style={{
+                                                  opacity: 0.3,
+                                                  margin: '1.2em 33%',
+                                                  border: 0,
+                                                  borderTop:
+                                                    '1px solid currentColor',
+                                                }}
+                                              />
+                                            )}
+                                          </div>
+                                        )}
+                                      </div>
+                                    )
+                                  })}
+
+                                  <Editorial.Credit
+                                    style={{
+                                      marginTop: '0',
+                                      paddingTop: '5px',
+                                    }}
                                   >
-                                    {answers.map((answer, idx) => {
-                                      return (
-                                        <div key={answer.id}>
-                                          {isChoiceQuestion && !idx ? (
-                                            <div {...styles.circleLabel}>
-                                              <span {...styles.circle} />
-                                              <AnswerText
-                                                text={answer.payload.text}
-                                                value={answer.payload.value}
-                                                question={currentQuestions[idx]}
-                                                isQuote
-                                              />
-                                            </div>
-                                          ) : (
-                                            <div
-                                              {...(isChoiceQuestion &&
-                                                styles.answerCardContent)}
-                                            >
-                                              <AnswerText
-                                                text={answer.payload.text}
-                                                value={answer.payload.value}
-                                                question={currentQuestions[idx]}
-                                                isQuote
-                                              />
-
-                                              {idx === 0 && twoTextQuestions && (
-                                                <hr
-                                                  style={{
-                                                    opacity: 0.3,
-                                                    margin: '1.2em 33%',
-                                                    border: 0,
-                                                    borderTop:
-                                                      '1px solid currentColor',
-                                                  }}
-                                                />
-                                              )}
-                                            </div>
-                                          )}
-                                        </div>
-                                      )
-                                    })}
-
-                                    <Editorial.Credit
+                                    Von{' '}
+                                    <span
                                       style={{
-                                        marginTop: '0',
-                                        paddingTop: '5px',
+                                        textDecoration: 'underline',
                                       }}
                                     >
-                                      Von{' '}
-                                      <span
-                                        style={{
-                                          textDecoration: 'underline',
-                                        }}
-                                      >
-                                        {displayAuthor.name}
-                                      </span>
-                                    </Editorial.Credit>
-                                  </div>
-                                </Editorial.P>
+                                      {displayAuthor.name}
+                                    </span>
+                                  </Editorial.Credit>
+                                </div>
                               </ColorContextProvider>
                             </div>
                           </a>

--- a/apps/www/components/Questionnaire/Submissions/graphql.js
+++ b/apps/www/components/Questionnaire/Submissions/graphql.js
@@ -116,8 +116,8 @@ export const QUESTIONNAIRE_SUBMISSION_BOOL_QUERY = gql`
   }
 `
 
-export const QUESTIONNAIRE_SUBMISSIONS_QUERY = gql`
-  query getQuestionnaireSubmissions(
+export const QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY = gql`
+  query getQuestionnaireWithSubmissions(
     $slug: String!
     $search: String
     $first: Int
@@ -149,6 +149,42 @@ export const QUESTIONNAIRE_SUBMISSIONS_QUERY = gql`
     }
   }
   ${questionnaireData}
+  ${submissionData}
+`
+
+// The same query as above but excluding the QuestionnaireFragment, which should improve query performance significantly in case the data is not needed.
+export const QUESTIONNAIRE_ONLY_SUBMISSIONS_QUERY = gql`
+  query getQuestionnaireOnlySubmissions(
+    $slug: String!
+    $search: String
+    $first: Int
+    $after: String
+    $sortBy: SubmissionsSortBy!
+    $sortDirection: OrderDirection
+    $answers: [SubmissionFilterAnswer]
+    $id: ID
+    $userIds: [ID!]
+  ) {
+    questionnaire(slug: $slug) {
+      id
+      results: submissions(
+        search: $search
+        first: $first
+        after: $after
+        sort: { by: $sortBy, direction: $sortDirection }
+        filters: { answers: $answers, id: $id, userIds: $userIds }
+      ) {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          ...QuestionnaireSubmissionFragment
+        }
+      }
+    }
+  }
   ${submissionData}
 `
 

--- a/apps/www/components/Questionnaire/Submissions/index.js
+++ b/apps/www/components/Questionnaire/Submissions/index.js
@@ -25,7 +25,7 @@ import {
   hasMoreData,
   loadMoreSubmissions,
   QUERY_PARAM,
-  QUESTIONNAIRE_SUBMISSIONS_QUERY,
+  QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
   SINGLE_SUBMISSION_QUERY,
   SORT_DIRECTION_PARAM,
   SORT_KEY_PARAM,
@@ -82,7 +82,7 @@ const Submissions = ({ slug, extract, share = {} }) => {
   }, [debouncedSearch])
   const pathname = router.asPath.split('?')[0]
   const { loading, error, data, previousData, fetchMore } = useQuery(
-    QUESTIONNAIRE_SUBMISSIONS_QUERY,
+    QUESTIONNAIRE_WITH_SUBMISSIONS_QUERY,
     {
       variables: {
         slug,


### PR DESCRIPTION
Adds a new query for fetching questionnaire submissions *without* questionnaire metadata.

This improves performance of the questionnaire overview significantly because at the time the submissions are fetched, questionnaire metadata has already been fetched and doesn't have to be re-fetched. Submissions for each question are queried separately which can lead to a lot of concurrent requests (this is still the case and should probably improved at some point). At least this way, each query takes ~1s whereas before it could take 5–10s.
