### PR TITLE
feat(api): audio-source metadata enriched with file byteSize

### DIFF
--- a/packages/backend-modules/documents/graphql/schema-types.js
+++ b/packages/backend-modules/documents/graphql/schema-types.js
@@ -28,6 +28,7 @@ type AudioSource implements PlayableMedia {
   aac: String
   ogg: String
   durationMs: Int!
+  byteSize: Int
 }
 
 enum AudioSourceKind {

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/commit.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/commit.js
@@ -18,7 +18,9 @@ const {
 
 const { hashObject } = require('../../../lib/git')
 const { updateCurrentPhase, toCommit } = require('../../../lib/postgres')
-const { maybeApplyAudioSourceDuration } = require('../../../lib/audioSource')
+const {
+  maybeApplyAudioSourceDurationAndByteSize,
+} = require('../../../lib/audioSource')
 
 const {
   lib: {
@@ -162,7 +164,7 @@ module.exports = async (_, args, context) => {
         { fields: ['id', 'meta'] },
       ))
 
-    await maybeApplyAudioSourceDuration(meta, parentCommit?.meta)
+    await maybeApplyAudioSourceDurationAndByteSize(meta, parentCommit?.meta)
 
     const author = {
       name: user.name,

--- a/packages/backend-modules/publikator/lib/Document.js
+++ b/packages/backend-modules/publikator/lib/Document.js
@@ -104,6 +104,7 @@ const prepareMetaForPublish = async ({
     audioSourceAac,
     audioSourceOgg,
     audioSourceDurationMs,
+    audioSourceByteSize,
   } = doc.content.meta
 
   const audioSource =
@@ -115,6 +116,7 @@ const prepareMetaForPublish = async ({
           aac: audioSourceAac,
           ogg: audioSourceOgg,
           durationMs: audioSourceDurationMs,
+          byteSize: audioSourceByteSize,
         }
       : null
 

--- a/packages/backend-modules/publikator/lib/audioSource.ts
+++ b/packages/backend-modules/publikator/lib/audioSource.ts
@@ -6,6 +6,7 @@ const debug = Debug('publikator:lib:audioSource')
 interface CommitMeta {
   audioSourceMp3?: string
   audioSourceDurationMs?: number
+  audioSourceByteSize?: number
 }
 
 const resToArrayBuffer = (res: Response) => {
@@ -28,7 +29,7 @@ const checkSeconds = (seconds: number) => {
 
 const toMiliseconds = (seconds: number) => Math.round(seconds * 1000)
 
-export const maybeApplyAudioSourceDuration = async (
+export const maybeApplyAudioSourceDurationAndByteSize = async (
   currentMeta: CommitMeta,
   previousMeta?: CommitMeta,
 ): Promise<void> => {
@@ -45,6 +46,10 @@ export const maybeApplyAudioSourceDuration = async (
     await fetch(currentMeta.audioSourceMp3)
       .then(resToArrayBuffer)
       .then(Buffer.from)
+      .then((buffer) => {
+        currentMeta.audioSourceByteSize = buffer.byteLength
+        return buffer
+      })
       .then(measureDuration)
       .then(checkSeconds)
       .then(toMiliseconds)

--- a/packages/backend-modules/publikator/script/migrateAudioSources.ts
+++ b/packages/backend-modules/publikator/script/migrateAudioSources.ts
@@ -12,7 +12,9 @@ const {
 } = require('@orbiting/backend-modules-base')
 
 const { maybeDelcareMilestonePublished } = require('../lib/postgres')
-const { maybeApplyAudioSourceDuration } = require('../lib/audioSource')
+const {
+  maybeApplyAudioSourceDurationAndByteSize,
+} = require('../lib/audioSource')
 
 const debug = Debug('publikator:script:migrateAudioSources')
 
@@ -102,7 +104,7 @@ const handleBatch = async (rows: any[], count: number, pgdb: any) => {
       return
     }
 
-    await maybeApplyAudioSourceDuration(meta)
+    await maybeApplyAudioSourceDurationAndByteSize(meta)
 
     const tx = await pgdb.transactionBegin()
     debug('transaction begin')


### PR DESCRIPTION
In addition to the durationMS being fetched for an attached audioSource, the byteSize is now also attached to the commit meta-data.

