### PR TITLE
fix(www): ensure clicking logged-out user button also acts as a toggle.

### DIFF
--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -82,8 +82,10 @@ const Header = ({
   }
 
   useEffect(() => {
-    router.prefetch('/meine-republik')
-  }, [])
+    router.prefetch(me ? '/meine-republik' : '/anmelden')
+  }, [me?.id])
+
+  const userButtonLink = me ? '/meine-republik' : '/anmelden'
 
   useEffect(() => {
     const onScroll = () => {
@@ -188,10 +190,10 @@ const Header = ({
                 )}
                 inNativeIOSApp={inNativeIOSApp}
                 onClick={() => {
-                  if (router.asPath === '/meine-republik') {
+                  if (router.asPath === userButtonLink) {
                     closeHandler()
                   } else {
-                    router.push('/meine-republik')
+                    router.push(userButtonLink)
                   }
                 }}
               />


### PR DESCRIPTION
## Description

We reworked the user-nav to have its own page '/meine-republik'. If a user is logged out, he is redirected to '/anmelden'.
The user button in the page header acts as a toggle. If you are on '/meine-republik' when clicking on your profile-image, you're either navigated back to the last page or to the front.
The image acts as a toggle for the navigation to '/meine-republik'.

Unfortunately, we forgot to handle this for the logged-out state:

### Current behavior

When clicking 'anmelden' (which is rendered instead of the portrait when not logged in),
the user is navigated to '/meine-republik' which then redirects to '/anmelden'.
If the user clicks the 'anmelden' button again while on '/anmelden', the user is navigated to '/meine-republik' again, which leads to an ugly redirection "flash".

![current-behavior](https://github.com/republik/plattform/assets/30313631/4b8bb0fe-ac7c-4836-9441-37d4518fe97d)


### New fixed behavior

Clicking 'anmelden' now has the exact same behavior as clicking the portrait when logged in.
If the user is on '/anmelden' while clicking it, he is either navigated back or navigated to the front. If he is on any other page clicking 'anmelden' will navigate the user to '/anmelden'.

![new-behavior](https://github.com/republik/plattform/assets/30313631/7b778aa0-8696-4e22-aaed-1946aaeba0e1)

(we still have the issue that a non-logged in user currently can't change the theme, but we will have to solve that in a separate PR)

