### PR TITLE
feat(coreEditor): fix disappearing links upon copy paste

### DIFF
--- a/apps/publikator/components/editor/modules/document/createPasteHtml.js
+++ b/apps/publikator/components/editor/modules/document/createPasteHtml.js
@@ -20,6 +20,15 @@ const normalise = (html) =>
 
 const PARAGRAPH_TYPES = ['PARAGRAPH', 'INFOP', 'BLOCKQUOTEPARAGRAPH']
 
+
+/*const {
+  FRAGMENT,
+  HTML,
+  NODE,
+  RICH,
+  TEXT
+} = TRANSFER_TYPES*/
+
 export default (centerModule, figureModule) => (event, change, editor) => {
   const transfer = getEventTransfer(event)
   const cursor = editor.value.selection.anchorKey
@@ -27,7 +36,7 @@ export default (centerModule, figureModule) => (event, change, editor) => {
 
   if (!transfer?.text) return
 
-  if (transfer.type !== 'html') {
+  if (transfer.type === 'text' || transfer.type === 'rich') {
     if (PARAGRAPH_TYPES.includes(blockType)) {
       change.insertText(transfer.text.replace(/\n{2,}/g, '\n\n'))
       return true
@@ -36,27 +45,29 @@ export default (centerModule, figureModule) => (event, change, editor) => {
     return true
   }
 
-  const isByline = blockType === 'CENTERBYLINE' || blockType === 'BYLINE'
-  if (isByline) return
+  if (transfer.type === 'html') {
+    const isByline = blockType === 'CENTERBYLINE' || blockType === 'BYLINE'
+    if (isByline) return
 
-  const isCenter = hasParent(centerModule.TYPE, editor.value.document, cursor)
-  const isCaption = blockType === 'CAPTION_TEXT'
+    const isCenter = hasParent(centerModule.TYPE, editor.value.document, cursor)
+    const isCaption = blockType === 'CAPTION_TEXT'
 
-  const toMd = unified()
-    .use(htmlParse, {
-      emitParseErrors: true,
-      duplicateAttribute: false,
-    })
-    .use(rehype2remark)
-    .use(stringify)
-  const pastedMd = toMd.processSync(
-    isCenter || isCaption ? normalise(transfer.html) : transfer.text,
-  )
-  const currentSerializer = isCaption
-    ? figureModule.helpers.captionSerializer
-    : centerModule.helpers.childSerializer
-  const pastedAst = currentSerializer.deserialize(parse(pastedMd.contents))
+    const toMd = unified()
+      .use(htmlParse, {
+        emitParseErrors: true,
+        duplicateAttribute: false,
+      })
+      .use(rehype2remark)
+      .use(stringify)
+    const pastedMd = toMd.processSync(
+      isCenter || isCaption ? normalise(transfer.html) : transfer.text,
+    )
+    const currentSerializer = isCaption
+      ? figureModule.helpers.captionSerializer
+      : centerModule.helpers.childSerializer
+    const pastedAst = currentSerializer.deserialize(parse(pastedMd.contents))
 
-  change.insertFragment(pastedAst.document)
-  return true
+    change.insertFragment(pastedAst.document)
+    return true
+  }
 }


### PR DESCRIPTION
Inserting the **text** manually for slate-to-slate copy-paste is removing all the styling/links/etc.

We leave slate to handle these inserts and only check/edit text and html copy-pastes