### PR TITLE
fix: consistent audio player offset & env(safe-area-) fixes

### DIFF
--- a/apps/www/components/Article/ActionBarOverlay.js
+++ b/apps/www/components/Article/ActionBarOverlay.js
@@ -14,9 +14,7 @@ const ActionBarOverlay = ({ children }) => {
   const isDesktop = useMediaQuery(mediaQueries.mUp)
   const { audioPlayerVisible } = useAudioContext()
 
-  const audioPlayerOffset = audioPlayerVisible
-    ? MINI_AUDIO_PLAYER_HEIGHT + 20
-    : 0
+  const audioPlayerOffset = audioPlayerVisible ? MINI_AUDIO_PLAYER_HEIGHT + 15 : 0
   const lastY = useRef()
   const diff = useRef(0)
 

--- a/apps/www/components/Article/ActionBarOverlay.js
+++ b/apps/www/components/Article/ActionBarOverlay.js
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { mediaQueries, useMediaQuery } from '@project-r/styleguide'
-import { AUDIO_PLAYER_HEIGHT } from '../constants'
 
 import BottomPanel from '../Frame/BottomPanel'
-import useAudioQueue from '../Audio/hooks/useAudioQueue'
 import { useAudioContext } from '../Audio/AudioProvider'
 import { MINI_AUDIO_PLAYER_HEIGHT } from '../Audio/AudioPlayer/MiniAudioPlayer'
 
@@ -14,13 +12,10 @@ const FOOTER_FADE_AREA_MOBILE = 1200
 const ActionBarOverlay = ({ children }) => {
   const [overlayVisible, setOverlayVisible] = useState(false)
   const isDesktop = useMediaQuery(mediaQueries.mUp)
-  const { isAudioQueueAvailable } = useAudioQueue()
   const { audioPlayerVisible } = useAudioContext()
 
   const audioPlayerOffset = audioPlayerVisible
-    ? isAudioQueueAvailable
-      ? MINI_AUDIO_PLAYER_HEIGHT + 16
-      : AUDIO_PLAYER_HEIGHT + 20
+    ? MINI_AUDIO_PLAYER_HEIGHT + 20
     : 0
   const lastY = useRef()
   const diff = useRef(0)

--- a/apps/www/components/Audio/AudioPlayer/AudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/AudioPlayer.tsx
@@ -18,6 +18,7 @@ import AudioPlaybackElement from './AudioPlaybackElement'
 import { useUserAgent } from '../../../lib/context/UserAgentContext'
 import { ZINDEX_POPOVER } from '../../constants'
 import { AUDIO_PLAYER_WRAPPER_ID } from './constants'
+
 const MARGIN = 15
 
 // TODO: handle previously stored audio-player state
@@ -43,9 +44,9 @@ const styles = {
     },
   }),
   wrapperMini: css({
-    marginRight: ['15px', 'max(15px, env(safe-area-inset-right))'],
-    marginLeft: ['15px', 'max(15px, env(safe-area-inset-left))'],
-    marginBottom: ['24px', 'max(24px, env(safe-area-inset-bottom))'],
+    marginRight: 'calc(15px + env(safe-area-inset-right))',
+    marginLeft: 'calc(15px + env(safe-area-inset-left))',
+    marginBottom: 'calc(15px + env(safe-area-inset-bottom))',
     width: ['290px', `calc(100% - ${MARGIN * 2}px)`],
     maxHeight: '100vh',
   }),
@@ -58,16 +59,15 @@ const styles = {
       'fill-available',
     ],
     margin: 0,
-    paddingLeft: ['15px', 'max(15px, env(safe-area-inset-left))'],
-    paddingRight: ['15px', 'max(15px, env(safe-area-inset-right))'],
+    paddingLeft: 'calc(15px + env(safe-area-inset-right))',
+    paddingRight: 'calc(15px + env(safe-area-inset-left))',
     paddingBottom: 0,
     width: '100%',
     [mediaQueries.mUp]: {
       height: 'auto',
-      //paddingTop: ['15px', 'max(15px, env(safe-area-inset-top))'],
-      marginRight: ['15px', 'max(15px, env(safe-area-inset-right))'],
-      marginLeft: ['15px', 'max(15px, env(safe-area-inset-left))'],
-      marginBottom: ['24px', 'max(24px, env(safe-area-inset-bottom))'],
+      marginRight: 'calc(15px + env(safe-area-inset-right))',
+      marginLeft: 'calc(15px + env(safe-area-inset-left))',
+      marginBottom: 'calc(15px + env(safe-area-inset-bottom))',
       padding: 9,
     },
   }),

