### PR TITLE
Extend document count script

### DIFF
--- a/packages/backend-modules/documents/script/count.js
+++ b/packages/backend-modules/documents/script/count.js
@@ -44,6 +44,7 @@ const run = async () => {
                   'article',
                   'editorialNewsletter',
                   'discussion',
+                  'flyer',
                 ],
               },
             },

--- a/packages/backend-modules/documents/script/count.js
+++ b/packages/backend-modules/documents/script/count.js
@@ -44,7 +44,7 @@ const run = async () => {
                   'article',
                   'editorialNewsletter',
                   'discussion',
-                  'flyer',
+                  'flyer', // only necessary for financial year 22/23 to count in journal documents
                 ],
               },
             },

--- a/packages/backend-modules/republik/script/segment/defaultSegments.js
+++ b/packages/backend-modules/republik/script/segment/defaultSegments.js
@@ -124,13 +124,13 @@ const handleRow = async (row) => {
     stats[key]++
   }
 
-  if (stats[key] <= 20) {
-    console.log(
-      Object.keys(record)
-        .map((key) => record[key])
-        .join(','),
-    )
-  }
+  // if (stats[key] <= 20) {
+  console.log(
+    Object.keys(record)
+      .map((key) => record[key])
+      .join(','),
+  )
+  // }
 }
 
 const handleBatch = async (rows, count, pgdb) => {


### PR DESCRIPTION
The document count script is used for our annual report and provides information about number of docs of a certain type, number of interactive stories and overall number of characters. 
In 22/23 we introduced the Republik Journal (and stopped it in the same financial year) and this minor change takes Republik Journal aka «flyer» into account as well. 