### PR TITLE
fix(calendar): throw error if role is missing

### DIFF
--- a/packages/backend-modules/calendar/graphql/resolvers/_mutations/bookCalendarSlot.js
+++ b/packages/backend-modules/calendar/graphql/resolvers/_mutations/bookCalendarSlot.js
@@ -29,10 +29,12 @@ module.exports = async (_, args, context) => {
     calendar.limitRoles?.length &&
     !Roles.userIsInRoles(user, calendar.limitRoles)
   ) {
-    t.pluralize('api/unauthorized', {
-      count: calendar.limitRoles.length,
-      role: calendar.limitRoles.map((r) => `«${r}»`).join(', '),
-    })
+    throw new Error(
+      t.pluralize('api/unauthorized', {
+        count: calendar.limitRoles.length,
+        role: calendar.limitRoles.map((r) => `«${r}»`).join(', '),
+      }),
+    )
   }
 
   const userSlots = await loaders.CalendarSlot.byKeyObj.load({

--- a/packages/backend-modules/calendar/graphql/resolvers/_mutations/cancelCalendarSlot.js
+++ b/packages/backend-modules/calendar/graphql/resolvers/_mutations/cancelCalendarSlot.js
@@ -29,10 +29,12 @@ module.exports = async (_, args, context) => {
     calendar.limitRoles?.length &&
     !Roles.userIsInRoles(user, calendar.limitRoles)
   ) {
-    t.pluralize('api/unauthorized', {
-      count: calendar.limitRoles.length,
-      role: calendar.limitRoles.map((r) => `«${r}»`).join(', '),
-    })
+    throw new Error(
+      t.pluralize('api/unauthorized', {
+        count: calendar.limitRoles.length,
+        role: calendar.limitRoles.map((r) => `«${r}»`).join(', '),
+      }),
+    )
   }
 
   const userSlots = await loaders.CalendarSlot.byKeyObj.load({


### PR DESCRIPTION
This Pull Request ensures a role, defined in calendars `limitRoles`, is present on signed in user on mutations `bookCalendarSlot`, `cancelCalendarSlot`.

Up until now it did not throw an error (albeit check was present).

Mutations used in https://github.com/republik/vorlesen.