### PR TITLE
fix(publikator): add uuid as a dependency

### DIFF
--- a/apps/publikator/package.json
+++ b/apps/publikator/package.json
@@ -117,6 +117,7 @@
     "unified": "^7.0.0",
     "unist-util-visit": "^2.0.3",
     "url": "^0.11.0",
+    "uuid": "^9.0.1",
     "validator": "^10.11.0"
   }
 }


### PR DESCRIPTION
I stumbled upon [this error](https://republik-ag.sentry.io/issues/5110815261/?project=4505796048453632&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=2) and found [this](
https://github.com/republik/plattform/blob/63395e7d53c52ebb6e07e23bd092cd10847c6859/apps/publikator/components/Publication/useValidation.tsx#L13).

