### PR TITLE
feat: explore limiting access grants to one period

### DIFF
--- a/packages/backend-modules/access/lib/constraints/index.js
+++ b/packages/backend-modules/access/lib/constraints/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   granterDenylist: require('./granterDenylist'),
   limitGrants: require('./limitGrants'),
+  limitClaims: require('./limitClaims'),
   limitRevokedSlots: require('./limitRevokedSlots'),
   limitSlots: require('./limitSlots'),
   notGrantable: require('./notGrantable'),

--- a/packages/backend-modules/access/lib/constraints/limitClaims.js
+++ b/packages/backend-modules/access/lib/constraints/limitClaims.js
@@ -1,0 +1,49 @@
+const debug = require('debug')('access:lib:constraints:limitClaims')
+
+/**
+ * Constraint limits claims.
+ *
+ * Story: There is a limited amount of times a user can claim an access grant.
+ *
+ * @example: {"limitClaims": {"allowedClaims": 1}}
+ */
+
+const isGrantable = async (args, context) => {
+  const { settings, granter, campaign } = args
+  const { pgdb } = context
+
+  const pastClaims = await pgdb.query(
+    `
+    SELECT "accessGrants".id
+
+    FROM "accessGrants"
+
+    WHERE
+      "accessGrants"."accessCampaignId" = :campaignId
+      AND "accessGrants"."recipientUserId" = :granterId
+  `,
+    { campaignId: campaign.id, granterId: granter.id },
+  )
+
+  const isLimitReached = pastClaims.length >= settings.allowedClaims
+
+  debug('isGrantable', {
+    granter: granter.id,
+    settings,
+    campaign,
+    isLimitReached,
+  })
+
+  return !isLimitReached
+}
+
+const getMeta = async (args, context) => ({
+  visible: true,
+  grantable: await isGrantable(args, context),
+  payload: {},
+})
+
+module.exports = {
+  isGrantable,
+  getMeta,
+}


### PR DESCRIPTION
Explore possibilities to limit access grant claims to one trial period. First try: added a new constraint that restricts the number of claims of an access grant.