--- a/apps/www/components/Audio/AudioPlayer/ExpandedAudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/ExpandedAudioPlayer.tsx
@@ -50,7 +50,7 @@ const styles = {
     overflow: 'hidden',
   }),
   rootNoAccess: css({
-    paddingBottom: 'calc(24px + env(safe-area-inset-bottom))',
+    paddingBottom: 'calc(15px + env(safe-area-inset-bottom))',
   }),
   queueWrapper: css({
     flex: 1,

--- a/apps/www/components/Audio/AudioPlayer/ExpandedAudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/ExpandedAudioPlayer.tsx
@@ -49,6 +49,9 @@ const styles = {
     },
     overflow: 'hidden',
   }),
+  rootNoAccess: css({
+    paddingBottom: 'calc(24px + env(safe-area-inset-bottom))',
+  }),
   queueWrapper: css({
     flex: 1,
     minHeight: 0,
@@ -198,7 +201,7 @@ const ExpandedAudioPlayer = ({
   )
 
   return (
-    <div {...styles.root}>
+    <div {...styles.root} {...(!hasAccess && styles.rootNoAccess)}>
       <div {...styles.header}>
         <p {...styles.heading} {...colorScheme.set('color', 'text')}>
           {t('AudioPlayer/Queue/ActiveHeading')}

--- a/apps/www/components/Audio/AudioPlayer/ui/tabs/shared/AudioCalloutMenu.tsx
+++ b/apps/www/components/Audio/AudioPlayer/ui/tabs/shared/AudioCalloutMenu.tsx
@@ -35,7 +35,6 @@ const AudioCalloutMenu = ({ actions }: { actions: AudioListItemAction[] }) => {
 
   return (
     <CalloutMenu
-      contentPaddingMobile={'30px'}
       Element={MoreIconButton}
       align='right'
       elementProps={{

--- a/apps/www/components/Frame/BottomPanel.js
+++ b/apps/www/components/Frame/BottomPanel.js
@@ -14,7 +14,6 @@ const styles = {
     margin: `0 ${MARGIN}px`,
     [mediaQueries.mUp]: {
       right: MARGIN,
-      marginBottom: MARGIN,
     },
   }),
   wide: css({
@@ -33,21 +32,15 @@ const BottomPanel = ({
   const [colorScheme] = useColorContext()
   const { inIOSVersion, inNativeApp } = useInNativeApp()
 
-  const bottomOffset =
-    !inNativeApp && inIOSVersion < 15
-      ? 44 // tap safety distance for iOS below 15
-      : MARGIN + 5 // 5px away from the bottom looks better
-  const bottomPosition = offset + bottomOffset
-
   const bottomRule = useMemo(
     () =>
       css({
         bottom: [
-          bottomPosition,
-          `calc(${bottomPosition}px + env(safe-area-inset-bottom))`,
+          offset,
+          `calc(${offset}px + env(safe-area-inset-bottom) + 15px)`,
         ],
       }),
-    [bottomPosition],
+    [offset],
   )
 
   return (

--- a/apps/www/components/Frame/DarkmodeSwitch.js
+++ b/apps/www/components/Frame/DarkmodeSwitch.js
@@ -30,12 +30,8 @@ const DarkmodeSwitch = ({ t }) => {
     />
   ))
 
-  const calloutPaddingNativeApp = inNativeApp
-    ? '15px 15px 25px'
-    : '15px 15px 50px'
-
   return (
-    <CalloutMenu contentPaddingMobile={calloutPaddingNativeApp} Element={Icon}>
+    <CalloutMenu Element={Icon}>
       <div style={{ width: 180, lineHeight: '2.5rem' }}>
         {
           <>

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -87,7 +87,7 @@ const WebApp = ({
                       <Head>
                         <meta
                           name='viewport'
-                          content='width=device-width, initial-scale=1'
+                          content='width=device-width, initial-scale=1, viewport-fit=cover'
                         />
                       </Head>
                       <Component

--- a/packages/styleguide/src/components/Callout/CalloutMenu.tsx
+++ b/packages/styleguide/src/components/Callout/CalloutMenu.tsx
@@ -28,7 +28,6 @@ type Props<ElementProps = any> = {
   elementProps: ElementProps
   align?: 'left' | 'right'
   initiallyOpen?: boolean
-  contentPaddingMobile?: string
   padded?: boolean
   attributes?: any
   inline?: boolean
@@ -40,7 +39,6 @@ const CalloutMenu = ({
   elementProps,
   align,
   initiallyOpen,
-  contentPaddingMobile,
   padded,
   attributes,
   inline = false,
@@ -77,7 +75,6 @@ const CalloutMenu = ({
         <Callout
           onClose={() => setMenu(false)}
           align={align}
-          contentPaddingMobile={contentPaddingMobile}
         >
           {children}
         </Callout>

--- a/packages/styleguide/src/components/Callout/docs.md
+++ b/packages/styleguide/src/components/Callout/docs.md
@@ -5,7 +5,7 @@ A fixed callout animating in from the bottom on mobile and a in place callout on
 - `initiallyOpen`: boolean, note: after a click outside of it, it hides again
 - `icon`: React element
 - `align`: `left` (default) or `right`, alignment on desktop
-- `contentPaddingMobile`: set padding of callout content. (Defaults to "safari safe": `'15px 15px 50px'`).
+
 
 ```react|responsive
 <div style={{ padding: 20 }}>

--- a/packages/styleguide/src/components/Callout/index.tsx
+++ b/packages/styleguide/src/components/Callout/index.tsx
@@ -49,11 +49,16 @@ const styles = {
     right: 0,
     animation: `0.3s ${slideUp} 0.2s forwards`,
     textAlign: 'left',
+    paddingTop: '24px',
+    paddingLeft: 'calc(24px + env(safe-area-inset-left))',
+    paddingRight: 'calc(24px + env(safe-area-inset-right))',
+    paddingBottom: 'calc(24px + env(safe-area-inset-bottom))',
     [mUp]: {
       bottom: 'auto',
       top: 20,
       left: 'auto',
       animation: 'none',
+      padding: 12,
     },
   }),
   right: {
@@ -84,15 +89,9 @@ type Props = {
   children?: React.ReactNode
   align?: 'left' | 'right'
   onClose: () => void
-  contentPaddingMobile?: string
 }
 
-const Callout = ({
-  children,
-  align = 'left',
-  onClose,
-  contentPaddingMobile = '15px 15px 50px',
-}: Props) => {
+const Callout = ({ children, align = 'left', onClose }: Props) => {
   const [colorScheme] = useColorContext()
   const calloutRule = useMemo(
     () =>
@@ -107,7 +106,6 @@ const Callout = ({
   return (
     <span {...styles.calloutContainer} onClick={onClose}>
       <span
-        {...css({ padding: contentPaddingMobile, [mUp]: { padding: 10 } })}
         {...styles.callout}
         {...styles[align].callout}
         {...calloutRule}
@@ -127,7 +125,6 @@ const Callout = ({
 Callout.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   onClose: PropTypes.func,
-  contentPaddingMobile: PropTypes.string,
 }
 
 export default Callout

--- a/packages/styleguide/src/components/Discussion/Internal/Comment/ActionsMenu.tsx
+++ b/packages/styleguide/src/components/Discussion/Internal/Comment/ActionsMenu.tsx
@@ -42,7 +42,6 @@ const ActionsMenu = ({ items = [] }: Props) => {
 
   return (
     <CalloutMenu
-      contentPaddingMobile={'30px'}
       Element={MoreIconWithProps}
       align='right'
       elementProps={{


### PR DESCRIPTION
This PR fixes `env(safe-area-inset-...)` not working properly. It wasn't working in the webview of our react native app, because `viewport-fit=cover'` wasn't set on the meta tag.

Now that it's set it is working as expected and the Callout Element has been simplified by removing the explicit definition of mobile paddings. Now it defines consistent paddings that work both in Native and Web views

example web:
<img width="457" alt="Screenshot 2024-10-22 at 15 19 53" src="https://github.com/user-attachments/assets/11ed6118-0859-419e-adc6-bb487cadd8f9">
same code in native (notice that the marginBottom is larger, because the bottom margin is added to the safe area start `calc(15px + env(safe-area-inset-bottom))`. This ensures consistent hit boxes and enough space that the native UI elements and our buttons don't conflict:
<img width="443" alt="Screenshot 2024-10-22 at 15 19 45" src="https://github.com/user-attachments/assets/039b684e-9055-404d-a0c2-a02ccf6b8ec4">


before the change, the last item of the list was very close to the bottom UI
<img width="430" alt="Screenshot 2024-10-22 at 15 16 19" src="https://github.com/user-attachments/assets/6e848458-9a6b-4562-b421-38474dcc3177">

using env(safe-are-inset..) ensures that the additonal paddings are only ever applied in the native app, since browsers on the web or mobile don't have safe-area-insets.

 new consistent audio-player paddings:
<img width="1953" alt="Screenshot 2024-10-22 at 15 04 18" src="https://github.com/user-attachments/assets/a29c5392-ffe7-41e6-8cb2-d3a086007428">

