### PR TITLE
add stripe promo code handling for starter price test

### DIFF
--- a/packages/backend-modules/mail/templates/pledge_monthly_abo.html
+++ b/packages/backend-modules/mail/templates/pledge_monthly_abo.html
@@ -43,12 +43,16 @@
                   <td style="padding: 20px">
                     <p>Guten Tag</p>
                     <p>
-                      Wir freuen uns sehr, dass Sie sich für ein Republik Monats-Abo 
+                      Wir freuen uns sehr, dass Sie sich für ein Republik Monats-Abo
                       entschieden haben.
                     </p>
                     <p>
-                      Die von Ihnen angegebene Kreditkarte belasten wir
-                      monatlich mit CHF 22.–. Unter
+                      Das Monats-Abo verlängert sich automatisch jeweils um einen weiteren Monat.
+                      Die von Ihnen angegebene Kreditkarte belasten wir dementsprechend ab Beginn der
+                      ersten Verlängerungsperiode monatlich mit CHF 22.-.
+                    </p>
+                    <p>
+                      Unter
                       <a href="{{link_account_goto}}">Konto</a> finden Sie Ihre
                       <a href="{{link_account_abos_goto}}"
                         >persönliche Übersicht zu Ihrem Abonnement</a

--- a/packages/backend-modules/mail/templates/pledge_monthly_abo.txt
+++ b/packages/backend-modules/mail/templates/pledge_monthly_abo.txt
@@ -3,8 +3,11 @@ Guten Tag
 Wir freuen uns sehr, dass Sie sich für ein Republik Monats-Abo entschieden
 haben.
 
-Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–. Unter
-Konto {{link_account_goto}} finden Sie Ihre persönliche Übersicht zu Ihrem
+Das Monats-Abo verlängert sich automatisch jeweils um einen weiteren Monat.
+Die von Ihnen angegebene Kreditkarte belasten wir dementsprechend ab Beginn der
+ersten Verlängerungsperiode monatlich mit CHF 22.-.
+
+Unter Konto {{link_account_goto}} finden Sie Ihre persönliche Übersicht zu Ihrem
 Abonnement {{link_account_abos_goto}} . Am gleichen Ort können Sie alle
 Einstellungen vornehmen (z. B. Kreditkarteninformationen ändern) oder das Abo
 jederzeit kündigen.

--- a/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/payPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/payPledge.js
@@ -31,6 +31,7 @@ module.exports = async (_, args, context) => {
         })
         throw new Error(t('api/unexpected'))
       }
+
       if (pledge.status === 'SUCCESSFUL') {
         // check if the pledge was paid with the same paypal transaction
         // happens if the webhook is faster than redirect
@@ -109,6 +110,7 @@ module.exports = async (_, args, context) => {
           sourceId: pledgePayment.sourceId,
           pspPayload: pledgePayment.pspPayload,
           makeDefault: pledgePayment.makeDefault,
+          promoCode: pledge?.payload?.coupon,
           userId: user.id,
           pkg,
           transaction,

--- a/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
@@ -396,7 +396,8 @@ module.exports = async (_, args, context) => {
           if (userHasActiveMembership) {
             throw new Error(t('api/membership/monthly/hasActive'))
           } else if (userHasMonthlyMembership) {
-            throw new Error(t('api/membership/monthly/reactivate'))
+            // TODO: throw error again after starter price test
+            // throw new Error(t('api/membership/monthly/reactivate'))
           }
         }
       }

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createSubscription.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createSubscription.js
@@ -12,6 +12,8 @@ module.exports = async ({
   platformPaymentMethodId, // optional
   errIfIncomplete, // optional
   metadata,
+  idempotencyKey,
+  discounts = [],
   pgdb,
   clients: _clients, // optional
   t,
@@ -35,6 +37,7 @@ module.exports = async ({
     items: [{ plan }],
     metadata,
     expand: ['latest_invoice', 'latest_invoice.payment_intent'],
+    discounts,
   }
 
   if (errIfIncomplete) {
@@ -54,7 +57,9 @@ module.exports = async ({
 
   if (!platformPaymentMethodId) {
     debug('subscribe user with default payment method %o', subscription)
-    return stripe.subscriptions.create(subscription)
+    return stripe.subscriptions.create(subscription, {
+      idempotencyKey,
+    })
   }
 
   subscription.default_payment_method = await getPaymentMethodForCompany({

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
@@ -184,9 +184,11 @@ const payWithPaymentMethod = async ({
 
   const discounts = []
   if (promoCode) {
-    console.log(promoCode)
-    const promotions = await fetchPromotions(clients, companyId, promoCode)
-    console.log(promotions)
+    const promotions = await fetchStripePromotions(
+      clients,
+      companyId,
+      promoCode,
+    )
     discounts.push(
       ...promotions.map((p) => ({
         promotion_code: p.id,
@@ -279,13 +281,13 @@ const payWithPaymentMethod = async ({
   }
 }
 
-async function fetchPromotions(clients, companyId, promoCode) {
+async function fetchStripePromotions(clients, companyId, promoCode) {
   const { stripe } = clients.accountForCompanyId(companyId)
 
-  const discounts = await stripe.promotionCodes.list({
+  const promotions = await stripe.promotionCodes.list({
     active: true,
     code: promoCode,
   })
 
-  return discounts.data
+  return promotions.data
 }

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
@@ -91,6 +91,7 @@ const payWithSource = async ({
         metadata: {
           pledgeId,
         },
+        idempotencyKey: pledgeId,
         pgdb: transaction,
       })
     } else {
@@ -139,6 +140,7 @@ const payWithPaymentMethod = async ({
   stripePlatformPaymentMethodId,
   makeDefault = false,
   userId,
+  promoCode,
   pkg,
   pgdb,
   t,
@@ -180,6 +182,18 @@ const payWithPaymentMethod = async ({
     )
   }
 
+  const discounts = []
+  if (promoCode) {
+    console.log(promoCode)
+    const promotions = await fetchPromotions(clients, companyId, promoCode)
+    console.log(promotions)
+    discounts.push(
+      ...promotions.map((p) => ({
+        promotion_code: p.id,
+      })),
+    )
+  }
+
   const isSubscription = pkg.name === 'MONTHLY_ABO'
   let paymentIntent
   if (isSubscription) {
@@ -191,6 +205,8 @@ const payWithPaymentMethod = async ({
       metadata: {
         pledgeId,
       },
+      idempotencyKey: pledgeId,
+      discounts,
       pgdb,
       clients,
       t,
@@ -261,4 +277,15 @@ const payWithPaymentMethod = async ({
     stripePublishableKey: account.publishableKey,
     companyId,
   }
+}
+
+async function fetchPromotions(clients, companyId, promoCode) {
+  const { stripe } = clients.accountForCompanyId(companyId)
+
+  const discounts = await stripe.promotionCodes.list({
+    active: true,
+    code: promoCode,
+  })
+
+  return discounts.data
 }


### PR DESCRIPTION
Adds a promo code to the stripe subscription if provided as part of the pledge payload