### PR TITLE
feat(cors): translate allow list to regex patterns

### DIFF
--- a/apps/assets/package.json
+++ b/apps/assets/package.json
@@ -47,7 +47,7 @@
     "@orbiting/backend-modules-types": "*",
     "@orbiting/backend-modules-utils": "*",
     "@orbiting/backend-modules-voting": "*",
-    "cors": "^2.8.4",
+    "cors": "^2.8.5",
     "express": "^4.16.3",
     "regiment": "^0.0.5"
   },

--- a/apps/assets/server.js
+++ b/apps/assets/server.js
@@ -2,6 +2,9 @@ const express = require('express')
 const cors = require('cors')
 const { express: middlewares } = require('@orbiting/backend-modules-assets')
 const basicAuthMiddleware = require('@orbiting/backend-modules-auth/express/basicAuth')
+const {
+  createCORSMatcher,
+} = require('@orbiting/backend-modules-base/lib/corsRegex')
 
 const DEV = process.env.NODE_ENV ? process.env.NODE_ENV !== 'production' : true
 
@@ -33,7 +36,7 @@ const start = (workerId) => {
 
   if (CORS_ALLOWLIST_URL) {
     const corsOptions = {
-      origin: CORS_ALLOWLIST_URL.split(','),
+      origin: createCORSMatcher(CORS_ALLOWLIST_URL.split(',')),
       credentials: true,
       // maxAge: <seconds>; up to 24 hours
       // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age

--- a/packages/backend-modules/base/__tests__/corsRegex.u.jest.js
+++ b/packages/backend-modules/base/__tests__/corsRegex.u.jest.js
@@ -1,0 +1,84 @@
+const express = require('express')
+const request = require('supertest')
+const { faker } = require('@faker-js/faker')
+const cors = require('cors')
+const { createCORSMatcher } = require('../lib/corsRegex.js')
+
+function makeServerWithCorsList(corsList) {
+  const app = express()
+  app.use(
+    cors({
+      credentials: true,
+      // maxAge: <seconds>; up to 24 hours
+      // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+      maxAge: 60 * 60 * 24,
+      optionsSuccessStatus: 200,
+      origin: createCORSMatcher(corsList),
+    }),
+  )
+  app.get('/', (req, res) => {
+    res.status(200).json({ message: 'Success' })
+  })
+  return app
+}
+
+const corsList = [
+  'http://republik.test',
+  'http://www.republik.test',
+  'http://api.republik.test',
+  'http://*.preview.republik.test',
+  'http://*.republik.local',
+]
+
+const expectedToPass = [
+  'http://republik.test',
+  'http://www.republik.test',
+  'http://api.republik.test',
+  'http://foo.republik.local',
+  'http://foo.bar.republik.local',
+  'http://foo.bar.baz.republik.local',
+]
+
+const expectedPreviewDomainsToPass = [
+  `http://${faker.internet.domainWord()}.preview.republik.test`,
+  `http://${faker.internet.domainWord()}.preview.republik.test`,
+  `http://${faker.internet.domainWord()}.preview.republik.test`,
+  `http://${faker.internet.domainWord()}.preview.republik.test`,
+]
+
+const expectedToFail = [
+  `http://${faker.internet.domainWord()}.republik.test`,
+  `http://${faker.internet.domainWord()}.republik.test`,
+  `http://${faker.internet.domainWord()}.republik.test`,
+  `http://${faker.internet.domainWord()}.republik.test`,
+]
+
+describe('custom cors regex domain support', () => {
+  const server = makeServerWithCorsList(corsList)
+
+  for (const origin of expectedToPass) {
+    test(`✅ - origin '${origin}' is allowed with cors-list '[${corsList}]'`, async () => {
+      const res = await request(server).get('/').set('origin', origin)
+
+      expect(res.status).toEqual(200)
+      expect(res.body.message).toEqual('Success')
+    })
+  }
+
+  for (const origin of expectedPreviewDomainsToPass) {
+    test(`✅ - preview origin '${origin}' is allowed with cors-list '[${corsList}]'`, async () => {
+      const res = await request(server).get('/').set('origin', origin)
+
+      expect(res.status).toEqual(200)
+      expect(res.body.message).toEqual('Success')
+    })
+  }
+
+  for (const origin of expectedToFail) {
+    test(`🛑 - origin '${origin}' is denied with cors-list '[${corsList}]'`, async () => {
+      const res = await request(server).get('/').set('origin', origin)
+
+      expect(res.status).toEqual(500)
+    })
+  }
+})

--- a/packages/backend-modules/base/lib/corsRegex.js
+++ b/packages/backend-modules/base/lib/corsRegex.js
@@ -1,0 +1,47 @@
+const debug = require('debug')('base:server:cors')
+
+function wildcardToRegex(pattern) {
+  const escapedPattern = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\\\*/g, '.*')
+  return new RegExp(`^${escapedPattern}$`)
+}
+
+function createCORSMatcher(allowedOrigins) {
+  const regexPatterns = allowedOrigins.map(wildcardToRegex)
+
+  return (origin, callback) => {
+    if (!origin) {
+      // Allow non-origin requests (like mobile apps, curl requests, etc.)
+      return callback(null, true)
+    }
+    debug(
+      `checking [${origin}] against CORS allow list ${JSON.stringify(
+        regexPatterns.map((r) => r.toString()),
+        null,
+        2,
+      )}`,
+    )
+
+    const originIsAllowed = regexPatterns.some((regex) => {
+      const itMatches = regex.test(origin)
+      debug(
+        `origin [${origin}] ${
+          itMatches ? 'matches' : 'does not match'
+        } [${regex}]`,
+      )
+      return itMatches
+    })
+    if (originIsAllowed) {
+      return callback(null, true)
+    }
+
+    return callback(
+      new Error(`Origin ${origin} not allowed by CORS ${allowedOrigins}`),
+    )
+  }
+}
+
+module.exports = {
+  createCORSMatcher,
+}

--- a/packages/backend-modules/base/package.json
+++ b/packages/backend-modules/base/package.json
@@ -35,7 +35,7 @@
     "connect-timeout": "^1.9.0",
     "cookie": "^0.4.1",
     "cookie-parser": "^1.4.5",
-    "cors": "^2.8.4",
+    "cors": "^2.8.5",
     "d3-time-format": "^2.2.3",
     "express": "^4.16.3",
     "graphql": "^15.3.0",
@@ -48,6 +48,8 @@
   },
   "devDependencies": {
     "@orbiting/backend-modules-types": "*",
-    "@types/debug": "^4.1.5"
+    "@types/debug": "^4.1.5",
+    "supertest": "^7.0.0",
+    "@faker-js/faker": "^8.4.1"
   }
 }

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -32,6 +32,7 @@ const {
 } = require('@orbiting/backend-modules-auth')
 const requestLog = require('./express/requestLog')
 const keepalive = require('./express/keepalive')
