### PR TITLE
fix(subscriptions): prevent error when object is undefined

### DIFF
--- a/packages/backend-modules/subscriptions/lib/Subscriptions.js
+++ b/packages/backend-modules/subscriptions/lib/Subscriptions.js
@@ -327,7 +327,7 @@ const subscriptionIsEligibleForNotifications = async (
     getSubject(subscription, context),
     getObject(subscription, context),
   ])
-  if (object.__typename === 'Document') {
+  if (object && object.__typename === 'Document') {
     return (
       hasFullDocumentAccess(user) ||
       includesUnrestrictedChildRepoId([object.objectId])


### PR DESCRIPTION
There was an error when trying to publish a document in Publikator, root cause has still to be checked, this is just a try to quick fix the issue.