### PR TITLE
chore: add heroku-cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "heroku-prebuild": "scripts/prune.sh",
     "heroku-postbuild": "scripts/build.sh && scripts/heroku-postbuild.sh",
+    "heroku-cleanup": "scripts/heroku-cleanup.sh",
     "dev:setup": "yarn migrate:db:create && yarn migrate:up && yarn migrate:db:import && yarn pull:elasticsearch --flush && yarn populate",
     "pull:elasticsearch": "packages/backend-modules/search/script/pullElasticsearch.js",
     "pull:images": "packages/backend-modules/publikator/script/copyImages.js",

--- a/scripts/heroku-cleanup.sh
+++ b/scripts/heroku-cleanup.sh
@@ -1,0 +1,8 @@
+SERVER=${SERVER:-www}
+
+if [ "$SERVER" != "api" ]
+then
+  echo Removing .next/cache from apps/$SERVER
+  rm -rf "apps/${SERVER}/.next/cache"
+fi
+


### PR DESCRIPTION
Reduces heroku slug size from >400MB to ~270MB