### PR TITLE
fix(www): convert choice-question layout to css-grid

### DIFF
--- a/apps/www/components/Questionnaire/ChoiceQuestion.js
+++ b/apps/www/components/Questionnaire/ChoiceQuestion.js
@@ -28,19 +28,19 @@ const styles = {
     marginBottom: 15,
   }),
   optionList: css({
-    columnCount: 1,
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gridAutoRows: 'auto',
     [mediaQueries.mUp]: {
-      columnCount: 2,
+      gridTemplateColumns: '1fr 1fr',
     },
     [mediaQueries.lUp]: {
-      columnCount: 3,
+      gridTemplateColumns: '1fr 1fr 1fr',
     },
   }),
   option: css({
     marginTop: 0,
     marginBottom: 5,
-    display: 'table',
-    breakInside: 'avoid-column',
   }),
 }
 


### PR DESCRIPTION
## Description

We had an odd bug in a questionnaire instance

![CleanShot 2023-10-17 at 16 01 04](https://github.com/republik/plattform/assets/30313631/f4d02b65-b173-495c-b7ce-7e61f228732d)


As seen in the video above, clicking the top checkbox in the third column
caused the wrong checkbox to be toggled.

After playing around with it, I noticed an issue with the area around the checkbox that allowed it to be toggled. Clicking the label yielded the expected outcome. (Video below)

![CleanShot 2023-10-18 at 10 57 28](https://github.com/republik/plattform/assets/30313631/6ed0afc2-95e1-408d-88f8-7364c33d50b2)

### Solution

The previous implementation seems to have been using some sort of a css-table(?).
I updated the layout to use CSS-Grid and it now seems to be working as expected.
(It should be note though that the order of the checkboxes has changed with the new implementation)

![CleanShot 2023-10-18 at 11 02 29](https://github.com/republik/plattform/assets/30313631/29cb2d59-c301-43eb-972b-7327fc0de84b)


