### PR TITLE
chore(gdpr-export): add new datapoints to script

### DIFF
--- a/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
+++ b/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
@@ -1091,7 +1091,7 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
     await save(
       destination,
       'campaign-referral-rewards',
-      'Erhaltene Belohnungen durch Vermittlungen bei einer Mitgliederkampagne',
+      'Erhaltene Belohnungen für Vermittlungen bei einer Mitgliederkampagne',
       userCampaignRewards.map((userReward) => {
         const reward = campaignsRewardsById.get(userReward.campaignRewardId)
         const campaginName = campaignsById.get(reward.campaignId)?.name

--- a/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
+++ b/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
@@ -1072,7 +1072,7 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
     await save(
       destination,
       'campaign-referrals',
-      'Referrals bei einer Mitglieder Kampagne',
+      'Vermittlungen bei einer Mitgliederkampagne',
       campaignReferrals.map((referral) => {
         return {
           campaign: campaignsById.get(referral.campaignId)?.name,
@@ -1091,7 +1091,7 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
     await save(
       destination,
       'campaign-referral-rewards',
-      'Erhaltene Rewards durch Vermittlungen bei einer Mitgliederkampagne',
+      'Erhaltene Belohnungen durch Vermittlungen bei einer Mitgliederkampagne',
       userCampaignRewards.map((userReward) => {
         const reward = campaignsRewardsById.get(userReward.campaignRewardId)
         const campaginName = campaignsById.get(reward.campaignId)?.name

--- a/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
+++ b/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
@@ -777,7 +777,7 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
     await save(
       destination,
       'direct-newsletter-signups',
-      'Newsletter Sign-Ups, die nicht über die Republik Webseite geschehen sind, in Verbindung mit einer Ad Campaign',
+      'Newsletter Sign-Ups, die nicht über die Republik Webseite geschehen sind, sondern durch das Angeben der Email beim Klicken auf Online-Werbung für die Republik-Newsletter (z.B. auf Instagram)',
       leadTrackingResults.map((leads) => pick(leads, ['email', 'leadTag'])),
     )
 

--- a/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
+++ b/packages/backend-modules/republik/script/gdpr/extractPersonalData.js
@@ -154,6 +154,7 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
             'discussionNotificationChannels',
             'preferredFirstFactor',
             'disclosures',
+            'referralCode',
           ]),
           ...(address && {
             address_name: address.name,
@@ -763,6 +764,24 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
     )
 
     /**
+     * Mailchimp lead campaigns data
+     *
+     * Checks if the users email shows up in the imported mailchimp data
+     * from our 'Zapier to mailchimp ad campaigns'
+     */
+
+    const leadTrackingResults = await pgdb.public.leadTracking.find({
+      email: user.email,
+    })
+
+    await save(
+      destination,
+      'direct-newsletter-signups',
+      'Newsletter Sign-Ups, die nicht über die Republik Webseite geschehen sind, in Verbindung mit einer Ad Campaign',
+      leadTrackingResults.map((leads) => pick(leads, ['email', 'leadTag'])),
+    )
+
+    /**
      * membershipPeriods, membershipCancellations, chargeAttempts
      */
 
@@ -1033,6 +1052,56 @@ Promise.props({ pgdb: PgDb.connect(), elastic: Elasticsearch.connect() })
           'readAt',
         ]),
       ),
+    )
+
+    /**
+     * Campaign Referrals
+     *
+     * Saves the referral created at time as well as the campaign name.
+     * The pledge id is not part of the export because it
+     * conerns a diffrent user.
+     */
+
+    const campaignsById = new Map()
+    const campaigns = await pgdb.public.campaigns.findAll()
+    campaigns.forEach((c) => campaignsById.set(c.id, c))
+
+    const campaignReferrals = await pgdb.public.referrals.find({
+      referrerId: user.id,
+    })
+    await save(
+      destination,
+      'campaign-referrals',
+      'Referrals bei einer Mitglieder Kampagne',
+      campaignReferrals.map((referral) => {
+        return {
+          campaign: campaignsById.get(referral.campaignId)?.name,
+          createdAt: referral.createdAt,
+        }
+      }),
+    )
+
+    const campaignsRewardsById = new Map()
+    const campaignRewards = await pgdb.public.campaignRewards.findAll()
+    const userCampaignRewards = await pgdb.public.userCampaignRewards.find({
+      userId: user.id,
+    })
+    campaignRewards.forEach((c) => campaignsRewardsById.set(c.id, c))
+
+    await save(
+      destination,
+      'campaign-referral-rewards',
+      'Erhaltene Rewards durch Vermittlungen bei einer Mitgliederkampagne',
+      userCampaignRewards.map((userReward) => {
+        const reward = campaignsRewardsById.get(userReward.campaignRewardId)
+        const campaginName = campaignsById.get(reward.campaignId)?.name
+
+        return {
+          reward: reward?.name,
+          campaign: campaginName,
+          createdAt: userReward.createdAt,
+        }
+      }),
     )
 
     await saveReadMe(destination)


### PR DESCRIPTION
- adds the referral code and campaign referrals
- adds claimed referral rewards
- adds nl sign-up data from external sign-ups