### PR TITLE
Handle mailchimp audiences correctly when users are deleted or change emails

### DIFF
--- a/packages/backend-modules/mail/MailchimpInterface.js
+++ b/packages/backend-modules/mail/MailchimpInterface.js
@@ -203,4 +203,6 @@ MailchimpInterface.MemberStatus = {
   Unsubscribed: 'unsubscribed',
 }
 
+MailchimpInterface.audiences = audiences
+
 module.exports = MailchimpInterface

--- a/packages/backend-modules/mail/MailchimpInterface.js
+++ b/packages/backend-modules/mail/MailchimpInterface.js
@@ -7,7 +7,21 @@ const base64u = require('@orbiting/backend-modules-base64u')
 
 const { NewsletterMemberMailError } = require('./errors')
 
-const { MAILCHIMP_API_KEY, MAILCHIMP_URL, MAILCHIMP_MAIN_LIST_ID } = process.env
+const BluePromise = require('bluebird')
+
+const {
+  MAILCHIMP_API_KEY,
+  MAILCHIMP_URL,
+  MAILCHIMP_MAIN_LIST_ID,
+  MAILCHIMP_ONBOARDING_AUDIENCE_ID,
+  MAILCHIMP_MARKETING_AUDIENCE_ID,
+} = process.env
+
+const audiences = [
+  MAILCHIMP_MAIN_LIST_ID,
+  MAILCHIMP_ONBOARDING_AUDIENCE_ID,
+  MAILCHIMP_MARKETING_AUDIENCE_ID,
+]
 
 const MINIMUM_HTTP_RESPONSE_STATUS_ERROR = 400
 
@@ -133,20 +147,26 @@ const MailchimpInterface = ({ logger }) => {
         throw new NewsletterMemberMailError({ error, email })
       }
     },
-    async deleteMember(email, audienceId = MAILCHIMP_MAIN_LIST_ID) {
-      debug(`deleting ${email}`)
-      const url = this.buildMembersApiUrl(email) + '/actions/delete-permanent'
-      try {
-        const response = await this.fetchAuthenticated('POST', url)
-        if (response.status >= MINIMUM_HTTP_RESPONSE_STATUS_ERROR) {
-          debug(`could not delete member: ${email}`)
-          return null
+    async deleteMember(email) {
+      debug(`deleting ${email} from audiences ${audiences}`)
+      return BluePromise.map(audiences, async (audienceId) => {
+        try {
+          const url =
+            this.buildMembersApiUrl(email, audienceId) +
+            '/actions/delete-permanent'
+          const response = await this.fetchAuthenticated('POST', url)
+          if (response.status >= MINIMUM_HTTP_RESPONSE_STATUS_ERROR) {
+            debug(
+              `could not delete member from audience ${audienceId}: ${email}`,
+            )
+            return false
+          }
+          return true
+        } catch (error) {
+          logger.error(`mailchimp -> exception: ${error.message}`)
+          throw new NewsletterMemberMailError({ error, email })
         }
-        return true
-      } catch (error) {
-        logger.error(`mailchimp -> exception: ${error.message}`)
-        throw new NewsletterMemberMailError({ error, email })
-      }
+      })
     },
     async postBatch(operations) {
       const preparedOperations = operations.map((operation) => {

--- a/packages/backend-modules/mail/lib/deleteEmail.js
+++ b/packages/backend-modules/mail/lib/deleteEmail.js
@@ -8,5 +8,8 @@ module.exports = async ({ email }) => {
   }
 
   const mailchimp = MailchimpInterface({ logger })
-  return mailchimp.deleteMember(email)
+  const deleted = MailchimpInterface.audiences.map((audienceId) => {
+    return mailchimp.deleteMember(email, audienceId)
+  })
+  return deleted
 }

--- a/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/deleteUser.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/deleteUser.js
@@ -205,8 +205,10 @@ module.exports = async (_, args, context) => {
     const mailchimpResult = await deleteFromMailchimp({
       email: user.email,
     })
-    if (!mailchimpResult) {
-      console.warn(`deleteUser: could not delete ${user.email} from mailchimp.`)
+    if (!mailchimpResult.every((result) => result === true)) {
+      console.warn(
+        `deleteUser: could not delete ${user.email} from all mailchimp audiences. This might be because they were not added to all currently used audiences.`,
+      )
     }
 
     await deleteRelatedData(


### PR DESCRIPTION
- Delete user emails from all audiences on mailchimp when a user is deleted (deleteUser mutation)
- Update user email and interests/subscriptions on all audiences when a user email is changed