### PR TITLE
chore(base/graphql): set apollo server cache to bounded

### DIFF
--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -99,6 +99,7 @@ module.exports = async (
         ? connection.context
         : createContext({ user: req.user, req, res, scope: 'request' }),
     debug: true,
+    cache: 'bounded',
     introspection: true,
     playground: false, // see ./graphiql.js
     tracing: NODE_ENV === 'development',


### PR DESCRIPTION
The default cache config of apollo server can be used for DOS attacks