### PR TITLE
chore: remove links to package ABO to force redirect to new shop

### DIFF
--- a/apps/www/components/Account/Memberships/Manage.js
+++ b/apps/www/components/Account/Memberships/Manage.js
@@ -97,7 +97,6 @@ const Actions = ({
                     <Link
                       href={{
                         pathname: '/angebote',
-                        query: { package: 'ABO' },
                       }}
                       passHref
                       legacyBehavior>

--- a/apps/www/components/Account/Memberships/Manage.js
+++ b/apps/www/components/Account/Memberships/Manage.js
@@ -97,6 +97,7 @@ const Actions = ({
                     <Link
                       href={{
                         pathname: '/angebote',
+                        query: { package: 'ABO' },
                       }}
                       passHref
                       legacyBehavior>

--- a/apps/www/components/Frame/ProlongBox.js
+++ b/apps/www/components/Frame/ProlongBox.js
@@ -151,7 +151,7 @@ const ProlongBox = ({ t, prolongBeforeDate, membership }) => {
           {buttonText && !membership.canProlong && (
             <Link
               key='link'
-              href={{ pathname: `/angebote`, query: { package: 'ABO' } }}
+              href={{ pathname: `/angebote`}}
               passHref
               prefetch={false}
               legacyBehavior

--- a/apps/www/pages/teilen.js
+++ b/apps/www/pages/teilen.js
@@ -1,16 +1,14 @@
-import { useState } from 'react'
-import Link from 'next/link'
 import { Interaction } from '@project-r/styleguide'
 
 import { t, useTranslation } from '../lib/withT'
 import { withDefaultSSR } from '../lib/apollo/helpers'
 import { useMe } from '../lib/context/MeContext'
-import { PackageBuffer, PackageItem } from '../components/Pledge/Accordion'
 import AccessCampaigns from '../components/Access/Campaigns'
 import Frame from '../components/Frame'
 import SignIn from '../components/Auth/SignIn'
 import { useInNativeApp } from '../lib/withInNativeApp'
 import { CDN_FRONTEND_BASE_URL } from '../lib/constants'
+import { Offers } from '@app/components/paynote-overlay/paynote-offers'
 
 const meta = {
   title: t('pages/access/title'),
@@ -22,7 +20,6 @@ const Page = () => {
   const { inNativeIOSApp } = useInNativeApp()
   const { t } = useTranslation()
   const { me, hasActiveMembership } = useMe()
-  const [hover, setHover] = useState()
 
   return (
     <Frame meta={meta}>
@@ -37,40 +34,10 @@ const Page = () => {
       )}
       {me && !hasActiveMembership && !inNativeIOSApp && (
         <div style={{ marginTop: 36 }}>
-          <Interaction.H2 style={{ marginBottom: 10 }}>
+          <Interaction.H2 style={{ marginBottom: 36 }}>
             {t('Account/Access/Campaigns/becomeMamber/title')}
           </Interaction.H2>
-          <Link
-            href={{
-              pathname: '/angebote',
-            }}
-            passHref
-            legacyBehavior
-          >
-            <PackageItem
-              t={t}
-              name='ABO'
-              hover={hover}
-              setHover={setHover}
-              price={24000}
-            />
-          </Link>
-          <Link
-            href={{
-              pathname: '/angebote',
-            }}
-            passHref
-            legacyBehavior
-          >
-            <PackageItem
-              t={t}
-              name='MONTHLY_ABO'
-              hover={hover}
-              setHover={setHover}
-              price={2200}
-            />
-          </Link>
-          <PackageBuffer />
+          <Offers />
         </div>
       )}
     </Frame>

--- a/apps/www/pages/teilen.js
+++ b/apps/www/pages/teilen.js
@@ -43,7 +43,6 @@ const Page = () => {
           <Link
             href={{
               pathname: '/angebote',
-              query: { package: 'ABO' },
             }}
             passHref
             legacyBehavior
@@ -59,7 +58,6 @@ const Page = () => {
           <Link
             href={{
               pathname: '/angebote',
-              query: { package: 'MONTHLY_ABO' },
             }}
             passHref
             legacyBehavior


### PR DESCRIPTION
~~apps/www/components/Account/Memberships/Manage.js~~
~~Users with yearly abo and monthly abo are now directed to shop when they click on "Jahresmitgliedschaft kaufen" button~~ *needs to stay with ABO since we can't upsell new packages yet

apps/www/components/Frame/ProlongBox.js
The Prolongbox links to the new shop if the membership that is expiring can't be prolonged (yearly_abo for example) !membership.canProlong

apps/www/pages/teilen.js
The hard coded paynote on the teilen page now links to the new shop overview for both monthly and yearly