### PR TITLE
fix(SyntheticReadAloud): associate derivatives with commits so that not every publish or commit needs a newly generated audio if not necessary

### DIFF
--- a/apps/publikator/components/Derivatives/index.js
+++ b/apps/publikator/components/Derivatives/index.js
@@ -57,7 +57,7 @@ const styles = {
   }),
 }
 
-const SynthesizedAudio = withT(({ t, derivative, onClickGenerate }) => {
+const SynthesizedAudio = withT(({ t, derivative, associatedDerivative, onClickGenerate }) => {
   const [showAudioPlayer, setShowAudioPlayer] = useState(false)
   const [showErrorMessage, setShowErrorMessage] = useState(false)
 
@@ -134,7 +134,7 @@ const SynthesizedAudio = withT(({ t, derivative, onClickGenerate }) => {
         />
       )}
       {showAudioPlayer && (
-        <diy {...styles.audioPlayerContainer}>
+        <div {...styles.audioPlayerContainer}>
           <div {...styles.audioPlayer}>
             <AudioPlayer
               src={{
@@ -146,20 +146,20 @@ const SynthesizedAudio = withT(({ t, derivative, onClickGenerate }) => {
               t={t}
             />
           </div>
-        </diy>
+        </div>
       )}
     </>
   )
 })
 
-const Derivatives = ({ commit, repoId, generateDerivative }) => {
+const Derivatives = ({ commit, repoId, showAssociated, generateDerivative }) => {
   if (!commit.derivatives) {
     return null
   }
 
-  const { derivatives, canDeriveSyntheticReadAloud } = commit
+  const { derivatives, associatedDerivative, canDeriveSyntheticReadAloud } = commit
 
-  const synthesizedAudio = derivatives.find(
+  const synthesizedAudio = showAssociated ? associatedDerivative : derivatives.find(
     (d) => d.type === 'SyntheticReadAloud',
   )
 

--- a/apps/publikator/components/Derivatives/index.js
+++ b/apps/publikator/components/Derivatives/index.js
@@ -11,6 +11,7 @@ import {
   OverlayBody,
   OverlayToolbar,
   Interaction,
+  inQuotes,
 } from '@project-r/styleguide'
 import { IconHearing, IconPlay } from '@republik/icons'
 
@@ -57,9 +58,10 @@ const styles = {
   }),
 }
 
-const SynthesizedAudio = withT(({ t, derivative, associatedDerivative, onClickGenerate }) => {
+const SynthesizedAudio = withT(({ t, derivative, onClickGenerate }) => {
   const [showAudioPlayer, setShowAudioPlayer] = useState(false)
   const [showErrorMessage, setShowErrorMessage] = useState(false)
+  const associatedCommit = derivative?.commit
 
   return (
     <>
@@ -123,15 +125,17 @@ const SynthesizedAudio = withT(({ t, derivative, associatedDerivative, onClickGe
           )}
         </>
       ) : (
-        <IconButton
-          invert
-          style={{ marginRight: 0 }}
-                Icon={IconPlay}
-          label='Audio-Version anhören'
-          labelShort='anhören'
-          size={24}
-          onClick={() => setShowAudioPlayer(true)}
-        />
+        <>
+          <IconButton
+            invert
+            style={{ marginRight: 0 }}
+                  Icon={IconPlay}
+            label={associatedCommit ? `Audio-Version: ${inQuotes(associatedCommit.message)}` : 'Audio-Version anhören'}
+            labelShort='anhören'
+            size={24}
+            onClick={() => setShowAudioPlayer(true)}
+          />
+        </>
       )}
       {showAudioPlayer && (
         <div {...styles.audioPlayerContainer}>

--- a/apps/publikator/components/Publication/Current.js
+++ b/apps/publikator/components/Publication/Current.js
@@ -44,6 +44,9 @@ export const getRepoWithPublications = gql`
             ...SimpleDerivative
           }
           canDeriveSyntheticReadAloud: canDerive(type: SyntheticReadAloud)
+          associatedDerivative {
+            ...SimpleDerivative
+          }
         }
         document {
           id

--- a/apps/publikator/components/Publication/Current.js
+++ b/apps/publikator/components/Publication/Current.js
@@ -46,6 +46,10 @@ export const getRepoWithPublications = gql`
           canDeriveSyntheticReadAloud: canDerive(type: SyntheticReadAloud)
           associatedDerivative {
             ...SimpleDerivative
+            commit {
+              id
+              message
+            }
           }
         }
         document {

--- a/apps/publikator/components/Publication/Current.js
+++ b/apps/publikator/components/Publication/Current.js
@@ -124,7 +124,7 @@ class CurrentPublications extends Component {
                       }}
                     >
                       <PublicationLink publication={publication} />
-                      <Derivatives repoId={repo.id} commit={publication.commit} />
+                      <Derivatives repoId={repo.id} commit={publication.commit} showAssociated />
                     </div>
                   </Item>
                 ))}

--- a/apps/publikator/components/Publication/PublicationForm.js
+++ b/apps/publikator/components/Publication/PublicationForm.js
@@ -85,6 +85,7 @@ const Form = ({
 
   const [state, setCompleteState] = useState({
     prepublication: true,
+    skipSynthAudioGeneration: true,
     scheduled: false,
     updateMailchimp: false,
     notifyFilters: [!hasBeenPublished && 'Document'].filter(Boolean),
@@ -99,6 +100,7 @@ const Form = ({
     scheduled,
     scheduledAt,
     publishing,
+    skipSynthAudioGeneration,
   } = state
 
   const schema = getSchema(meta.template)
@@ -262,10 +264,24 @@ const Form = ({
         onChange={(_, value) => {
           setState({
             prepublication: value,
+            skipSynthAudioGeneration: meta.template === 'front' || value,
           })
         }}
       >
         {t('publish/label/prepublication')}
+      </Checkbox>
+      <br />
+      <br />
+      <Checkbox
+        disabled={meta.template === 'front'}
+        checked={!skipSynthAudioGeneration}
+        onChange={(_, value) => {
+          setState({
+            skipSynthAudioGeneration: !value,
+          })
+        }}
+      >
+        {t('publish/label/generateAudio')}
       </Checkbox>
       <br />
       <br />
@@ -431,6 +447,7 @@ const Form = ({
                 commitId: commit.id,
                 settings: {
                   prepublication,
+                  skipSynthAudioGeneration,
                   updateMailchimp,
                   notifyFilters,
                   scheduledAt: scheduled ? scheduledAtDate : undefined,

--- a/apps/publikator/lib/translations.json
+++ b/apps/publikator/lib/translations.json
@@ -1193,6 +1193,10 @@
       "value": "Interne Publikation (Vorschau für Editoren)"
     },
     {
+      "key": "publish/label/generateAudio",
+      "value": "Audio-Version erstellen"
+    },
+    {
       "key": "publish/label/updateMailchimp",
       "value": "Mailchimp aktualisieren"
     },

--- a/apps/publikator/next-env.d.ts
+++ b/apps/publikator/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/publikator/pages/repo/[owner]/[repo]/tree.js
+++ b/apps/publikator/pages/repo/[owner]/[repo]/tree.js
@@ -48,6 +48,9 @@ export const getRepoHistory = gql`
           derivatives {
             ...SimpleDerivative
           }
+          associatedDerivative {
+            ...SimpleDerivative
+          }
           canDeriveSyntheticReadAloud: canDerive(type: SyntheticReadAloud)
         }
       }

--- a/apps/publikator/pages/repo/[owner]/[repo]/tree.js
+++ b/apps/publikator/pages/repo/[owner]/[repo]/tree.js
@@ -58,6 +58,9 @@ export const getRepoHistory = gql`
           derivatives {
             ...SimpleDerivative
           }
+          associatedDerivative {
+            ...SimpleDerivative
+          }
           canDeriveSyntheticReadAloud: canDerive(type: SyntheticReadAloud)
         }
       }

--- a/apps/www/next-env.d.ts
+++ b/apps/www/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/backend-modules/migrations/migrations/20241002113441-commits-with-readaloud.js
+++ b/packages/backend-modules/migrations/migrations/20241002113441-commits-with-readaloud.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/publikator/migrations/sqls'
+const file = '20241002113441-commits-with-readaloud'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/publikator/.gitignore
+++ b/packages/backend-modules/publikator/.gitignore
@@ -4,5 +4,6 @@ lib/cache/**/*.js
 lib/Derivative/**/*.js
 lib/audioSource.js
 lib/phases.js
+lib/types.js
 loaders/**/*.js
 script/*.js

--- a/packages/backend-modules/publikator/graphql/resolvers/Commit.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/Commit.js
@@ -78,6 +78,26 @@ module.exports = {
 
     return derivatives.map(applyAssetsAudioUrl)
   },
+  associatedDerivative: async (commit, args, context) => {
+    const commitWithSynthReadAloud =
+      await context.pgdb.publikator.commitsWithSynthReadAloud.findOne({
+        commitId: commit.id,
+      })
+
+    if (!commitWithSynthReadAloud) {
+      return null
+    }
+
+    const associatedDerivative = await context.loaders.Derivative.byId.load(
+      commitWithSynthReadAloud.derivativeId,
+    )
+
+    if (!associatedDerivative) {
+      return null
+    }
+    
+    return applyAssetsAudioUrl(associatedDerivative)
+  },
   canDerive: async (commit, args) => {
     const { type } = args
 

--- a/packages/backend-modules/publikator/graphql/resolvers/Derivative.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/Derivative.js
@@ -1,0 +1,12 @@
+
+
+
+module.exports = {
+  commit: async (derivative, args, context) => {
+    if (!(derivative?.commitId)) {
+      throw new Error('Could not find commit the derivative %s was generated from', derivative.id)
+    }
+    const dbCommit = await context.loaders.Commit.byId.load(derivative.commitId)
+    return dbCommit
+  }
+}

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/generateDerivative.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/generateDerivative.js
@@ -10,6 +10,8 @@ const {
 
 const { document: getDocument } = require('../Commit')
 
+const { associateReadAloudDerivativeWithCommit } = require('../../../lib/Derivative/associateReadAloudDerivativeWithCommit')
+
 module.exports = async (_, { commitId }, context) => {
   const { user, pgdb, loaders, pubsub, t } = context
   ensureUserHasRole(user, 'editor')
@@ -35,6 +37,8 @@ module.exports = async (_, { commitId }, context) => {
   if (!derivative) {
     throw new Error(t('api/publikator/generateDerivative/unable'))
   }
+
+  await associateReadAloudDerivativeWithCommit(derivative, commit, pgdb)
 
   await pubsub.publish('repoChange', {
     repoChange: {

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
@@ -59,6 +59,7 @@ module.exports = async (_, args, context) => {
     updateMailchimp = false,
     ignoreUnresolvedRepoIds = false,
     notifyFilters = [],
+    skipSynthAudioGeneration = false,
   } = settings
   const { user, t, redis, elastic, pgdb, pubsub, loaders } = context
   ensureUserHasRole(user, 'editor')
@@ -233,7 +234,7 @@ module.exports = async (_, args, context) => {
     await handleRedirection(repoId, doc.content.meta, context)
   }
 
-  await onPublishSyntheticReadAloud(resolvedDoc, context.pgdb, context.user)
+  await onPublishSyntheticReadAloud(resolvedDoc, commit, skipSynthAudioGeneration, context.pgdb, context.user)
 
   // get/create campaign on mailchimp
   // fail early if mailchimp not available

--- a/packages/backend-modules/publikator/graphql/schema-types.js
+++ b/packages/backend-modules/publikator/graphql/schema-types.js
@@ -219,6 +219,8 @@ type Derivative {
   readyAt: DateTime
   failedAt: DateTime
   destroyedAt: DateTime
+  # commit the derivative was generated from
+  commit: Commit!
 }
 
 enum DerivativeType {

--- a/packages/backend-modules/publikator/graphql/schema-types.js
+++ b/packages/backend-modules/publikator/graphql/schema-types.js
@@ -157,6 +157,7 @@ type Commit {
   markdown: String!
   document: Document!
   derivatives: [Derivative!]
+  associatedDerivative: Derivative
   canDerive(type: DerivativeType!): Boolean!
   repo: Repo!
 }

--- a/packages/backend-modules/publikator/graphql/schema-types.js
+++ b/packages/backend-modules/publikator/graphql/schema-types.js
@@ -106,14 +106,14 @@ interface MilestoneInterface {
 
 input PublishSettings {
   prepublication: Boolean!
-
   # on all channels
   scheduledAt: DateTime
   # this API never triggers sending
   # not immediately, not scheduled
   updateMailchimp: Boolean!
-
   ignoreUnresolvedRepoIds: Boolean
+  # skip generating new synth voice audio derivative and use latest instead
+  skipSynthAudioGeneration: Boolean
 }
 
 type PublishResponse {

--- a/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
@@ -242,7 +242,6 @@ export const derive = async (
       WHERE status = 'Pending'
       AND c."repoId" = :repoId;`, {repoId: document.repoId})
       
-      console.log('pending count: %s', pendingCount)
     if (pendingCount > 0) {
       handlerDebug('more than one pending derivatives for this repo. skipping synthesizing.', {
         userId: user.id,

--- a/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
@@ -161,6 +161,11 @@ export const onPublish = async (
       { repoId: repoId },
     )
 
+    if (!latestPublishedDerivative) {
+      console.error('No previously published successful derivative available, not associating derivative with commit.')
+      return
+    }
+
     await associateReadAloudDerivativeWithCommit(latestPublishedDerivative, commit, pgdb)
 
     return

--- a/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/SyntheticReadAloud.ts
@@ -171,7 +171,11 @@ export const onPublish = async (
     return
   }
 
-  return derive(document, { force: false }, pgdb, user)
+  const newDerivative = await derive(document, { force: false }, pgdb, user)
+
+  await associateReadAloudDerivativeWithCommit(newDerivative, commit, pgdb)
+  
+  return newDerivative
 }
 
 interface DeriveOptions {

--- a/packages/backend-modules/publikator/lib/Derivative/associateReadAloudDerivativeWithCommit.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/associateReadAloudDerivativeWithCommit.ts
@@ -17,6 +17,7 @@ export async function associateReadAloudDerivativeWithCommit(
         derivativeId: derivative.id,
         updatedAt: new Date(),
       })
+      await tx.transactionCommit()
     } else {
       await tx.publikator.commitsWithSynthReadAloud.insertAndGet({
         derivativeId: derivative.id,

--- a/packages/backend-modules/publikator/lib/Derivative/associateReadAloudDerivativeWithCommit.ts
+++ b/packages/backend-modules/publikator/lib/Derivative/associateReadAloudDerivativeWithCommit.ts
@@ -1,0 +1,31 @@
+import { PgDb } from 'pogi'
+import { Commit, DerivativeRow } from '../types'
+
+export async function associateReadAloudDerivativeWithCommit(
+  derivative: DerivativeRow,
+  commit: Commit,
+  pgdb: PgDb,
+) {
+  const tx = await pgdb.transactionBegin()
+  try {
+    const existingCommitWithSynthReadAloud =
+      await tx.publikator.commitsWithSynthReadAloud.find({
+        commitId: commit.id,
+      })
+    if (existingCommitWithSynthReadAloud && existingCommitWithSynthReadAloud.length > 0) {
+      await tx.publikator.commitsWithSynthReadAloud.updateAndGetOne({commitId: commit.id}, {
+        derivativeId: derivative.id,
+        updatedAt: new Date(),
+      })
+    } else {
+      await tx.publikator.commitsWithSynthReadAloud.insertAndGet({
+        derivativeId: derivative.id,
+        commitId: commit.id,
+      })
+      await tx.transactionCommit()
+    }
+  } catch (e) {
+    console.error('Error while associating commit %s with derivative %s: %s', commit?.id, derivative?.id, e)
+    await tx.transactionRollback()
+  }
+}

--- a/packages/backend-modules/publikator/lib/types.js
+++ b/packages/backend-modules/publikator/lib/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/packages/backend-modules/publikator/lib/types.js
+++ b/packages/backend-modules/publikator/lib/types.js
@@ -1,2 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });

--- a/packages/backend-modules/publikator/lib/types.ts
+++ b/packages/backend-modules/publikator/lib/types.ts
@@ -1,0 +1,38 @@
+export interface DerivativeRow {
+  id: string
+  commitId?: string
+  type: 'SyntheticReadAloud'
+  status: 'Pending' | 'Ready' | 'Failure' | 'Destroyed'
+  result?: any
+  userId?: string
+  author: DerivativeAuthor
+  createdAt: Date
+  updatedAt: Date
+  readyAt?: Date
+  failedAt?: Date
+  destroyedAt?: Date
+}
+
+interface DerivativeAuthor {
+  name: string
+  email: string
+}
+
+export interface Commit {
+  id: string
+  repoId: string
+  parentIds: string[]
+  message: string
+  type: null | 'mdast' | 'slate'
+  content: string
+  content__markdown: string
+  meta: any
+  userId?: string
+  author: CommitAuthor
+  createdAt: Date
+}
+
+interface CommitAuthor {
+  name: string
+  email: string
+}

--- a/packages/backend-modules/publikator/loaders/Commit.ts
+++ b/packages/backend-modules/publikator/loaders/Commit.ts
@@ -4,30 +4,12 @@ import { v4 } from 'is-uuid'
 
 import createDataLoader from '@orbiting/backend-modules-dataloader'
 import { GraphqlContext } from '@orbiting/backend-modules-types'
+import { Commit } from '../lib/types'
 
 const { parse: mdastParse } = require('@republik/remark-preset')
 const {
   cache: { create: createCache },
 } = require('@orbiting/backend-modules-utils')
-
-export interface Commit {
-  id: string
-  repoId: string
-  parentIds: string[]
-  message: string
-  type: null | 'mdast' | 'slate'
-  content: string
-  content__markdown: string
-  meta: any
-  userId?: string
-  author: CommitAuthor
-  createdAt: Date
-}
-
-interface CommitAuthor {
-  name: string
-  email: string
-}
 
 const fields = [
   'id',

--- a/packages/backend-modules/publikator/loaders/Derivative.ts
+++ b/packages/backend-modules/publikator/loaders/Derivative.ts
@@ -2,25 +2,9 @@ import { PgTable } from 'pogi'
 
 import createDataLoader from '@orbiting/backend-modules-dataloader'
 import { GraphqlContext } from '@orbiting/backend-modules-types'
+import { DerivativeRow } from '../lib/types'
 
-export interface DerivativeRow {
-  id: string
-  commitId?: string
-  type: 'SyntheticReadAloud'
-  status: 'Pending' | 'Ready' | 'Failure' | 'Destroyed'
-  result?: any
-  userId?: string
-  author: DerivativeAuthor
-  createdAt: Date
-  updatedAt: Date
-  readyAt?: Date
-  failedAt?: Date
-  destroyedAt?: Date
-}
-interface DerivativeAuthor {
-  name: string
-  email: string
-}
+
 
 export default module.exports = function (context: GraphqlContext) {
   const derivatives: PgTable<DerivativeRow> =

--- a/packages/backend-modules/publikator/migrations/sqls/20241002113441-commits-with-readaloud-down.sql
+++ b/packages/backend-modules/publikator/migrations/sqls/20241002113441-commits-with-readaloud-down.sql
@@ -1,0 +1,3 @@
+-- migrate down here: DROP TABLE...
+
+DROP TABLE IF EXISTS publikator."commitsWithSynthReadAloud" ;

--- a/packages/backend-modules/publikator/migrations/sqls/20241002113441-commits-with-readaloud-up.sql
+++ b/packages/backend-modules/publikator/migrations/sqls/20241002113441-commits-with-readaloud-up.sql
@@ -1,0 +1,13 @@
+-- migrate up here: CREATE TABLE...
+
+CREATE TABLE "publikator"."commitsWithSynthReadAloud" (
+    "id" uuid DEFAULT uuid_generate_v4(),
+    "commitId" uuid NOT NULL,
+    "derivativeId" uuid NOT NULL,
+    "createdAt" timestamptz DEFAULT now(),
+    "updatedAt" timestamptz DEFAULT now(),
+    PRIMARY KEY ("id"),
+    UNIQUE ("commitId"),
+    FOREIGN KEY ("commitId") REFERENCES "publikator"."commits"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("derivativeId") REFERENCES "publikator"."derivatives"("id")
+);

--- a/packages/backend-modules/publikator/script/copyImages.ts
+++ b/packages/backend-modules/publikator/script/copyImages.ts
@@ -28,7 +28,7 @@ const {
 import { ConnectionContext } from '@orbiting/backend-modules-types'
 
 import { Repo } from '../loaders/Repo'
-import { Commit } from '../loaders/Commit'
+import { Commit } from '../lib/types'
 
 const debug = _debug('publikator:script:copyImages')
 
@@ -62,6 +62,7 @@ const createAdd = (imagePaths: Set<string>) => {
 }
 
 const createMaybeUpload = (repoId: string, origin: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_, name] = repoId.split('/')
 
   return async function maybeUpload(path: string) {


### PR DESCRIPTION
add feature to skip audio generation while publishing, and use audio from latest published commit instead. Adds new table to associate derivatives with commits.