### PR TITLE
Handle Certain GraphQL Errors More Gracefully

### DIFF
--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -327,9 +327,11 @@ const ArticlePage = ({
     errorPolicy: 'all',
   })
 
-  if (articleError) {
-    reportError('Article Page getDocument Query', articleError)
-  }
+  useEffect(() => {
+    if (articleError) {
+      reportError('Article Page getDocument Query', articleError)
+    }
+  }, [reportError, articleError])
 
   const article = articleData?.article
   const documentId = article?.id

--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -84,6 +84,7 @@ import TeaserAudioPlayButton from '../Audio/shared/TeaserAudioPlayButton'
 import useAudioQueue from '../Audio/hooks/useAudioQueue'
 import { IconEdit } from '@republik/icons'
 import { ArticleAudioPlayer } from '../Audio/AudioPlayer/ArticleAudioPlayer'
+import { reportError } from 'lib/errors/reportError'
 
 const LoadingComponent = () => <SmallLoader loading />
 
@@ -322,7 +323,13 @@ const ArticlePage = ({
       path: cleanedPath,
     },
     skip: clientRedirection,
+    // When graphQLErrors happen, we still want to get partial data to render the page
+    errorPolicy: 'all',
   })
+
+  if (articleError) {
+    reportError('Article Page getDocument Query', articleError)
+  }
 
   const article = articleData?.article
   const documentId = article?.id
