### PR TITLE
feat(cors): always allow request from localhost

### DIFF
--- a/packages/backend-modules/base/__tests__/corsRegex.u.jest.js
+++ b/packages/backend-modules/base/__tests__/corsRegex.u.jest.js
@@ -31,6 +31,9 @@ const corsList = [
 ]
 
 const expectedToPass = [
+  'http://localhost',
+  'http://localhost:3010',
+  'https://localhost:3010',
   'http://republik.test',
   'http://www.republik.test',
   'http://api.republik.test',

--- a/packages/backend-modules/base/lib/corsRegex.js
+++ b/packages/backend-modules/base/lib/corsRegex.js
@@ -7,14 +7,24 @@ function wildcardToRegex(pattern) {
   return new RegExp(`^${escapedPattern}$`)
 }
 
+const LOCALHOST_ORIGIN =
+  /https?:\/\/(?:localhost|127\.0\.0\.1|::1)(?::\d{1,5})?/
+
 function createCORSMatcher(allowedOrigins) {
   const regexPatterns = allowedOrigins.map(wildcardToRegex)
 
   return (origin, callback) => {
     if (!origin) {
-      // Allow non-origin requests (like mobile apps, curl requests, etc.)
+      debug(`allowing non web request`)
+      // Allow non-origin requests (like mobile apps, curl requests, etc.) and request from localhost
       return callback(null, true)
     }
+    if (LOCALHOST_ORIGIN.test(origin)) {
+      debug(`allowing request from local origin [${origin}]`)
+      // Allow non-origin requests (like mobile apps, curl requests, etc.) and request from localhost
+      return callback(null, true)
+    }
+
     debug(
       `checking [${origin}] against CORS allow list ${JSON.stringify(
         regexPatterns.map((r) => r.toString()),


### PR DESCRIPTION
the new dynamic regex matcher prevents request proxied from localhost.

There is no real reason why we should prevent localhost request similar to requests cli tools like `curl`