### PR TITLE
fix(Prolitteris): fix tracking by adding i param

### DIFF
--- a/apps/www/pages/api/prolitteris.ts
+++ b/apps/www/pages/api/prolitteris.ts
@@ -128,11 +128,11 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
       `/${paid}/vzm.${PROLITTERIS_MEMBER_ID}-${uidParam}`,
   )
   fetchURL.searchParams.append('c', cParam)
+  fetchURL.searchParams.append('i', maskedIP)
 
   const requestHeaders = {
     'User-Agent': PROLITTERIS_USER_AGENT,
     Referer: PUBLIC_BASE_URL + path,
-    'X-Forwarded-For': maskedIP,
   }
 
   log(LogLevel.INFO, requestID, 'Requesting', fetchURL.toString(), {


### PR DESCRIPTION
According to Kantar, this way tracking should work:

> Hallo Herr Baumann
>  
> Die späte Antwort tut mir leid, die Urlaubszeit auf allen Seiten hat leider nicht zur Beschleunigung der Thematik beigetragen.
>  
> Wir haben mit dem Betreiber des Zählsystem (Kantar) Rücksprache gehalten, das Zählsystem wertet die IP im Header nicht aus. Es gibt jedoch eine Alternative, die bereits im Einsatz ist.
> Bitte die IP nicht im Header „X-Forwared-For“ übertragen, sondern über den Parameter „i“ übertragen.
> Zum Beispiel: https://pl02.owen.prolitteris.ch/na/vzm.889053-republik-am-gericht-urteile-die-kein-mensch-mehr-versteht?c=12ce82b9f7ef0d432253&i=100.808.0.0
>  
> Viele Grüße
> Andreas Kohlweiß
> [Kantar Disclaimer](https://www.kantar.com/disclaimer)
> 
> 
> [Kantar Disclaimer](https://www.kantar.com/disclaimer)