### PR TITLE
fix(questionnaire): correctly calculate percentages in answers chart

### DIFF
--- a/apps/www/components/Questionnaire/Submissions/QuestionFeatured.js
+++ b/apps/www/components/Questionnaire/Submissions/QuestionFeatured.js
@@ -113,7 +113,7 @@ export const LinkToEditQuestionnaire = ({
 
 export const AnswersChart = ({ question, skipTitle }) => {
   if (!question.result) return
-  const totalAnswers = question.result.reduce((agg, r) => agg + r.count, 0)
+  const totalAnswers = question.turnout.submitted
   const values = question.options.map((option) => ({
     answer: option.label,
     value:

--- a/apps/www/components/Questionnaire/Submissions/graphql.js
+++ b/apps/www/components/Questionnaire/Submissions/graphql.js
@@ -51,6 +51,9 @@ const questionnaireData = gql`
       __typename
       id
       text
+      turnout {
+        submitted
+      }
       ... on QuestionTypeChoice {
         options {
           label


### PR DESCRIPTION
Instead dividing by the sum of all given answers, it should be divided by submissions.

This way, for multiple choice questions, they can add up to more than 100% (as they should)