### PR TITLE
chore(dev): update postgres in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - ./docker-data/redis:/data:delegated
 
   postgres:
-    image: postgres:12.7
+    image: postgres:14.11
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:


### PR DESCRIPTION
Update the postgres version in the docke-compose to version 14.11 to match love and the upcoming production update.

The local postgres data directory needs to be deleted for this to work.