### PR TITLE
fix archive unsubscribe on mailchimp

### DIFF
--- a/packages/backend-modules/mail/MailchimpInterface.js
+++ b/packages/backend-modules/mail/MailchimpInterface.js
@@ -108,7 +108,11 @@ const MailchimpInterface = ({ logger }) => {
       status,
       audienceId = MAILCHIMP_MAIN_LIST_ID,
     ) {
-      const url = this.buildApiUrl(`/members?status=${status}`, audienceId)
+      const count = 1000
+      const url = this.buildApiUrl(
+        `/members?status=${status}&count=${count}`,
+        audienceId,
+      )
       try {
         const response = await this.fetchAuthenticated('GET', url)
         const json = await response.json()


### PR DESCRIPTION
set count to fetch members from list to max (1000), because otherwise only 10 mails are fetched (and archived) every time the scheduler runs