### PR TITLE
fix(www): re-add missing margin to lead paragraphs on marketing-front

### DIFF
--- a/apps/www/components/Marketing/Lead.js
+++ b/apps/www/components/Marketing/Lead.js
@@ -37,6 +37,7 @@ const styles = {
     lineHeight: 1.3,
     marginBottom: 0,
     textAlign: 'center',
+    marginBlock: '1em 0',
     [mediaQueries.mUp]: {
       fontSize: 22,
       textAlign: 'left',


### PR DESCRIPTION
Readds these margins
![CleanShot 2024-05-03 at 11 15 07@2x](https://github.com/republik/plattform/assets/30313631/6677e3d9-f8f9-4e84-bef1-722a172f161e)
