### PR TITLE
fix: infobox margins

### DIFF
--- a/packages/styleguide/src/components/InfoBox/Subhead.tsx
+++ b/packages/styleguide/src/components/InfoBox/Subhead.tsx
@@ -8,9 +8,12 @@ import { useColorContext } from '../Colors/useColorContext'
 
 const styles = {
   text: css({
+    marginTop: '1em',
+    marginBottom: '-12px',
     ...convertStyleToRem(sansSerifMedium15),
     [mUp]: {
       ...convertStyleToRem(sansSerifMedium18),
+      marginBottom: '-14px',
     },
   }),
 }

--- a/packages/styleguide/src/components/List/List.tsx
+++ b/packages/styleguide/src/components/List/List.tsx
@@ -15,7 +15,7 @@ const MARGIN = 8
 
 const styles = {
   unorderedList: css({
-    marginLeft: 0,
+    margin: '1em 0',
     paddingLeft: 0,
     listStyle: 'none',
     '& > li:before': {


### PR DESCRIPTION
Due to the global reset.css which sets margin: 0 in the frontend, List and Subhead components need explicit definitions of margins, since before they relied on browser defaults (usually 1em). 

With these margins added back, the negative margins that were removed as a quick fix can be added back, resulting in visual parity between publikator and www.