### PR TITLE
fix(profile): make people with subscriptions eligible for public profile

### DIFF
--- a/packages/backend-modules/republik/graphql/resolvers/User.js
+++ b/packages/backend-modules/republik/graphql/resolvers/User.js
@@ -92,7 +92,7 @@ module.exports = {
   },
   isEligibleForProfile(user, args, { user: me, pgdb }) {
     if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter', 'author'])) {
-      return Roles.userHasRole(user, 'author') || isEligible(user.id, pgdb)
+      return Roles.userHasRole(user, 'author') || isEligible(user, pgdb)
     }
     return null
   },

--- a/packages/backend-modules/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/backend-modules/republik/graphql/resolvers/_mutations/updateMe.js
@@ -179,7 +179,7 @@ module.exports = async (_, args, context) => {
     // Authors always have the option to make their profile public,
     // we can skip the DB check if the user has the role 'author'.
     const check =
-      Roles.userHasRole(me, 'author') || (await isEligible(me.id, pgdb))
+      Roles.userHasRole(me, 'author') || (await isEligible(me, pgdb))
     if (!check) {
       throw new Error(t('profile/notEligible'))
     }

--- a/packages/backend-modules/republik/lib/profile.js
+++ b/packages/backend-modules/republik/lib/profile.js
@@ -1,14 +1,12 @@
+const hasUserActiveMembership = require('@orbiting/backend-modules-utils/hasUserActiveMembership')
 const {
   hasUserCandidacies,
   hasUserCandidaciesInCandidacyPhase,
   hasUserCandidaciesInElectionPhase,
 } = require('@orbiting/backend-modules-voting/lib/Candidacy')
 
-exports.isEligible = async (userId, pgdb) => {
-  return !!(await pgdb.public.memberships.findFirst({
-    userId,
-    active: true,
-  }))
+exports.isEligible = async (user, pgdb) => {
+  return await hasUserActiveMembership(user, pgdb)
 }
 
 /**


### PR DESCRIPTION
Check `hasUserActiveMembership` instead of membership table for profile eligibility. 
Alternative implementation: we could also replace `isEligible` directly with `hasUserActiveMembership`.