### PR TITLE
fix(assets): encode URI of frontend assets

### DIFF
--- a/packages/backend-modules/assets/express/frontend.js
+++ b/packages/backend-modules/assets/express/frontend.js
@@ -26,7 +26,7 @@ module.exports = (server) => {
     )
 
     const frontendUrl = `${FRONTEND_BASE_URL}/${sanitizedPath}`
-    const result = await fetch(frontendUrl, {
+    const result = await fetch(encodeURI(frontendUrl), {
       method: 'GET',
       headers: {
         Authorization:
@@ -41,6 +41,7 @@ module.exports = (server) => {
       return res.status(404).end()
     })
     if (!result.ok) {
+      console.log(result)
       console.error('frontend fetch failed', result.url, result.status)
       return res.status(result.status).end()
     }


### PR DESCRIPTION
When assets are loaded via CDN, the asset server tries to fetch the asset from the frontend first.

On parameterized routes, Next.js fetches URIs like `https://www.republik.ch/_next/static/chunks/pages/~/%5Bslug%5D-xyz.js`

The asset server decodes the special characters and tries to call `fetch("https://www.republik.ch/_next/static/chunks/pages/~/[slug]-xyz.js")` which seemed to work fine when fetching from Next.js 12 but Next.js 13 will return a 404.

When the asset URI is encoded, it works.