### PR TITLE
UTM Session Storage

### DIFF
--- a/apps/www/lib/utils/conversion-payload.js
+++ b/apps/www/lib/utils/conversion-payload.js
@@ -6,7 +6,9 @@ import {
 
 import { inNativeAppBrowserAppVersion } from '../withInNativeApp'
 
-const getUtmParams = (query) => {
+import { getUTMSessionStorage } from '@app/lib/analytics/utm-session-storage'
+
+export const getUtmParams = (query) => {
   // support /probelesen?campaign=x
   let defaultCampaign = query.campaign
 
@@ -58,6 +60,7 @@ export const getConversionPayload = (query = {}) => {
             : 'unknown',
         }
       : undefined,
+    ...getUTMSessionStorage(),
     ...getUtmParams(query),
     ...getCampaignReferralParams(query),
     ...getCouponCodeParams(query),

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -20,6 +20,7 @@ import PageErrorBoundary from '../lib/errors/PageErrorBoundary'
 import { reportError } from '../lib/errors/reportError'
 import { ThemeProvider } from '../components/ColorScheme/ThemeProvider'
 import { AnalyticsProvider } from '@app/lib/analytics/provider'
+import { StoreUTM } from '@app/lib/analytics/utm-session-storage'
 
 if (typeof window !== 'undefined') {
   window.addEventListener('error', (event: ErrorEvent) => {
@@ -82,6 +83,7 @@ const WebApp = ({
                         {...otherPageProps}
                       />
                       <AudioPlayerOrchestrator />
+                      <StoreUTM />
                     </ColorContextProvider>
                   </ThemeProvider>
                 </AppVariableContext>

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -20,7 +20,7 @@ import PageErrorBoundary from '../lib/errors/PageErrorBoundary'
 import { reportError } from '../lib/errors/reportError'
 import { ThemeProvider } from '../components/ColorScheme/ThemeProvider'
 import { AnalyticsProvider } from '@app/lib/analytics/provider'
-import { StoreUTM } from '@app/lib/analytics/utm-session-storage'
+import { SyncUTMToSessionStorage } from '@app/lib/analytics/utm-session-storage'
 
 if (typeof window !== 'undefined') {
   window.addEventListener('error', (event: ErrorEvent) => {
@@ -83,7 +83,7 @@ const WebApp = ({
                         {...otherPageProps}
                       />
                       <AudioPlayerOrchestrator />
-                      <StoreUTM />
+                      <SyncUTMToSessionStorage />
                     </ColorContextProvider>
                   </ThemeProvider>
                 </AppVariableContext>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -9,7 +9,7 @@ import { PUBLIC_BASE_URL } from 'lib/constants'
 import { Metadata } from 'next'
 import { ReactNode } from 'react'
 import { AnalyticsProvider } from '@app/lib/analytics/provider'
-import { StoreUTM } from '@app/lib/analytics/utm-session-storage'
+import { SyncUTMToSessionStorage } from '@app/lib/analytics/utm-session-storage'
 
 export const metadata: Metadata = {
   metadataBase: new URL(PUBLIC_BASE_URL),
@@ -49,7 +49,7 @@ export default async function RootLayout({
           <ApolloWrapper>
             {children}
             <NativeAppMessageSync />
-            <StoreUTM />
+            <SyncUTMToSessionStorage />
           </ApolloWrapper>
         </ThemeProvider>
       </body>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { PUBLIC_BASE_URL } from 'lib/constants'
 import { Metadata } from 'next'
 import { ReactNode } from 'react'
 import { AnalyticsProvider } from '@app/lib/analytics/provider'
+import { StoreUTM } from '@app/lib/analytics/utm-session-storage'
 
 export const metadata: Metadata = {
   metadataBase: new URL(PUBLIC_BASE_URL),
@@ -48,6 +49,7 @@ export default async function RootLayout({
           <ApolloWrapper>
             {children}
             <NativeAppMessageSync />
+            <StoreUTM />
           </ApolloWrapper>
         </ThemeProvider>
       </body>

--- a/apps/www/src/lib/analytics/utm-session-storage.tsx
+++ b/apps/www/src/lib/analytics/utm-session-storage.tsx
@@ -28,7 +28,7 @@ export function getUTMSessionStorage(): Record<string, string> {
   return {}
 }
 
-export function StoreUTM() {
+export function SyncUTMToSessionStorage() {
   useEffect(() => {
     setUTMSessionStorage()
   }, [])

--- a/apps/www/src/lib/analytics/utm-session-storage.tsx
+++ b/apps/www/src/lib/analytics/utm-session-storage.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { useEffect } from 'react'
+
+const STORAGE_KEY = 'republik-utm'
+
+function setUTMSessionStorage(): void {
+  try {
+    const params = getUTMSessionStorage()
+
+    for (const [k, v] of new URLSearchParams(window.location.search)) {
+      if (k.startsWith('utm_')) {
+        params[k] = v
+      }
+    }
+
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(params))
+  } catch {
+    // ignore
+  }
+}
+
+export function getUTMSessionStorage(): Record<string, string> {
+  try {
+    return JSON.parse(window.sessionStorage.getItem(STORAGE_KEY) ?? '{}')
+  } catch {
+    // ignore
+  }
+  return {}
+}
+
+export function StoreUTM() {
+  useEffect(() => {
+    setUTMSessionStorage()
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
Stores UTM params in session storage to prevent them getting lost on the way to the final checkout page.

This is inspired the old implementation removed in #884 but uses sessionStorage instead of localStorage and doesn't track the path of the user.