### PR TITLE
fix: harden regex with try catch

### DIFF
--- a/apps/www/components/Profile/ProfileView/ProfileUrls.tsx
+++ b/apps/www/components/Profile/ProfileView/ProfileUrls.tsx
@@ -2,23 +2,43 @@ import ProfileUrlIcon from '../Common/ProfileUrlIcon'
 import { IconButton } from '@project-r/styleguide'
 
 const ProfileUrlLabel = (url: string) => {
-  if (/bsky\.app/.test(url)) {
-    return url?.match(/\/profile\/([^/\s]+)/)[1] ?? 'Bluesky'
-  } else if (/facebook\.com/.test(url)) {
-    return 'Facebook'
-  } else if (/x\.com/.test(url)) {
-    return url?.match(/x\.com\/([^/\s]+)/)[1] ?? 'X'
-  } else if (/threema\.id/.test(url)) {
-    return url?.match(/\/threema\.id\/([^/\s]+)/)[1] ?? 'Threema'
-  } else if (/signal\.me/.test(url)) {
-    return 'Signal'
-  } else if (/linkedin\.com/.test(url)) {
-    return 'LinkedIn'
-  } else if (/\/@.+@/.test(url) || /mastodon/.test(url)) {
-    return url?.match(/@[A-Za-z0-9]+/)[0] ?? 'Mastodon'
-  } else {
-    const urlObject = new URL(url)
-    return urlObject.host ?? url
+  try {
+    if (/bsky\.app/.test(url)) {
+      try {
+        return url?.match(/\/profile\/([^/\s]+)/)[1] ?? 'Bluesky'
+      } catch (e) {
+        return 'Bluesky'
+      }
+    } else if (/facebook\.com/.test(url)) {
+      return 'Facebook'
+    } else if (/x\.com/.test(url)) {
+      try {
+        return url?.match(/x\.com\/([^/\s]+)/)[1] ?? 'X'
+      } catch (e) {
+        return 'X'
+      }
+    } else if (/threema\.id/.test(url)) {
+      try {
+        return url?.match(/\/threema\.id\/([^/\s]+)/)[1] ?? 'Threema'
+      } catch (e) {
+        return 'Threema'
+      }
+    } else if (/signal\.me/.test(url)) {
+      return 'Signal'
+    } else if (/linkedin\.com/.test(url)) {
+      return 'LinkedIn'
+    } else if (/\/@.+@/.test(url) || /mastodon/.test(url)) {
+      try {
+        return url?.match(/@[A-Za-z0-9]+/)[0] ?? 'Mastodon'
+      } catch (e) {
+        return 'Mastodon'
+      }
+    } else {
+      const urlObject = new URL(url)
+      return urlObject.host ?? url
+    }
+  } catch (e) {
+    return url
   }
 }
 


### PR DESCRIPTION
If users had invalid urls stored (could be during migration or an edge case that is not caught with the url validator) the site crashes. The regex typeerror should never crash the site but fallback gracefully to a default value