### PR TITLE
fix(Front): fix infinite loop on the front

### DIFF
--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -225,7 +225,7 @@ async function middlewareFunc(req: NextRequest): Promise<NextResponse> {
   if (sessionCookie && tokenCookie) {
     // Rewrite based on token
     return await rewriteBasedOnToken(tokenCookie)
-  } else if (sessionCookie) {
+  } else {
     // Rewrite if no JWT is present
     return await rewriteBasedOnMe(req)
   }


### PR DESCRIPTION
Problem:

```
useEffect(() => {
    if (meLoading) return
    // reload to re-trigger the middleware to rewrite to the marketing-page
    if (!hasAccess) {
      window.location.reload()
    }
  }, [meLoading, hasAccess])
```
`pages/index.tsx`: the marketing redirect never takes effect, which cause the page to reload and reload and reload…

(Tentative) fix: always call `rewriteBasedOnMe` in the middleware. Why did the session cookie disappear? No idea. 

1. Please test thoroughly before merging. 
2. Maybe returning that session cookie is a better fix?

