### PR TITLE
Small fixes for campaign reward scheduler

### DIFF
--- a/packages/backend-modules/referral-campaigns/lib/repo.ts
+++ b/packages/backend-modules/referral-campaigns/lib/repo.ts
@@ -125,6 +125,7 @@ export class PGReferralsRepo implements ReferralCampaignRepo, ReferralCodeRepo {
       FROM referrals r
       LEFT JOIN "userCampaignRewards" ucr ON r."referrerId" = ucr."userId"
       WHERE ucr."userId" IS NULL
+      AND r."referrerId" IS NOT NULL
       GROUP BY r."referrerId", r."campaignId"`)
   }
 

--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/index.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/index.js
@@ -144,7 +144,7 @@ const init = async (context) => {
         await rewardReferrers(args, pgdb)
       },
       lockTtlSecs,
-      runIntervalSecs: 60 * 10,
+      runIntervalSecs: 60 * 60 * 6,
     }),
   )
 


### PR DESCRIPTION
Small fixes for campaign rewards scheduler to improve efficiency for future campaigns. 
- decrease scheduler frequency, now runs every 6h
- ignore non-personal referrals