### PR TITLE
fix(InterviewAnswer): replace wrapping div with css class

### DIFF
--- a/packages/styleguide/src/components/Typography/Editorial.tsx
+++ b/packages/styleguide/src/components/Typography/Editorial.tsx
@@ -245,6 +245,7 @@ const paragraph = css({
 type ParagraphProps = {
   children: React.ReactNode
   attributes?: React.ComponentPropsWithoutRef<'p'>
+  noMarginTop?: boolean
 } & React.ComponentPropsWithoutRef<'p'>
 
 export const P = ({ children, attributes, noMarginTop, ...props }: ParagraphProps) => {

--- a/packages/styleguide/src/components/Typography/Editorial.tsx
+++ b/packages/styleguide/src/components/Typography/Editorial.tsx
@@ -218,24 +218,6 @@ export const Format = ({
   )
 }
 
-const noTopMargin = css({
-  margin: '-22px 0 22px 0',
-  [mUp]: {
-    margin: `-${pxToRem(30)} 0 ${pxToRem(30)} 0`,
-  },
-  ':last-child': {
-    marginBottom: 0,
-  },
-})
-
-export const NoTopMargin = ({ children, attributes, ...props }) => {
-  return (
-    <div {...attributes} {...props} {...noTopMargin}>
-      {children}
-    </div>
-  )
-}
-
 const paragraph = css({
   margin: '22px 0 22px 0',
   ...convertStyleToRem(styles.serifRegular17),
@@ -245,6 +227,12 @@ const paragraph = css({
   },
   ':first-child': {
     marginTop: 0,
+  },
+  '&.no-margin-top': {
+    marginTop: -22,
+    [mUp]: {
+      marginTop: `-${pxToRem(30)}`,
+    },
   },
   ':last-child': {
     marginBottom: 0,
@@ -259,11 +247,16 @@ type ParagraphProps = {
   attributes?: React.ComponentPropsWithoutRef<'p'>
 } & React.ComponentPropsWithoutRef<'p'>
 
-export const P = ({ children, attributes, ...props }: ParagraphProps) => {
+export const P = ({ children, attributes, noMarginTop, ...props }: ParagraphProps) => {
   const [colorScheme] = useColorContext()
+  const className = [
+    attributes?.className,
+    noMarginTop && 'no-margin-top'
+  ].filter(Boolean).join(' ')
   return (
     <p
       {...attributes}
+      className={className}
       {...props}
       {...paragraph}
       {...colorScheme.set('color', 'text')}

--- a/packages/styleguide/src/templates/Article/base.js
+++ b/packages/styleguide/src/templates/Article/base.js
@@ -140,6 +140,11 @@ const createBase = ({ metaBody, metaHeadlines, Link = DefaultLink }) => {
 
   const paragraph = {
     matchMdast: matchParagraph,
+    props: (node, index, parent) => {
+      return {
+        noMarginTop: matchZone('INTERVIEWANSWER')(parent),
+      }
+    },
     component: Typography.P,
     editorModule: 'paragraph',
     editorOptions: {

--- a/packages/styleguide/src/templates/Article/blocks.js
+++ b/packages/styleguide/src/templates/Article/blocks.js
@@ -44,7 +44,6 @@ import {
 } from './utils'
 
 import { slug } from '../../lib/slug'
-import { NoTopMargin } from "../../components/Typography/Editorial";
 
 const createBlocks = ({ base, COVER_TYPE, t, onAudioCoverClick }) => {
   const createInfoBox = ({ t }) => ({
@@ -174,7 +173,7 @@ const createBlocks = ({ base, COVER_TYPE, t, onAudioCoverClick }) => {
       }
     },
     component: ({ isEmpty, children }) =>
-      isEmpty ? null : <NoTopMargin>{children}</NoTopMargin>,
+      isEmpty ? null : children,
     editorModule: 'interviewAnswer',
     editorOptions: {
       type: 'INTERVIEWANSWER',


### PR DESCRIPTION
Replace wrapping `div` around interview-answer `p` with a `no-top-margin` class, in the hope it fixes our pdf problem.