### PR TITLE
Use Idempotent key to prevent double pay

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createPaymentIntent.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createPaymentIntent.js
@@ -1,4 +1,5 @@
 const getStripeClients = require('./clients')
+const { genIdempotencyKey } = require('./genIdempotencyKey')
 const { getPaymentMethodForCompany } = require('./paymentMethod')
 
 // paymentMethod(Id) is expected to be in company(Id)
@@ -59,7 +60,7 @@ module.exports = async ({
       ...(offSession ? {} : { setup_future_usage: 'off_session' }),
     },
     {
-      idempotencyKey: pledgeId,
+      idempotencyKey: genIdempotencyKey(pledgeId, paymentMethodId),
     },
   )
 }

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createPaymentIntent.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/createPaymentIntent.js
@@ -44,17 +44,22 @@ module.exports = async ({
 
   // customer needs to be attached to PaymentIntent
   // otherwise she can't use her saved paymentMethods
-  return stripe.paymentIntents.create({
-    amount: total,
-    currency: 'chf',
-    customer: customer.id,
-    payment_method: paymentMethodId,
-    metadata: {
-      pledgeId,
-      ...metadata,
+  return stripe.paymentIntents.create(
+    {
+      amount: total,
+      currency: 'chf',
+      customer: customer.id,
+      payment_method: paymentMethodId,
+      metadata: {
+        pledgeId,
+        ...metadata,
+      },
+      confirm,
+      off_session: offSession,
+      ...(offSession ? {} : { setup_future_usage: 'off_session' }),
     },
-    confirm,
-    off_session: offSession,
-    ...(offSession ? {} : { setup_future_usage: 'off_session' }),
-  })
+    {
+      idempotencyKey: pledgeId,
+    },
+  )
 }

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/genIdempotencyKey.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/genIdempotencyKey.js
@@ -1,0 +1,12 @@
+const crypto = require('node:crypto')
+
+function genIdempotencyKey(...segments) {
+  return crypto
+    .createHash('sha256')
+    .update(segments.join(':'))
+    .digest('base64url')
+}
+
+module.exports = {
+  genIdempotencyKey,
+}

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/payPledge.js
@@ -91,7 +91,6 @@ const payWithSource = async ({
         metadata: {
           pledgeId,
         },
-        idempotencyKey: pledgeId,
         pgdb: transaction,
       })
     } else {
@@ -207,7 +206,6 @@ const payWithPaymentMethod = async ({
       metadata: {
         pledgeId,
       },
-      idempotencyKey: pledgeId,
       discounts,
       pgdb,
       clients,

--- a/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/paymentMethod.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/payments/stripe/paymentMethod.js
@@ -138,7 +138,7 @@ exports.getPaymentMethodForCompany = async ({
   companyId,
   platformPaymentMethodId, // optional: if ommited, the default is used
   pgdb,
-  clients: _clients, // optional
+  clients: _clients = null, // optional
   t,
   acceptCachedData,
 }) => {


### PR DESCRIPTION
This is a bandaid for the existing payment flow.

A payment with the same pledgeId and the same payment method should always return the same payment Intent for 24 hours.

- The idempotent key is derived from the pledgeId and the payment method id 