### PR TITLE
Fix scatter plot

### DIFF
--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -5,7 +5,7 @@ import { graphql } from '@apollo/client/react/hoc'
 import { Value, resetKeyGenerator } from 'slate'
 import debounce from 'lodash/debounce'
 import { timeFormat } from 'd3-time-format'
-import { parse } from '@republik/remark-preset'
+import { parse, stringify } from '@republik/remark-preset'
 import { css } from 'glamor'
 
 import Frame from '../Frame'
@@ -187,7 +187,7 @@ export class EditorPage extends Component {
       }
     }
     this.lockHandler = (event) => {
-      event?.preventDefault()
+      event && event.preventDefault()
       this.setState({
         didUnlock: false,
       })
@@ -201,7 +201,7 @@ export class EditorPage extends Component {
       this.setState(this.lock)
     }
     this.unlockHandler = (event) => {
-      event?.preventDefault()
+      event && event.preventDefault()
       const { t } = this.props
 
       const { activeUsers } = this.state
@@ -632,7 +632,6 @@ export class EditorPage extends Component {
           'loadState',
           'documentChangeHandler',
           'diff',
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
           require('diff').createPatch(
             'string',
             JSON.stringify(JSON.parse(committedRawDocString), null, 2),
@@ -701,8 +700,12 @@ export class EditorPage extends Component {
       isTemplate: isNew ? isTemplate === 'true' : data?.repo?.isTemplate,
       message: message,
       document: {
-        content: JSON.parse(
-          JSON.stringify(this.editor.serializer.serialize(editorState)),
+        content: parse(
+          stringify(
+            JSON.parse(
+              JSON.stringify(this.editor.serializer.serialize(editorState)),
+            ),
+          ),
         ),
       },
     })

--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -5,7 +5,7 @@ import { graphql } from '@apollo/client/react/hoc'
 import { Value, resetKeyGenerator } from 'slate'
 import debounce from 'lodash/debounce'
 import { timeFormat } from 'd3-time-format'
-import { parse, stringify } from '@republik/remark-preset'
+import { parse } from '@republik/remark-preset'
 import { css } from 'glamor'
 
 import Frame from '../Frame'
@@ -187,7 +187,7 @@ export class EditorPage extends Component {
       }
     }
     this.lockHandler = (event) => {
-      event && event.preventDefault()
+      event?.preventDefault()
       this.setState({
         didUnlock: false,
       })
@@ -201,7 +201,7 @@ export class EditorPage extends Component {
       this.setState(this.lock)
     }
     this.unlockHandler = (event) => {
-      event && event.preventDefault()
+      event?.preventDefault()
       const { t } = this.props
 
       const { activeUsers } = this.state
@@ -632,6 +632,7 @@ export class EditorPage extends Component {
           'loadState',
           'documentChangeHandler',
           'diff',
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
           require('diff').createPatch(
             'string',
             JSON.stringify(JSON.parse(committedRawDocString), null, 2),
@@ -700,12 +701,8 @@ export class EditorPage extends Component {
       isTemplate: isNew ? isTemplate === 'true' : data?.repo?.isTemplate,
       message: message,
       document: {
-        content: parse(
-          stringify(
-            JSON.parse(
-              JSON.stringify(this.editor.serializer.serialize(editorState)),
-            ),
-          ),
+        content: JSON.parse(
+          JSON.stringify(this.editor.serializer.serialize(editorState)),
         ),
       },
     })

--- a/packages/styleguide/src/components/Chart/ScatterPlots.js
+++ b/packages/styleguide/src/components/Chart/ScatterPlots.js
@@ -139,13 +139,13 @@ const ScatterPlot = ({
       ticks: xLines ? xLines.map(tickAccessor) : xTicks,
     },
   ) // xUnit is rendered separately
-  const plotXLines =
+  let plotXLines =
     xLines ||
     (
       xTicks || (xScale === 'log' ? get3EqualDistTicks(plotX) : xAxis.ticks)
     ).map((tick) => ({ tick }))
   // ensure highest value is last: the last value is labelled with the unit
-  plotXLines.sort((a, b) => ascending(a.tick, b.tick))
+  plotXLines = plotXLines.slice().sort((a, b) => ascending(a.tick, b.tick))
 
   // setup y axis
   const yValues = aggregateValues(data, yAccessor, yTicks, yLines)


### PR DESCRIPTION
`sort` sorts the array in place, which caused a bug in our scatter plots.

https://stackoverflow.com/questions/53420055/error-while-sorting-array-of-objects-cannot-assign-to-read-only-property-2-of