### PR TITLE
fix: missing flexshrink distorts profile images in comments on mobile

### DIFF
--- a/packages/styleguide/src/components/Discussion/Internal/Comment/Header.js
+++ b/packages/styleguide/src/components/Discussion/Internal/Comment/Header.js
@@ -27,7 +27,6 @@ const styles = {
     width: pxToRem(40),
     flex: `0 0 ${pxToRem(40)}`,
     height: pxToRem(40),
-    marginRight: pxToRem(8),
   }),
   indentIndicators: css({
     flexShrink: 0,
@@ -60,6 +59,8 @@ const styles = {
   link: css({
     color: 'inherit',
     textDecoration: 'none',
+    marginRight: pxToRem(8),
+    flexShrink: 0,
   }),
   linkUnderline: css({
     color: 'inherit',


### PR DESCRIPTION
before:
<img width="376" alt="Screenshot 2024-11-07 at 18 40 34" src="https://github.com/user-attachments/assets/8ce14a12-fab2-47be-903c-41296a8a773e">



after:
<img width="376" alt="Screenshot 2024-11-07 at 18 40 15" src="https://github.com/user-attachments/assets/a34557ab-7fe9-4614-85a9-91c71175912e">
