### PR TITLE
fix(mutations/updateMe): allow users with author role to publish profile

### DIFF
--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/updateMe.js
@@ -3,6 +3,7 @@ const {
   checkUsername,
   transformUser,
   Users,
+  Roles,
 } = require('@orbiting/backend-modules-auth')
 const { getKeyId, containsPrivateKey } = require('../../../lib/pgp')
 const {
@@ -175,7 +176,10 @@ module.exports = async (_, args, context) => {
     (isListed && !me._raw.isListed) ||
     (args.hasPublicProfile && !me.hasPublicProfile)
   ) {
-    const check = await isEligible(me.id, pgdb)
+    // Authors always have the option to make their profile public,
+    // we can skip the DB check if the user has the role 'author'.
+    const check =
+      Roles.userHasRole(me, 'author') || (await isEligible(me.id, pgdb))
     if (!check) {
       throw new Error(t('profile/notEligible'))
     }


### PR DESCRIPTION
Updates the `updateMe` mutation to allow users with the `author` role to make their profile public.

This change should have been part of:
cefefcde1 (feat(auth): add author role, 2024-02-07)