### PR TITLE
Front teaser link fixes

### DIFF
--- a/packages/styleguide/src/components/TeaserCarousel/Tile.js
+++ b/packages/styleguide/src/components/TeaserCarousel/Tile.js
@@ -31,6 +31,7 @@ const styles = {
     width: '33%',
     minWidth: 290,
     maxWidth: TILE_MAX_WIDTH,
+    position: 'relative',
     display: 'flex',
     justifyContent: 'center',
     ':last-of-type': { margin: 0 },

--- a/packages/styleguide/src/components/TeaserFront/Split.js
+++ b/packages/styleguide/src/components/TeaserFront/Split.js
@@ -154,7 +154,7 @@ const Split = ({
         )}
       >
         <Text
-          position={'splitcenterright'}
+          position={reverse ? 'splitreverse' : 'split'}
           color={color}
           center={center}
           feuilleton={feuilleton}

--- a/packages/styleguide/src/components/TeaserFront/Split.js
+++ b/packages/styleguide/src/components/TeaserFront/Split.js
@@ -9,6 +9,7 @@ const styles = {
   container: css({
     margin: 0,
     overflow: 'hidden',
+    position: 'relative',
     [mUp]: {
       display: 'flex',
       alignItems: 'center',
@@ -153,6 +154,7 @@ const Split = ({
         )}
       >
         <Text
+          position={'splitcenterright'}
           color={color}
           center={center}
           feuilleton={feuilleton}

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -82,6 +82,17 @@ const styles = {
       justifyContent: 'flex-end',
     },
   }),
+  splitcenterright: css({
+    position: 'static',
+    [tUp]: {
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px 5% ${TEXT_PADDING}px calc(50% + 5%)`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+    },
+  }),
   top: css({
     position: 'static',
     [tUp]: {
@@ -160,7 +171,7 @@ const Text = ({
   return (
     <div {...rootStyles} {...middleStyles}>
       <div
-        data-position={position}
+        data-position={position ?? 'none'}
         {...attributes}
         {...colorRule}
         {...textAlignStyle}

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -39,37 +39,58 @@ const styles = {
     position: 'relative',
   }),
   topleft: css({
+    position: 'static',
     [tUp]: {
-      ...positionHalfWidth,
-      left: `${TEXT_PADDING}px`,
-      top: `${TEXT_PADDING}px`,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px 50% ${TEXT_PADDING}px ${TEXT_PADDING}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
     },
   }),
   topright: css({
+    position: 'static',
     [tUp]: {
-      ...positionHalfWidth,
-      left: '50%',
-      top: `${TEXT_PADDING}px`,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px ${TEXT_PADDING}px ${TEXT_PADDING}px 50%`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
     },
   }),
   bottomleft: css({
+    position: 'static',
     [tUp]: {
-      ...positionHalfWidth,
-      bottom: `${TEXT_PADDING}px`,
-      left: `${TEXT_PADDING}px`,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px 50% ${TEXT_PADDING}px ${TEXT_PADDING}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
     },
   }),
   bottomright: css({
+    position: 'static',
     [tUp]: {
-      ...positionHalfWidth,
-      bottom: `${TEXT_PADDING}px`,
-      left: '50%',
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px ${TEXT_PADDING}px ${TEXT_PADDING}px 50%`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
     },
   }),
   top: css({
+    position: 'static',
     [tUp]: {
-      ...positionFullWidth,
-      top: `${TEXT_PADDING}px`,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
     },
   }),
   middle: css({
@@ -78,9 +99,14 @@ const styles = {
     },
   }),
   bottom: css({
+    position: 'static',
     [tUp]: {
-      ...positionFullWidth,
-      bottom: `${TEXT_PADDING}px`,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
     },
   }),
   center: css({
@@ -134,16 +160,20 @@ const Text = ({
   return (
     <div {...rootStyles} {...middleStyles}>
       <div
+        data-position={position}
         {...attributes}
         {...colorRule}
         {...textAlignStyle}
         {...css(styles.positioned, position ? styles[position] : {})}
         style={{ maxWidth, margin }}
       >
-        {children}
-        {audioPlayButton && (
-          <div style={{ marginTop: 20 }}>{audioPlayButton}</div>
-        )}
+        {' '}
+        <div>
+          {children}
+          {audioPlayButton && (
+            <div style={{ marginTop: 20 }}>{audioPlayButton}</div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -36,7 +36,7 @@ const styles = {
     },
   }),
   positioned: css({
-    position: 'relative',
+    position: 'static',
   }),
   topleft: css({
     position: 'static',

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -116,8 +116,14 @@ const styles = {
     },
   }),
   middle: css({
+    position: 'static',
     [tUp]: {
-      ...positionFullWidth,
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
     },
   }),
   bottom: css({

--- a/packages/styleguide/src/components/TeaserFront/Text.js
+++ b/packages/styleguide/src/components/TeaserFront/Text.js
@@ -82,12 +82,23 @@ const styles = {
       justifyContent: 'flex-end',
     },
   }),
-  splitcenterright: css({
+  split: css({
     position: 'static',
     [tUp]: {
       position: 'absolute',
       inset: 0,
       padding: `${TEXT_PADDING}px 5% ${TEXT_PADDING}px calc(50% + 5%)`,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+    },
+  }),
+  splitreverse: css({
+    position: 'static',
+    [tUp]: {
+      position: 'absolute',
+      inset: 0,
+      padding: `${TEXT_PADDING}px calc(50% + 5%) ${TEXT_PADDING}px 5%`,
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',

--- a/packages/styleguide/src/components/TeaserFront/TileRow.js
+++ b/packages/styleguide/src/components/TeaserFront/TileRow.js
@@ -21,6 +21,7 @@ const styles = {
       textAlign: 'center',
       padding: '30px 15px 40px 15px',
       width: '100%',
+      position: 'relative',
       [mUp]: {
         display: 'flex',
         flexDirection: 'column',

--- a/packages/styleguide/src/components/TeaserFront/Typo.js
+++ b/packages/styleguide/src/components/TeaserFront/Typo.js
@@ -9,6 +9,7 @@ export const MAX_WIDTH_PERCENT = 70
 const styles = {
   root: css({
     margin: 0,
+    position: 'relative',
   }),
   textContainer: css({
     margin: '0 auto',

--- a/packages/styleguide/src/templates/Article/utils.js
+++ b/packages/styleguide/src/templates/Article/utils.js
@@ -133,7 +133,9 @@ export const styles = {
       position: 'absolute',
       inset: 0,
       content: '""',
-      background: 'rgba(255,0,127,0.3)', // TODO: Remove
+      background:
+        'repeating-linear-gradient(45deg, transparent, transparent 32px, rgba(0,255,255,.5) 32px, rgba(0,255,255,.5) 64px);', // TODO: Remove
+      mixBlendMode: 'difference',
       zIndex: 0,
     },
   }),

--- a/packages/styleguide/src/templates/Article/utils.js
+++ b/packages/styleguide/src/templates/Article/utils.js
@@ -127,6 +127,16 @@ export const styles = {
     color: 'inherit',
     textDecoration: 'none',
   }),
+  areaLink: css({
+    position: 'static',
+    '&::before': {
+      position: 'absolute',
+      inset: 0,
+      content: '""',
+      background: 'rgba(255,0,127,0.3)', // TODO: Remove
+      zIndex: 0,
+    },
+  }),
   anchor: css({
     display: 'block',
     visibility: 'hidden',

--- a/packages/styleguide/src/templates/Front/index.js
+++ b/packages/styleguide/src/templates/Front/index.js
@@ -116,7 +116,13 @@ const createFrontSchema = ({
         },
         component: ({ children, data, ...props }) => (
           <Link href={props.href} passHref>
-            <TeaserFrontCreditLink {...props}>{children}</TeaserFrontCreditLink>
+            <TeaserFrontCreditLink
+              data-link='credit'
+              {...props}
+              style={{ zIndex: 1, position: 'relative' }}
+            >
+              {children}
+            </TeaserFrontCreditLink>
           </Link>
         ),
         editorModule: 'link',
@@ -131,7 +137,12 @@ const createFrontSchema = ({
     matchMdast: matchHeading(1),
     component: ({ children, href, ...props }) => (
       <Link href={href} passHref>
-        <a {...styles.link} href={href}>
+        <a
+          data-link='headline'
+          {...styles.link}
+          {...styles.areaLink}
+          href={href}
+        >
           <Headline {...props}>{children}</Headline>
         </a>
       </Link>
@@ -243,19 +254,17 @@ const createFrontSchema = ({
       ...node.data,
     }),
     component: ({ children, attributes, ...props }) => (
-      <Link href={props.url}>
-        <TeaserFrontImage
-          audioPlayButton={
-            !!AudioPlayButton && shouldRenderPlayButton(props) ? (
-              <AudioPlayButton documentId={props?.urlMeta.documentId} />
-            ) : undefined
-          }
-          attributes={attributes}
-          {...props}
-        >
-          {children}
-        </TeaserFrontImage>
-      </Link>
+      <TeaserFrontImage
+        audioPlayButton={
+          !!AudioPlayButton && shouldRenderPlayButton(props) ? (
+            <AudioPlayButton documentId={props?.urlMeta.documentId} />
+          ) : undefined
+        }
+        attributes={attributes}
+        {...props}
+      >
+        {children}
+      </TeaserFrontImage>
     ),
     editorModule: 'teaser',
     editorOptions: {
@@ -306,19 +315,17 @@ const createFrontSchema = ({
   const frontSplitTeaser = {
     matchMdast: matchTeaserType('frontSplit'),
     component: ({ children, attributes, ...props }) => (
-      <Link href={props.url}>
-        <TeaserFrontSplit
-          audioPlayButton={
-            !!AudioPlayButton && shouldRenderPlayButton(props) ? (
-              <AudioPlayButton documentId={props?.urlMeta.documentId} />
-            ) : undefined
-          }
-          attributes={attributes}
-          {...props}
-        >
-          {children}
-        </TeaserFrontSplit>
-      </Link>
+      <TeaserFrontSplit
+        audioPlayButton={
+          !!AudioPlayButton && shouldRenderPlayButton(props) ? (
+            <AudioPlayButton documentId={props?.urlMeta.documentId} />
+          ) : undefined
+        }
+        attributes={attributes}
+        {...props}
+      >
+        {children}
+      </TeaserFrontSplit>
     ),
     props: (node, i) => ({
       image: extractImage(node.children[0]),
@@ -373,19 +380,17 @@ const createFrontSchema = ({
   const frontTypoTeaser = {
     matchMdast: matchTeaserType('frontTypo'),
     component: ({ children, attributes, ...props }) => (
-      <Link href={props.url}>
-        <TeaserFrontTypo
-          audioPlayButton={
-            !!AudioPlayButton && shouldRenderPlayButton(props) ? (
-              <AudioPlayButton documentId={props?.urlMeta.documentId} />
-            ) : undefined
-          }
-          attributes={attributes}
-          {...props}
-        >
-          {children}
-        </TeaserFrontTypo>
-      </Link>
+      <TeaserFrontTypo
+        audioPlayButton={
+          !!AudioPlayButton && shouldRenderPlayButton(props) ? (
+            <AudioPlayButton documentId={props?.urlMeta.documentId} />
+          ) : undefined
+        }
+        attributes={attributes}
+        {...props}
+      >
+        {children}
+      </TeaserFrontTypo>
     ),
     props(node) {
       return node.data
@@ -433,19 +438,17 @@ const createFrontSchema = ({
   const frontTileTeaser = {
     matchMdast: matchTeaserType('frontTile'),
     component: ({ children, attributes, ...props }) => (
-      <Link href={props.url}>
-        <TeaserFrontTile
-          audioPlayButton={
-            !!AudioPlayButton && shouldRenderPlayButton(props) ? (
-              <AudioPlayButton documentId={props?.urlMeta.documentId} />
-            ) : undefined
-          }
-          attributes={{ ...attributes, 'data-theme': 'light' }}
-          {...props}
-        >
-          {children}
-        </TeaserFrontTile>
-      </Link>
+      <TeaserFrontTile
+        audioPlayButton={
+          !!AudioPlayButton && shouldRenderPlayButton(props) ? (
+            <AudioPlayButton documentId={props?.urlMeta.documentId} />
+          ) : undefined
+        }
+        attributes={{ ...attributes, 'data-theme': 'light' }}
+        {...props}
+      >
+        {children}
+      </TeaserFrontTile>
     ),
     props: (node, index, parent, { ancestors }) => {
       const aboveTheFold = ancestors[1].children.indexOf(ancestors[0]) < 2
@@ -574,19 +577,17 @@ const createFrontSchema = ({
     matchMdast: matchTeaserType('articleTile'),
     component: ({ children, attributes, ...props }) => {
       return (
-        <Link href={props.url}>
-          <TeaserCarouselTile
-            audioPlayButton={
-              !!AudioPlayButton && shouldRenderPlayButton(props) ? (
-                <AudioPlayButton documentId={props?.urlMeta.documentId} />
-              ) : undefined
-            }
-            attributes={attributes}
-            {...props}
-          >
-            {children}
-          </TeaserCarouselTile>
-        </Link>
+        <TeaserCarouselTile
+          audioPlayButton={
+            !!AudioPlayButton && shouldRenderPlayButton(props) ? (
+              <AudioPlayButton documentId={props?.urlMeta.documentId} />
+            ) : undefined
+          }
+          attributes={attributes}
+          {...props}
+        >
+          {children}
+        </TeaserCarouselTile>
       )
     },
     props: (node) => ({


### PR DESCRIPTION
An attempt to solve #609

Uses the CSS-only technique described in https://www.sarasoueidan.com/blog/nested-links/

For this to work, only the teaser itself can have `position: relative`, so the pseudo element of the heading link can extend to its edges. I managed to adapt the positioning of most of the teasers but haven't figured out yet how to solve the Split teaser where the horizontal text position is based on the automatic image width instead of a defined position within the teaser (e.g. at 50% of its width).

The original solution was to wrap the teaser in a javascript-only "link" which handled the click event. I more or less accidentally removed it in e84fd1194f525c039ac62d1ce5e787cbbad2541c.

I still think a CSS-only solution should be preferred but at this point it may be more pragmatic to bring back the JS-based solution and revisit this issue in the future (when we have a good way to test that all teasers are visually consistent with the way they are implemented now).