### PR TITLE
fix subscribing to onboarding on reclaimPledge

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/reclaimPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/reclaimPledge.js
@@ -101,7 +101,7 @@ module.exports = async (
         pgdb,
         userId: req.user.id,
         subscribeToEditorialNewsletters: true,
-        isFirstMembership: true,
+        subscribeToOnboardingMails: true,
       })
     } catch (e) {
       // ignore issues with newsletter subscriptions


### PR DESCRIPTION
Fixes the problem, that someone who reclaims the pledge (changes their email after buying a subscription, but before confirming the email) is not subscribed to onboarding emails with the updated email