+const { createCORSMatcher } = require('./lib/corsRegex')
 
 // init httpServer and express and start listening
 const start = async (
@@ -111,7 +112,7 @@ const start = async (
 
   if (CORS_ALLOWLIST_URL) {
     const corsOptions = {
-      origin: CORS_ALLOWLIST_URL.split(','),
+      origin: createCORSMatcher(CORS_ALLOWLIST_URL.split(',')),
       credentials: true,
       // maxAge: <seconds>; up to 24 hours
       // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age

--- a/yarn.lock
+++ b/yarn.lock
@@ -8151,6 +8151,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+component-emitter@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
+  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
+
 compress-commons@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.2.tgz#6542e59cb63e1f46a8b21b0e06f9a32e4c8b06df"
@@ -8426,6 +8431,11 @@ cookie@^0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
+
 copy-anything@^3.0.2:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
@@ -8453,7 +8463,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cors@^2.8.4, cors@^2.8.5:
+cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
@@ -9773,7 +9783,7 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
-dezalgo@^1.0.0:
+dezalgo@^1.0.0, dezalgo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
   integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
@@ -11083,6 +11093,11 @@ fast-redact@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.3.0.tgz#7c83ce3a7be4898241a46560d51de10f653f7634"
   integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fast-text-encoding@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
@@ -11471,6 +11486,15 @@ formdata-node@^4.3.1:
   dependencies:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.3"
+
+formidable@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.1.tgz#9360a23a656f261207868b1484624c4c8d06ee1a"
+  integrity sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -12605,6 +12629,11 @@ helmet@^3.22.0:
     nocache "2.1.0"
     referrer-policy "1.2.0"
     x-xss-protection "1.3.0"
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 hide-powered-by@1.1.0:
   version "1.1.0"
@@ -16073,7 +16102,7 @@ meros@^1.2.1:
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.3.0.tgz#c617d2092739d55286bf618129280f362e6242f2"
   integrity sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -16532,7 +16561,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.2.0, mime@^2.4.3:
+mime@2.6.0, mime@^2.2.0, mime@^2.4.3:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
@@ -18822,6 +18851,13 @@ qs@^6.10.3, qs@^6.11.2, qs@^6.9.4:
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
   dependencies:
     side-channel "^1.0.4"
+
+qs@^6.11.0:
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.12.1.tgz#39422111ca7cbdb70425541cba20c7d7b216599a"
+  integrity sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==
+  dependencies:
+    side-channel "^1.0.6"
 
 qs@~6.5.2:
   version "6.5.3"
@@ -21224,7 +21260,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21241,15 +21277,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@~2.1.1:
   version "2.1.1"
@@ -21351,7 +21378,7 @@ stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21371,13 +21398,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -21510,12 +21530,35 @@ sucrase@^3.20.3:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
+superagent@^9.0.1:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-9.0.2.tgz#a18799473fc57557289d6b63960610e358bdebc1"
+  integrity sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^3.5.1"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+
 superjson@^1.12.2:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.3.tgz#3bd64046f6c0a47062850bb3180ef352a471f930"
   integrity sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==
   dependencies:
     copy-anything "^3.0.2"
+
+supertest@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-7.0.0.tgz#cac53b3d6872a0b317980b2b0cfa820f09cd7634"
+  integrity sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^9.0.1"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -23730,7 +23773,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -23743,15 +23786,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Turns every domain in the CORS_ALLOWLIST_URL to a regex pattern, escaping `[.*+?^${}()|[\]\\]` and turning `*` into `\.*`.

== Examples ==

```
https://www.republik.ch => /^https:\\/\\/www\\.republik\\.ch$/
https://*.republik.ch => /^https:\\/\\/.*\\.republik\\.ch$/
```