### PR TITLE
feat(print): adds media print queries to paynotes, headers, collapsables

### DIFF
--- a/apps/www/components/Article/Page.js
+++ b/apps/www/components/Article/Page.js
@@ -831,7 +831,10 @@ const ArticlePage = ({
                           showNewsletterSignupTop ||
                           isSyntheticReadAloud ||
                           isReadAloud ? (
-                            <Center breakout={breakout}>
+                            <Center
+                              breakout={breakout}
+                              {...styles.actionsAndInfosBlock}
+                            >
                               {showNewsletterSignupTop && (
                                 <div style={{ marginTop: 10 }}>
                                   <NewsletterSignUp
@@ -963,6 +966,11 @@ const ArticlePage = ({
 }
 
 const styles = {
+  actionsAndInfosBlock: css({
+    '@media print': {
+      display: 'none',
+    },
+  }),
   prepublicationNotice: css({
     backgroundColor: colors.social,
   }),

--- a/apps/www/components/Article/PayNote.js
+++ b/apps/www/components/Article/PayNote.js
@@ -27,6 +27,9 @@ import { useMe } from '../../lib/context/MeContext'
 const styles = {
   banner: css({
     padding: '5px 0',
+    '@media print': {
+      display: 'none',
+    },
   }),
   content: css({
     paddingBottom: 0,

--- a/apps/www/components/Frame/Header.js
+++ b/apps/www/components/Frame/Header.js
@@ -343,7 +343,7 @@ const styles = {
     left: 0,
     right: 0,
     '@media print': {
-      position: 'absolute',
+      display: 'none',
     },
   }),
   primary: css({

--- a/apps/www/src/app/(campaign)/components/trial-paynote.tsx
+++ b/apps/www/src/app/(campaign)/components/trial-paynote.tsx
@@ -103,6 +103,9 @@ export function TrialPaynote({
           textStyle: 'body',
           color: 'text.black',
           lineHeight: 1.5,
+          '@media print': {
+            display: 'none',
+          },
         })}
         style={{
           backgroundColor:

--- a/packages/styleguide/src/components/Collapsable/Collapsable.tsx
+++ b/packages/styleguide/src/components/Collapsable/Collapsable.tsx
@@ -97,8 +97,11 @@ const Collapsable = ({
   const isDesktop = useMediaQuery(mUp)
   const { desktop, mobile } = height
   useEffect(() => {
+    /* In print view the body should always be visible. */
+    if (window.matchMedia('print').matches) {
+      setBodyVisibility('full')
+    } else if (bodyVisibility === 'auto' && bodySize?.height !== undefined) {
     /* Collapse the body (switch to 'preview' visibility) when allowed and the size exceeds the threshold. */
-    if (bodyVisibility === 'auto' && bodySize?.height !== undefined) {
       const maxBodyHeight = isDesktop ? desktop : mobile
       if (bodySize.height > maxBodyHeight + threshold) {
         setBodyVisibility('preview')
@@ -226,6 +229,9 @@ const styles = {
       top: -60,
       height: 60,
     },
+    '@media print': {
+      display: 'none',
+    },
   }),
   buttonContainerDivider: css({
     borderTopWidth: 1,
@@ -245,6 +251,9 @@ const styles = {
     cursor: 'pointer',
     height: pxToRem('32px'),
     lineHeight: pxToRem('32px'),
+    '@media print': {
+      display: 'none',
+    },
   }),
 }
 


### PR DESCRIPTION
Should make our default print view more consistent, so we could in theory deprecated react-pdf in the future. Cherry picked a commit I did 4 months ago:  https://github.com/republik/plattform/pull/856/commits/49a97577b5bffa1ada2f686f530df688e66144c5

We should merge as there's no downside in adding the styles (all the changes only applie to media:print) and having it laying around is not a good idea. Deleted the old PR. 

ToDO
- [ ] Test on Love