### PR TITLE
Datawrapper 1st Improvements

### DIFF
--- a/apps/publikator/components/editor/modules/embeddatawrapper/EditOverlay.js
+++ b/apps/publikator/components/editor/modules/embeddatawrapper/EditOverlay.js
@@ -1,28 +1,34 @@
 import OverlayFormManager from '../../utils/OverlayFormManager'
 
-import { Label, Radio, Field, Checkbox } from '@project-r/styleguide'
+import {
+  Label,
+  Radio,
+  Field,
+  Checkbox,
+  Interaction,
+} from '@project-r/styleguide'
 
 const Form = ({ data, onChange, editor, node }) => {
   const parent = editor.value.document.getParent(node.key)
   const datawrapperId = node.data.get('datawrapperId')
-  const alt = node.data.get('alt')
   const plain = node.data.get('plain')
+  const forceDark = node.data.get('forceDark')
 
   return (
     <>
-      <div>
+      <Interaction.P>
         <Label>Size</Label>
         <br />
         {[
           {
-             label: 'Edge to Edge',
-             props: { size: undefined },
-             parent: {
-               kinds: ['document', 'block'],
-               types: ['CENTER'],
-             },
-             unwrap: true,
-           },
+            label: 'Edge to Edge',
+            props: { size: undefined },
+            parent: {
+              kinds: ['document', 'block'],
+              types: ['CENTER'],
+            },
+            unwrap: true,
+          },
           {
             label: 'Gross',
             props: { size: 'breakout' },
@@ -105,18 +111,16 @@ const Form = ({ data, onChange, editor, node }) => {
             </Radio>
           )
         })}
-      </div>
-      <div>
+      </Interaction.P>
+      <Interaction.P>
         <Field
-          label='Datawrapper ID'
+          label='Datawrapper Chart-ID'
           value={datawrapperId}
           onChange={(e, value) => onChange(data.set('datawrapperId', value))}
+          required
         />
-        <Field
-          label='Alt Text'
-          value={alt}
-          onChange={(e, value) => onChange(data.set('alt', value))}
-        />
+      </Interaction.P>
+      <Interaction.P>
         <Label>
           <Checkbox
             name='plain'
@@ -125,7 +129,17 @@ const Form = ({ data, onChange, editor, node }) => {
           />{' '}
           Header und Footer ausblenden
         </Label>
-      </div>
+      </Interaction.P>
+      <Interaction.P>
+        <Label>
+          <Checkbox
+            name='forceDark'
+            checked={forceDark}
+            onChange={(e, value) => onChange(data.set('forceDark', value))}
+          />{' '}
+          Dunkles Farbschema forcieren
+        </Label>
+      </Interaction.P>
     </>
   )
 }

--- a/packages/styleguide/src/components/Datawrapper/index.tsx
+++ b/packages/styleguide/src/components/Datawrapper/index.tsx
@@ -1,32 +1,66 @@
 import { useTheme } from 'next-themes'
 import Script from 'next/script'
 import { useEffect, useRef, useState } from 'react'
-import { Figure } from '../Figure'
+import { Figure, FigureSize } from '../Figure'
 
-function Datawrapper({ datawrapperId, alt, size, plain = false }) {
-  const chartRef = useRef()
-  const [embedData, setEmbedData] = useState()
+declare global {
+  interface Window {
+    datawrapper: any | undefined
+  }
+}
+
+function Datawrapper({
+  datawrapperId,
+  forceDark = false,
+  size,
+  plain = false,
+}: {
+  datawrapperId: string
+  size: FigureSize
+  forceDark?: boolean
+  plain?: boolean
+}) {
+  const chartRef = useRef<HTMLDivElement>(null)
+  const [embedData, setEmbedData] = useState<
+    Record<string, string | number> | undefined
+  >()
+  const [error, setError] = useState<string>()
   const [scriptReady, setScriptReady] = useState(false)
   const { theme: themeSetting, forcedTheme } = useTheme()
 
   const theme = forcedTheme ?? themeSetting
 
+  const idMissing = !datawrapperId
+
   // Datawrapper supports true/false/"auto"
-  const dark = theme === 'dark' ? true : theme === 'light' ? false : 'auto'
+  const dark =
+    forceDark || (theme === 'dark' ? true : theme === 'light' ? false : 'auto')
 
   useEffect(() => {
+    setError(undefined)
+    const target = chartRef.current
+    if (target) {
+      // Remove all children of the target because datawrapper.render() will just append more
+      while (target.firstChild) {
+        target.removeChild(target.firstChild)
+      }
+    }
     if (datawrapperId) {
       fetch(`https://datawrapper.dwcdn.net/${datawrapperId}/embed.json`)
         .then((res) => res.json())
         .then((data) => {
           setEmbedData(data)
         })
-        .catch((e) => console.error(e))
+        .catch((e) => {
+          setError('Grafik konnte nicht geladen werden')
+          console.error(e)
+        })
     }
   }, [datawrapperId])
 
   useEffect(() => {
     const target = chartRef.current
+
     if (embedData && target && scriptReady) {
       // Remove all children of the target because datawrapper.render() will just append more
       while (target.firstChild) {
@@ -45,7 +79,25 @@ function Datawrapper({ datawrapperId, alt, size, plain = false }) {
 
   return (
     <Figure size={size}>
-      {datawrapperId ? null : 'Chart-ID fehlt'}
+      {idMissing ? (
+        <div
+          style={{
+            color: 'var(--color-error)',
+            padding: 15,
+          }}
+        >
+          Chart-ID fehlt
+        </div>
+      ) : error ? (
+        <div
+          style={{
+            color: 'var(--color-error)',
+            padding: 15,
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
       <div ref={chartRef} style={{ minHeight: 10 }}></div>
       <Script
         id='datawrapper-lib'

--- a/packages/styleguide/src/components/Figure/index.tsx
+++ b/packages/styleguide/src/components/Figure/index.tsx
@@ -134,9 +134,11 @@ export const FIGURE_SIZES = {
   center: MAX_WIDTH,
 }
 
+export type FigureSize = keyof typeof FIGURE_SIZES
+
 export type FigureProps = {
   children: React.ReactNode
-  size?: keyof typeof FIGURE_SIZES
+  size?: FigureSize
   attributes?: React.ComponentPropsWithoutRef<'figure'>
 }
 


### PR DESCRIPTION
- Removed the alt field, as it's not necessary. Alt texts are already part of DW charts (if the author sets them)
- Added a setting to force dark mode. Not optimal but the only way I can think of to make them work in forced dark mode articles
- Some improvements (hopefully) around error handling when chart metadata could not be loaded etc.