### PR TITLE
fix(editorCore): forbid consecutive newline inserts

### DIFF
--- a/apps/publikator/components/editor/modules/document/createPasteHtml.js
+++ b/apps/publikator/components/editor/modules/document/createPasteHtml.js
@@ -18,12 +18,21 @@ const hasParent = (type, document, key) => {
 const normalise = (html) =>
   html.replace(/<b[^>]*font-weight\s*:\s*normal[^>]*>/g, '')
 
+const PARAGRAPH_TYPES = ['PARAGRAPH', 'INFOP', 'BLOCKQUOTEPARAGRAPH']
+
 export default (centerModule, figureModule) => (event, change, editor) => {
   const transfer = getEventTransfer(event)
-  if (transfer.type !== 'html') return
-
   const cursor = editor.value.selection.anchorKey
   const blockType = editor.value.document.getClosestBlock(cursor).type
+
+  if (transfer.type !== 'html') {
+    if (PARAGRAPH_TYPES.includes(blockType)) {
+      change.insertText(transfer.text.replace(/\n{2,}/g, '\n\n'))
+      return true
+    }
+    change.insertText(transfer.text.replace(/\n+/g, '\n'))
+    return true
+  }
 
   const isByline = blockType === 'CENTERBYLINE' || blockType === 'BYLINE'
   if (isByline) return

--- a/apps/publikator/components/editor/utils/keyHandlers.js
+++ b/apps/publikator/components/editor/utils/keyHandlers.js
@@ -73,13 +73,14 @@ export const createStaticKeyHandler = ({ TYPE, rule }) => {
 
   return (event, change) => {
     const isBackspace = event.key === 'Backspace'
-    const isEnter = event.key === 'Enter'
+    const isEnter = (event.key === 'Enter')
     const isTab = event.key === 'Tab'
     const isDelete = event.key === 'Delete'
 
     if (!isBackspace && !isEnter && !isDelete && !isTab) {
       return
     }
+
     const { value } = change
     const inSelection = value.blocks.some(matchBlock(TYPE))
 
@@ -158,9 +159,12 @@ export const createSoftBreakKeyHandler =
     if (event.key !== 'Enter') return
     if (event.shiftKey === false) return
 
-    const { startBlock } = value
+    const { startBlock, startText, endOffset } = value
+
+    const isConsecutiveSoftBreak = startText?.text[endOffset - 1] === '\n' || startText?.text[endOffset] === '\n'
+
     const { type } = startBlock
-    if (type !== TYPE) {
+    if (isConsecutiveSoftBreak || type !== TYPE) {
       return
     }
     return change.insertText('\n')

--- a/apps/publikator/components/editor/utils/keyHandlers.js
+++ b/apps/publikator/components/editor/utils/keyHandlers.js
@@ -159,9 +159,9 @@ export const createSoftBreakKeyHandler =
     if (event.key !== 'Enter') return
     if (event.shiftKey === false) return
 
-    const { startBlock, startText, endOffset } = value
+    const { startBlock, startText, startOffset, endText, endOffset } = value
 
-    const isConsecutiveSoftBreak = startText?.text[endOffset - 1] === '\n' || startText?.text[endOffset] === '\n'
+    const isConsecutiveSoftBreak = startText?.text[startOffset - 1] === '\n' || endText?.text[endOffset] === '\n'
 
     const { type } = startBlock
     if (isConsecutiveSoftBreak || type !== TYPE) {


### PR DESCRIPTION
Consecutive newlines in the title block are the ex-aequo number one cause of editor bugs in publikator (together with scrambled memos), as markdown interprets two consecutive `\n\n` as a new paragraph. However, multiple titles, or leads, are not tolerated.

This PR adds two new behaviours:

1. Ignore every newline insert that follows or precedes another newline character (`\n`)
2. Collapse multiple consecutive newlines into a single newline on copy-paste. An exception is made for paragraph types, where multiple newlines are converted into a double newline, which leads to the creation of a new paragraph (desired behaviour for paragraph types)