### PR TITLE
fix: theming issues

### DIFF
--- a/apps/www/components/ColorScheme/ThemeProvider.tsx
+++ b/apps/www/components/ColorScheme/ThemeProvider.tsx
@@ -12,23 +12,17 @@ const ColorSchemeMigration = () => {
   const { setTheme } = useTheme()
   const [key, setKey] = usePersistedColorSchemeKey<string>(null)
 
-  if (typeof window !== 'undefined' && key == 'auto') {
-    alert('theme')
-    setTheme('system')
+  if (typeof window !== 'undefined' && key) {
+    const cleanedKey = key.replaceAll('"', '')
+    setTheme(cleanedKey === 'auto' ? 'system' : cleanedKey)
     setKey(null)
   }
   return null
 }
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  // If set, the theme is forced on next-themes' Provider to bypass its internal localStorage-only implementation
-
   return (
-    <NextThemeProvider
-      // storageKey={COLOR_SCHEME_KEY}
-      attribute='data-theme'
-      disableTransitionOnChange
-    >
+    <NextThemeProvider attribute='data-theme' disableTransitionOnChange>
       <ColorSchemeMigration />
       {children}
     </NextThemeProvider>

--- a/apps/www/components/ColorScheme/ThemeProvider.tsx
+++ b/apps/www/components/ColorScheme/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes'
+import { ThemeProvider as NextThemeProvider } from 'next-themes'
 import { ReactNode } from 'react'
 import { useColorSchemePreference } from './useColorScheme'
 

--- a/apps/www/components/ColorScheme/ThemeProvider.tsx
+++ b/apps/www/components/ColorScheme/ThemeProvider.tsx
@@ -1,22 +1,35 @@
-import { ThemeProvider as NextThemeProvider } from 'next-themes'
+import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes'
 import { ReactNode } from 'react'
-import { useColorSchemePreference } from './useColorScheme'
+import { usePersistedColorSchemeKey } from './useColorScheme'
 
 export { useTheme } from 'next-themes'
 
-export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  // This uses our custom storage implementation which can store the preference in native apps too.
-  const [key] = useColorSchemePreference()
+/**
+ * This component is used to migrate the old color scheme key to the new one.
+ * managed by next-themes.
+ */
+const ColorSchemeMigration = () => {
+  const { setTheme } = useTheme()
+  const [key, setKey] = usePersistedColorSchemeKey<string>(null)
 
+  if (typeof window !== 'undefined' && key == 'auto') {
+    alert('theme')
+    setTheme('system')
+    setKey(null)
+  }
+  return null
+}
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   // If set, the theme is forced on next-themes' Provider to bypass its internal localStorage-only implementation
-  const forcedTheme = key === 'auto' ? null : key
 
   return (
     <NextThemeProvider
-      attribute='class'
-      forcedTheme={forcedTheme}
+      // storageKey={COLOR_SCHEME_KEY}
+      attribute='data-theme'
       disableTransitionOnChange
     >
+      <ColorSchemeMigration />
       {children}
     </NextThemeProvider>
   )

--- a/apps/www/components/ColorScheme/ThemeProvider.tsx
+++ b/apps/www/components/ColorScheme/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes'
 import { ReactNode } from 'react'
-import { usePersistedColorSchemeKey } from './useColorScheme'
+import { useColorSchemePreference } from './useColorScheme'
 
 export { useTheme } from 'next-themes'
 
@@ -9,13 +9,11 @@ export { useTheme } from 'next-themes'
  * managed by next-themes.
  */
 const ColorSchemeMigration = () => {
-  const { setTheme } = useTheme()
-  const [key, setKey] = usePersistedColorSchemeKey<string>(null)
+  const [key, setKey] = useColorSchemePreference()
 
   if (typeof window !== 'undefined' && key) {
     const cleanedKey = key.replaceAll('"', '')
-    setTheme(cleanedKey === 'auto' ? 'system' : cleanedKey)
-    setKey(null)
+    setKey(cleanedKey)
   }
   return null
 }

--- a/apps/www/components/ColorScheme/useColorScheme.ts
+++ b/apps/www/components/ColorScheme/useColorScheme.ts
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
 import createPersistedState from '../../lib/hooks/use-persisted-state'
 import { useInNativeApp, postMessage } from '../../lib/withInNativeApp'
+import { useTheme } from 'next-themes'
 
 export const COLOR_SCHEME_KEY = 'republik-color-scheme'
 
-const usePersistedColorSchemeKey =
+export const usePersistedColorSchemeKey =
   createPersistedState<string>(COLOR_SCHEME_KEY)
 
 // used to persist os color scheme when running in our Android app
@@ -16,10 +17,10 @@ export const usePersistedOSColorSchemeKey =
 const DEFAULT_KEY = 'auto'
 
 export const useColorSchemePreference = () => {
+  const { theme } = useTheme()
   const { inNativeApp, inNativeAppLegacy } = useInNativeApp()
   const inNewApp = inNativeApp && !inNativeAppLegacy
-  const [key, set] = usePersistedColorSchemeKey<string>(DEFAULT_KEY)
-  const currentKey = key || DEFAULT_KEY
+  const currentKey = (theme === 'sytem' ? 'auto' : theme) || DEFAULT_KEY
 
   useEffect(() => {
     if (inNewApp) {

--- a/apps/www/components/ColorScheme/useColorScheme.ts
+++ b/apps/www/components/ColorScheme/useColorScheme.ts
@@ -17,7 +17,7 @@ export const usePersistedOSColorSchemeKey =
 const DEFAULT_KEY = 'auto'
 
 export const useColorSchemePreference = () => {
-  const { theme } = useTheme()
+  const { theme, setTheme } = useTheme()
   const { inNativeApp, inNativeAppLegacy } = useInNativeApp()
   const inNewApp = inNativeApp && !inNativeAppLegacy
   const currentKey = (theme === 'sytem' ? 'auto' : theme) || DEFAULT_KEY
@@ -30,6 +30,10 @@ export const useColorSchemePreference = () => {
       })
     }
   }, [inNewApp, currentKey])
+
+  const set = (value: string) => {
+    setTheme(value === 'auto' ? 'system' : value)
+  }
 
   return [currentKey, set, DEFAULT_KEY] as const
 }

--- a/apps/www/components/ColorScheme/useColorScheme.ts
+++ b/apps/www/components/ColorScheme/useColorScheme.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import createPersistedState from '../../lib/hooks/use-persisted-state'
 import { useInNativeApp, postMessage } from '../../lib/withInNativeApp'
-import { useTheme } from 'next-themes'
+import { useTheme } from './ThemeProvider'
 
 export const COLOR_SCHEME_KEY = 'republik-color-scheme'
 

--- a/apps/www/components/ColorScheme/useColorScheme.ts
+++ b/apps/www/components/ColorScheme/useColorScheme.ts
@@ -5,8 +5,9 @@ import { useTheme } from 'next-themes'
 
 export const COLOR_SCHEME_KEY = 'republik-color-scheme'
 
-export const usePersistedColorSchemeKey =
-  createPersistedState<string>(COLOR_SCHEME_KEY)
+export const usePersistedColorSchemeKey = createPersistedState<
+  string | undefined
+>(COLOR_SCHEME_KEY)
 
 // used to persist os color scheme when running in our Android app
 // - our web view on Android currently does not support media query dark mode detection
@@ -21,6 +22,9 @@ export const useColorSchemePreference = () => {
   const { inNativeApp, inNativeAppLegacy } = useInNativeApp()
   const inNewApp = inNativeApp && !inNativeAppLegacy
   const currentKey = (theme === 'sytem' ? 'auto' : theme) || DEFAULT_KEY
+  const [legacyKey, setPersistedKey] = usePersistedColorSchemeKey<
+    string | undefined
+  >(undefined)
 
   useEffect(() => {
     if (inNewApp) {
@@ -33,7 +37,8 @@ export const useColorSchemePreference = () => {
 
   const set = (value: string) => {
     setTheme(value === 'auto' ? 'system' : value)
+    setPersistedKey(undefined)
   }
 
-  return [currentKey, set, DEFAULT_KEY] as const
+  return [legacyKey, set, DEFAULT_KEY] as const
 }

--- a/apps/www/components/Frame/DarkmodeSwitch.js
+++ b/apps/www/components/Frame/DarkmodeSwitch.js
@@ -2,17 +2,17 @@ import { forwardRef } from 'react'
 import { CalloutMenu, IconButton, Radio } from '@project-r/styleguide'
 import { useInNativeApp } from '../../lib/withInNativeApp'
 
-import { useColorSchemePreference } from '../ColorScheme/useColorScheme'
 import { IconDarkMode } from '@republik/icons'
+import { useTheme } from 'next-themes'
 
 const DarkmodeSwitch = ({ t }) => {
   const { inNativeApp, inNativeAppLegacy } = useInNativeApp()
-  const [colorSchemeKey, setColorSchemeKey] = useColorSchemePreference()
+  const { theme, setTheme } = useTheme()
 
   const iconLabel =
-    colorSchemeKey === 'light'
+    theme === 'light'
       ? t('darkmode/switch/off')
-      : colorSchemeKey === 'dark'
+      : theme === 'dark'
       ? t('darkmode/switch/on')
       : t('darkmode/switch/auto')
 
@@ -41,9 +41,9 @@ const DarkmodeSwitch = ({ t }) => {
           <>
             <Radio
               value='dark'
-              checked={colorSchemeKey === 'dark'}
+              checked={theme === 'dark'}
               onChange={() => {
-                setColorSchemeKey('dark')
+                setTheme('dark')
               }}
             >
               {t('darkmode/switch/on')}
@@ -51,9 +51,9 @@ const DarkmodeSwitch = ({ t }) => {
             <br />
             <Radio
               value='light'
-              checked={colorSchemeKey === 'light'}
+              checked={theme === 'light'}
               onChange={() => {
-                setColorSchemeKey(inNativeAppLegacy ? '' : 'light')
+                setTheme(inNativeAppLegacy ? '' : 'light')
               }}
             >
               {t('darkmode/switch/off')}
@@ -62,9 +62,9 @@ const DarkmodeSwitch = ({ t }) => {
             {!inNativeAppLegacy && (
               <Radio
                 value='auto'
-                checked={colorSchemeKey === 'auto'}
+                checked={theme === 'system'}
                 onChange={() => {
-                  setColorSchemeKey('auto')
+                  setTheme('system')
                 }}
               >
                 {t('darkmode/switch/auto')}

--- a/apps/www/components/Frame/DarkmodeSwitch.js
+++ b/apps/www/components/Frame/DarkmodeSwitch.js
@@ -3,7 +3,7 @@ import { CalloutMenu, IconButton, Radio } from '@project-r/styleguide'
 import { useInNativeApp } from '../../lib/withInNativeApp'
 
 import { IconDarkMode } from '@republik/icons'
-import { useTheme } from 'next-themes'
+import { useTheme } from '../ColorScheme/ThemeProvider'
 
 const DarkmodeSwitch = ({ t }) => {
   const { inNativeApp, inNativeAppLegacy } = useInNativeApp()

--- a/packages/styleguide/src/components/Colors/ColorContext.tsx
+++ b/packages/styleguide/src/components/Colors/ColorContext.tsx
@@ -173,10 +173,10 @@ export const RootColorVariables = () => {
   )
 }
 
-const colorSchemeKeyToClassName = (colorSchemeKey: string) => {
+const colorSchemeKeyToDataTheme = (colorSchemeKey: string) => {
   return colorSchemeKey === 'light' || colorSchemeKey === 'dark'
     ? colorSchemeKey
-    : ''
+    : undefined
 }
 
 export const ColorContextProvider: React.FC<{
@@ -190,7 +190,7 @@ export const ColorContextProvider: React.FC<{
 
   return (
     <ColorContext.Provider value={defaultColorContextValue}>
-      <div className={colorSchemeKeyToClassName(colorSchemeKey)}>
+      <div data-theme={colorSchemeKeyToDataTheme(colorSchemeKey)}>
         {children}
       </div>
     </ColorContext.Provider>

--- a/packages/styleguide/src/components/Colors/ColorContext.tsx
+++ b/packages/styleguide/src/components/Colors/ColorContext.tsx
@@ -136,10 +136,10 @@ export const ColorContextLocalExtension: React.FC<{
     return [
       createScheme(extendedColorDefinitions),
       css({
-        ':root &, .light &': {
+        ':root &, [data-theme="light"] &': {
           ...lightColorCSSDefs,
         },
-        '.dark &': {
+        '[data-theme="dark"] &': {
           ...darkColorCSSDefs,
         },
       }),
@@ -160,11 +160,11 @@ export const RootColorVariables = () => {
       dangerouslySetInnerHTML={{
         __html: [
           // default light
-          `:root, .light, .dark .inverted { ${generateCSSColorDefinitions(
+          `:root, [data-theme="light"], [data-theme="dark"] [data-theme-inverted] { ${generateCSSColorDefinitions(
             colors.light,
           )} }`,
           // dark class applied to html element via next-themes OR manually applied on an element
-          `.dark, .light .inverted { ${generateCSSColorDefinitions(
+          `[data-theme="dark"], [data-theme="light"] [data-theme-inverted] { ${generateCSSColorDefinitions(
             colors.dark,
           )} }`,
         ].join('\n'),
@@ -198,7 +198,7 @@ export const ColorContextProvider: React.FC<{
 }
 
 export const InvertedColorScheme = ({ children }: { children: ReactNode }) => {
-  return <div className='inverted'>{children}</div>
+  return <div data-theme-inverted>{children}</div>
 }
 
 export default ColorContext

--- a/packages/styleguide/src/templates/Front/index.js
+++ b/packages/styleguide/src/templates/Front/index.js
@@ -52,6 +52,7 @@ import {
 
 import createLiveTeasers from './liveTeasers'
 import { shouldRenderPlayButton } from '../shared/audio'
+import { ColorContextProvider } from '../../lib'
 
 export const subject = {
   matchMdast: matchHeading(2),
@@ -439,7 +440,7 @@ const createFrontSchema = ({
               <AudioPlayButton documentId={props?.urlMeta.documentId} />
             ) : undefined
           }
-          attributes={attributes}
+          attributes={{ ...attributes, 'data-theme': 'light' }}
           {...props}
         >
           {children}


### PR DESCRIPTION
- fix: force light theme on frontTileTeaser
- feat(styleguide): use data-theme instead of class for color-mode
- feat(www): communicate the color-scheme from nex-themes to the app
- feat(www): use data-theme attribute for styling & add migration util to migrate away from old color-scheme storage
- fix(styleguide): use data-theme to force color scheme in color context
- feat(www): update theme migration helper
- feat(www): useColorScheme now sets the theme via next-themes
- feat(www): get rid of useColorScheme usages
