### PR TITLE
fix(publikator): improved link validation

### DIFF
--- a/apps/publikator/components/Publication/useValidation.tsx
+++ b/apps/publikator/components/Publication/useValidation.tsx
@@ -41,7 +41,7 @@ const useValidation = ({ meta, content, t, updateMailchimp }) => {
             }
           }
           // WebP?
-          if (urlObject.pathname?.endsWith('.webp')) {
+          if (urlObject.pathname.endsWith('.webp')) {
             warnings.push('webp')
           }
           // Uhhhh really?

--- a/apps/publikator/components/Publication/useValidation.tsx
+++ b/apps/publikator/components/Publication/useValidation.tsx
@@ -8,7 +8,7 @@ import { SOCIAL_MEDIA } from '../editor/modules/meta/ShareImageForm'
 import { Editorial, renderSlateAsText } from '@project-r/styleguide'
 
 // Used to check for relative urls
-const FAKE_BASE_URL = `http://${uuid()}.com`
+const FAKE_BASE_URL = `http://${uuid()}.local`
 
 const useValidation = ({ meta, content, t, updateMailchimp }) => {
   const links = useMemo(() => {

--- a/apps/publikator/components/Publication/useValidation.tsx
+++ b/apps/publikator/components/Publication/useValidation.tsx
@@ -1,15 +1,14 @@
 import { useMemo } from 'react'
 import visit from 'unist-util-visit'
-import isUUID from 'is-uuid'
-import { parse } from 'url'
-import { FRONTEND_BASE_URL } from '../../lib/settings'
+import { v4 as uuid, validate as validateUUID } from 'uuid'
 import { mdastToString } from '../../lib/utils/helpers'
 
 import { SOCIAL_MEDIA } from '../editor/modules/meta/ShareImageForm'
 
 import { Editorial, renderSlateAsText } from '@project-r/styleguide'
 
-const FRONTEND_HOSTNAME = FRONTEND_BASE_URL && parse(FRONTEND_BASE_URL).hostname
+// Used to check for relative urls
+const FAKE_BASE_URL = `http://${uuid()}.com`
 
 const useValidation = ({ meta, content, t, updateMailchimp }) => {
   const links = useMemo(() => {
@@ -23,39 +22,37 @@ const useValidation = ({ meta, content, t, updateMailchimp }) => {
       const warnings = []
       const errors = []
 
-      if (!node || !node[urlKey] || !node[urlKey].trim()) {
+      if (!node?.[urlKey]?.trim()) {
         errors.push('empty')
       } else {
-        const urlObject = parse(node[urlKey])
-        if (urlObject.path) {
-          if (
-            !urlObject.protocol &&
-            urlObject.path[0] !== '/' &&
-            urlObject.path[0] !== '#' &&
-            urlObject.path[0] !== '?'
-          ) {
-            errors.push('relative')
-          }
-          if (urlObject.pathname.endsWith('.webp')) {
-            warnings.push('webp')
-          }
-          if (
-            (!urlObject.protocol || FRONTEND_HOSTNAME === urlObject.hostname) &&
-            urlObject.path.startsWith('/~')
-          ) {
-            const slug = urlObject.pathname.split('~')[1]
-            if (!isUUID.v4(slug)) {
-              warnings.push('profiles')
+        try {
+          const urlObject = new URL(node[urlKey], FAKE_BASE_URL)
+
+          // Is it a relative url?
+          if (urlObject.origin === FAKE_BASE_URL) {
+            // Profile urls are ok when relative, but only if they're a UUID
+            if (urlObject.pathname.startsWith('/~')) {
+              const slug = urlObject.pathname.split('~')[1]
+              if (!validateUUID(slug)) {
+                warnings.push('profiles')
+              }
+            } else {
+              errors.push('relative')
             }
           }
-        }
-        if (urlObject.hostname) {
+          // WebP?
+          if (urlObject.pathname?.endsWith('.webp')) {
+            warnings.push('webp')
+          }
+          // Uhhhh really?
           if (
             urlObject.hostname.startsWith('ww.') ||
             urlObject.hostname.startsWith('wwww.')
           ) {
             warnings.push('wwwws')
           }
+        } catch (e) {
+          console.log('Error validating URL', e)
         }
       }
 


### PR DESCRIPTION
Switch to WHATWG URL for validating links in Publikator. This now can handle mailto-URLs (like `mailto:?subject=Hi`) without recipient properly (previously those were missing a `pathname` which caused a crash).

It would be nice to have unit tests for this but alas we don't ¯\_(ツ)_/¯ 