### PR TITLE
Fix Image Copy on Commit

### DIFF
--- a/packages/backend-modules/documents/lib/mdast/process.js
+++ b/packages/backend-modules/documents/lib/mdast/process.js
@@ -43,7 +43,7 @@ const processRepoImageUrlsInContent = async (content, fn) => {
     }
   })
 
-  return Promise.all(fns.map((fn) => fn()))
+  return Promise.each(fns, fn => fn())
 }
 
 const processEmbedImageUrlsInContent = async (mdast, fn) => {
@@ -64,7 +64,7 @@ const processEmbedImageUrlsInContent = async (mdast, fn) => {
     }
   })
 
-  return Promise.all(fns.map((fn) => fn()))
+  return Promise.each(fns, fn => fn())
 }
 
 const processEmbedsInContent = async (mdast, fn, context) => {

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/commit.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/commit.js
@@ -32,15 +32,20 @@ const {
 } = require('@orbiting/backend-modules-documents')
 
 const generateImageData = async (blob) => {
-  const meta = await sharp(blob).metadata()
-  const suffix = meta.format
-  const hash = hashObject(blob)
-  const path = `images/${hash}.${suffix}`
-  return {
-    blob,
-    hash,
-    path,
-    meta,
+  try {
+    const meta = await sharp(blob).metadata()
+    const suffix = meta.format
+    const hash = hashObject(blob)
+    const path = `images/${hash}.${suffix}`
+    return {
+      blob,
+      hash,
+      path,
+      meta,
+    }
+  } catch (e) {
+    console.error(e)
+    throw new Error(e)
   }
 }
 


### PR DESCRIPTION
**The problem:** when processing a document with loads of images to copy, too many requests were made at once. This caused the asset server to crash and the commit to fail.

**The solution:** we now copy images sychronously. It takes a lot longer, and the backend might randomly hang up, but it works most of the time.