### PR TITLE
fix(signin): insert login link as raw string

### DIFF
--- a/packages/backend-modules/mail/templates/signin.html
+++ b/packages/backend-modules/mail/templates/signin.html
@@ -57,7 +57,7 @@
                           <table border="0" cellspacing="0" cellpadding="0">
                             <tr>
                               <td align="center" bgcolor="#3CAD00">
-                                <a href="{{LOGIN_LINK}}" style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;">Zugriff bestätigen</a>
+                                <a href="{{{LOGIN_LINK}}}" style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;">Zugriff bestätigen</a>
                               </td>
                             </tr>
                           </table>
@@ -66,7 +66,7 @@
                     </table>
                     <p>
                       Falls Sie diese Zugriffsanfrage nicht ausgelöst haben,
-                      <a href="{{LOGIN_LINK}}&amp;noAutoAuthorize=true">können Sie die Zugriffsaufforderung ablehnen</a>.
+                      <a href="{{{LOGIN_LINK}}}&noAutoAuthorize=true">können Sie die Zugriffsaufforderung ablehnen</a>.
                     </p>
                     <p>
                       Wenn Sie diese E-Mail öfters unaufgefordert erhalten,


### PR DESCRIPTION
Inserts links as raw string to prevent double encoding of links