@@ -562,7 +569,6 @@ const ArticlePage = ({
     return (
       <PageLoader
         loading={articleLoading && !articleData}
-        error={articleError}
         render={() => {
           if (!article) {
             return (
@@ -648,7 +654,6 @@ const ArticlePage = ({
     >
       <PageLoader
         loading={articleLoading && !articleData}
-        error={articleError}
         render={() => {
           if (!article || !schema) {
             return (

--- a/apps/www/components/Audio/AudioPlayer/ui/tabs/latest/LatestArticles.tsx
+++ b/apps/www/components/Audio/AudioPlayer/ui/tabs/latest/LatestArticles.tsx
@@ -45,6 +45,7 @@ const LatestArticlesTab = ({
     variables: {
       count: 20,
     },
+    errorPolicy: 'all',
   })
   const [isLoadingMore, setLoadingMore] = useState(false)
   const loadMore = () => {

--- a/apps/www/components/Audio/graphql/AudioQueueHooks.ts
+++ b/apps/www/components/Audio/graphql/AudioQueueHooks.ts
@@ -8,7 +8,7 @@ import { AudioPlayerItem } from '../types/AudioPlayerItem'
 export type AudioQueueItem = {
   id: string
   sequence: number
-  document: AudioPlayerItem
+  document?: AudioPlayerItem
 }
 
 const AudioQueueItemFragment = gql`

--- a/apps/www/components/Audio/hooks/useAudioQueue.tsx
+++ b/apps/www/components/Audio/hooks/useAudioQueue.tsx
@@ -21,6 +21,7 @@ import createPersistedState from '../../../lib/hooks/use-persisted-state'
 import { AudioPlayerItem } from '../types/AudioPlayerItem'
 import { ApolloError, FetchResult } from '@apollo/client'
 import OptimisticQueueResponseHelper from '../helpers/OptimisticQueueResponseHelper'
+import { reportError } from 'lib/errors/reportError'
 
 const usePersistedAudioState = createPersistedState<AudioQueueItem>(
   'audio-player-local-state',
@@ -68,11 +69,16 @@ const useAudioQueue = (): {
     refetch: refetchAudioQueue,
   } = useAudioQueueQuery({
     skip: meLoading || !hasAccess,
+    errorPolicy: 'all',
   })
   const isLoading = meLoading || audioQueueIsLoading
 
   const [localAudioItem, setLocalAudioItem] =
     usePersistedAudioState<AudioQueueItem>(null)
+
+  if (audioQueueHasError) {
+    reportError('useAudioQueue', audioQueueHasError)
+  }
 
   /**
    *

--- a/apps/www/components/Audio/hooks/useAudioQueue.tsx
+++ b/apps/www/components/Audio/hooks/useAudioQueue.tsx
@@ -22,6 +22,7 @@ import { AudioPlayerItem } from '../types/AudioPlayerItem'
 import { ApolloError, FetchResult } from '@apollo/client'
 import OptimisticQueueResponseHelper from '../helpers/OptimisticQueueResponseHelper'
 import { reportError } from 'lib/errors/reportError'
+import { useEffect } from 'react'
 
 const usePersistedAudioState = createPersistedState<AudioQueueItem>(
   'audio-player-local-state',
@@ -76,9 +77,11 @@ const useAudioQueue = (): {
   const [localAudioItem, setLocalAudioItem] =
     usePersistedAudioState<AudioQueueItem>(null)
 
-  if (audioQueueHasError) {
-    reportError('useAudioQueue', audioQueueHasError)
-  }
+  useEffect(() => {
+    if (audioQueueHasError) {
+      reportError('useAudioQueue', audioQueueHasError)
+    }
+  }, [reportError, audioQueueHasError])
 
   /**
    *

--- a/apps/www/components/Audio/hooks/useAudioQueue.tsx
+++ b/apps/www/components/Audio/hooks/useAudioQueue.tsx
@@ -261,16 +261,16 @@ const useAudioQueue = (): {
       return localAudioItem
     }
     return meWithAudioQueue?.me?.audioQueue?.find(
-      (audioQueueItem) => audioQueueItem.document.id === documentId,
+      (audioQueueItem) => audioQueueItem.document?.id === documentId,
     )
   }
 
   function getAudioQueueItemIndex(documentId: string): number {
-    if (!hasAccess && localAudioItem?.document.id === documentId) {
+    if (!hasAccess && localAudioItem?.document?.id === documentId) {
       return 0
     }
     return meWithAudioQueue?.me?.audioQueue?.findIndex(
-      (item) => item.document.id === documentId,
+      (item) => item.document?.id === documentId,
     )
   }
 

--- a/apps/www/components/Audio/hooks/useAudioQueue.tsx
+++ b/apps/www/components/Audio/hooks/useAudioQueue.tsx
@@ -260,7 +260,7 @@ const useAudioQueue = (): {
     if (!hasAccess && localAudioItem?.document?.id === documentId) {
       return localAudioItem
     }
-    return meWithAudioQueue?.me?.audioQueue.find(
+    return meWithAudioQueue?.me?.audioQueue?.find(
       (audioQueueItem) => audioQueueItem.document.id === documentId,
     )
   }
@@ -269,7 +269,7 @@ const useAudioQueue = (): {
     if (!hasAccess && localAudioItem?.document.id === documentId) {
       return 0
     }
-    return meWithAudioQueue?.me?.audioQueue.findIndex(
+    return meWithAudioQueue?.me?.audioQueue?.findIndex(
       (item) => item.document.id === documentId,
     )
   }

--- a/apps/www/components/Feed/DocumentListContainer.js
+++ b/apps/www/components/Feed/DocumentListContainer.js
@@ -63,6 +63,8 @@ export const makeLoadMore =
         ...variables,
         cursor: connection.pageInfo.endCursor,
       },
+      // When graphQLErrors happen, we still want to get partial data to render the feed
+      errorPolicy: 'all',
     })
 
 const DocumentListContainer = ({

--- a/apps/www/components/Feed/index.js
+++ b/apps/www/components/Feed/index.js
@@ -70,9 +70,11 @@ const Feed = ({ meta }) => {
     errorPolicy: 'all',
   })
 
-  if (error) {
-    reportError('Feed getFeed Query', error)
-  }
+  useEffect(() => {
+    if (error) {
+      reportError('Feed getFeed Query', error)
+    }
+  }, [reportError, error])
 
   const connection = data?.documents
   const greeting = data?.greeting

--- a/apps/www/components/Feed/index.js
+++ b/apps/www/components/Feed/index.js
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import compose from 'lodash/flowRight'
-import { graphql } from '@apollo/client/react/hoc'
 import { css } from 'glamor'
-import { gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import Frame from '../Frame'
 import withT from '../../lib/withT'
+import { reportError } from '../../lib/errors/reportError'
 import withInNativeApp from '../../lib/withInNativeApp'
 import Loader from '../Loader'
 
@@ -64,17 +64,19 @@ const greetingSubscription = gql`
   }
 `
 
-const Feed = ({
-  meta,
-  data: {
-    error,
-    loading,
-    greeting,
-    documents: connection,
-    fetchMore,
-    subscribeToMore,
-  },
-}) => {
+const Feed = ({ meta }) => {
+  const { error, loading, data, fetchMore, subscribeToMore } = useQuery(query, {
+    // When graphQLErrors happen, we still want to get partial data to render the feed
+    errorPolicy: 'all',
+  })
+
+  if (error) {
+    reportError('Feed getFeed Query', error)
+  }
+
+  const connection = data?.documents
+  const greeting = data?.greeting
+
   const mapNodes = (node) => node.entity
 
   useEffect(() => {
@@ -109,7 +111,6 @@ const Feed = ({
     <Frame hasOverviewNav stickySecondaryNav raw meta={meta}>
       <Center {...styles.container}>
         <Loader
-          error={error}
           loading={loading}
           render={() => {
             return (
@@ -139,4 +140,4 @@ const Feed = ({
   )
 }
 
-export default compose(graphql(query), withT, withInNativeApp)(Feed)
+export default compose(withT, withInNativeApp)(Feed)

--- a/apps/www/lib/errors/reportError.ts
+++ b/apps/www/lib/errors/reportError.ts
@@ -14,7 +14,7 @@ export const reportError = async (context: string, error: Error | string) => {
   lastError = error
   const buildId = process.env.BUILD_ID
 
-  console.error(error)
+  console.error(context, error)
 
   await fetch('/api/reportError', {
     method: 'POST',

--- a/apps/www/lib/errors/reportError.ts
+++ b/apps/www/lib/errors/reportError.ts
@@ -1,17 +1,20 @@
-let lastError
+let lastError: Error | string | undefined
 
-export const reportError = async (context, error) => {
+export const reportError = async (context: string, error: Error | string) => {
   // do not track server side
   if (typeof window === 'undefined') {
     return
   }
+
   // avoid double reporting from window.onerror
-  if (lastError && lastError.trim() === error.trim()) {
+  if (lastError?.toString().trim() === error.toString().trim()) {
     return
   }
 
   lastError = error
   const buildId = process.env.BUILD_ID
+
+  console.error(error)
 
   await fetch('/api/reportError', {
     method: 'POST',

--- a/apps/www/pages/[...path].tsx
+++ b/apps/www/pages/[...path].tsx
@@ -36,6 +36,8 @@ export const getStaticProps = createGetStaticProps<Props, Params>(
       variables: {
         path,
       },
+      // Ignore graphQLErrors and let the client handle/report them.
+      errorPolicy: 'ignore',
     })
 
     if (article && !article.meta.format?.meta.externalBaseUrl) {

--- a/packages/backend-modules/collections/graphql/schema-types.js
+++ b/packages/backend-modules/collections/graphql/schema-types.js
@@ -112,7 +112,7 @@ type AudioQueueItem implements CollectionItemInterface {
   createdAt: DateTime!
   updatedAt: DateTime!
   collection: Collection!
-  document: Document!
+  document: Document
 }
 
 enum AudioQueueEntityType {


### PR DESCRIPTION
By default queries completely fail when a GraphQL error is encountered, this is a not-so-great experience in some cases because the whole section/page will fail to render, even when there is partial data available in the query response. By changing `errorPolicy` to `"all"` in those queries we'll have acces to data _and_ errors.

This should work fine in practice because in GraphQL, errors in subtrees remove the closest nullable field and leave the rest of the tree intact. E.g. when there's an error in the `Document.audioSource.durationMs` field, `Document.audioSource` will be null but the rest of the document is still available to render.

Additionally, this fixes a long-standing bug in the audio queue where unpublished documents would generate a GraphQL error if they're referenced in the queue. By making them optional in the schema, this is fixed and also more consistent with the other collection items where documents are referenced.

- [x] Article Page
- [x] Feed
- [x] Audio Player Queue