### PR TITLE
feat(Charts): add custom stroke width for line charts

### DIFF
--- a/packages/styleguide/src/components/Chart/ChartContext.js
+++ b/packages/styleguide/src/components/Chart/ChartContext.js
@@ -213,7 +213,8 @@ export const defaultProps = {
     columns: 1,
     height: 240,
     yNice: 3,
-    strokeWidth: [6, 3],
+    strokeWidth: 3,
+    strokeWidthHighlighted: 6,
   },
   Slope: {
     x: 'year',
@@ -316,7 +317,8 @@ const propTypes = {
   xNormalizer: PropTypes.func.isRequired, // only used by timebar
   // line only
   columnHeight: PropTypes.number,
-  strokeWidth: PropTypes.array,
+  strokeWidth: PropTypes.number,
+  strokeWidthHighlighted: PropTypes.number,
   yLayout: PropTypes.shape({
     yCut: PropTypes.string,
     yCutHeight: PropTypes.number,

--- a/packages/styleguide/src/components/Chart/ChartContext.js
+++ b/packages/styleguide/src/components/Chart/ChartContext.js
@@ -213,6 +213,7 @@ export const defaultProps = {
     columns: 1,
     height: 240,
     yNice: 3,
+    strokeWidth: [6, 3],
   },
   Slope: {
     x: 'year',
@@ -315,6 +316,7 @@ const propTypes = {
   xNormalizer: PropTypes.func.isRequired, // only used by timebar
   // line only
   columnHeight: PropTypes.number,
+  strokeWidth: PropTypes.array,
   yLayout: PropTypes.shape({
     yCut: PropTypes.string,
     yCutHeight: PropTypes.number,

--- a/packages/styleguide/src/components/Chart/LineGroup.js
+++ b/packages/styleguide/src/components/Chart/LineGroup.js
@@ -82,6 +82,7 @@ const LineGroup = (props) => {
     xAccessor,
     xAxisElement,
     strokeWidth,
+    strokeWidthHighlighted,
   } = props
   const [colorScheme] = useColorContext()
 
@@ -109,6 +110,7 @@ const LineGroup = (props) => {
       // even if the line ends in the middle of the graph
       endX: width,
       strokeWidth: strokeWidth,
+      strokeWidthHighlighted: strokeWidthHighlighted,
     }
   })
 
@@ -153,6 +155,7 @@ const LineGroup = (props) => {
             endLabelY,
             lineColor,
             strokeWidth,
+            strokeWidthHighlighted,
           },
           i,
         ) => {
@@ -198,7 +201,9 @@ const LineGroup = (props) => {
                 <path
                   fill='none'
                   {...colorScheme.set('stroke', lineColor, 'charts')}
-                  strokeWidth={highlighted ? strokeWidth[0] : strokeWidth[1]}
+                  strokeWidth={
+                    highlighted ? strokeWidthHighlighted : strokeWidth
+                  }
                   strokeDasharray={stroked ? '6 2' : 'none'}
                   d={pathGenerator(line)}
                 />

--- a/packages/styleguide/src/components/Chart/LineGroup.js
+++ b/packages/styleguide/src/components/Chart/LineGroup.js
@@ -81,6 +81,7 @@ const LineGroup = (props) => {
     endDy,
     xAccessor,
     xAxisElement,
+    strokeWidth,
   } = props
   const [colorScheme] = useColorContext()
 
@@ -107,6 +108,7 @@ const LineGroup = (props) => {
       // we always render at end label outside of the chart area
       // even if the line ends in the middle of the graph
       endX: width,
+      strokeWidth: strokeWidth,
     }
   })
 
@@ -150,6 +152,7 @@ const LineGroup = (props) => {
             endY,
             endLabelY,
             lineColor,
+            strokeWidth,
           },
           i,
         ) => {
@@ -195,7 +198,7 @@ const LineGroup = (props) => {
                 <path
                   fill='none'
                   {...colorScheme.set('stroke', lineColor, 'charts')}
-                  strokeWidth={highlighted ? 6 : 3}
+                  strokeWidth={highlighted ? strokeWidth[0] : strokeWidth[1]}
                   strokeDasharray={stroked ? '6 2' : 'none'}
                   d={pathGenerator(line)}
                 />

--- a/packages/styleguide/src/components/Chart/Lines.js
+++ b/packages/styleguide/src/components/Chart/Lines.js
@@ -45,6 +45,7 @@ const LineChart = (props) => {
     areaOpacity,
     endDy,
     strokeWidth,
+    strokeWidthHighlighted,
   } = props
 
   const [colorScheme] = useColorContext()
@@ -116,6 +117,7 @@ const LineChart = (props) => {
                 width={chartContext.innerWidth}
                 paddingRight={paddingRight}
                 strokeWidth={strokeWidth}
+                strokeWidthHighlighted={strokeWidthHighlighted}
                 xAxisElement={
                   <XAxis
                     xUnit={props.xUnit}

--- a/packages/styleguide/src/components/Chart/Lines.js
+++ b/packages/styleguide/src/components/Chart/Lines.js
@@ -44,6 +44,7 @@ const LineChart = (props) => {
     area,
     areaOpacity,
     endDy,
+    strokeWidth,
   } = props
 
   const [colorScheme] = useColorContext()
@@ -114,6 +115,7 @@ const LineChart = (props) => {
                 endDy={endDy}
                 width={chartContext.innerWidth}
                 paddingRight={paddingRight}
+                strokeWidth={strokeWidth}
                 xAxisElement={
                   <XAxis
                     xUnit={props.xUnit}


### PR DESCRIPTION
How to use:

you can add a strokeWidth to the json config of a line chart
```
strokeWidth: [6, 3]
``` 
The first value is the width used if a datum is highlighted, the second value is the normal / standard strokeWidth.