### PR TITLE
fix: deactivate and winback transactionals

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/deactivate.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/deactivate.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 
 const createCache = require('../cache')
 const { activeMembershipsQuery } = require('./changeover')
+const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
 const deactivate = async (
   { dryRun },
@@ -59,7 +60,10 @@ const deactivate = async (
 
     await enforceSubscriptions({ userId: membership.userId, pgdb })
 
-    if (membership.renew) {
+    const user = {id: membership.userId }
+    const hasActiveMagazineAccess = hasUserActiveMembership(user, pgdb)
+
+    if (membership.renew && !hasActiveMagazineAccess) {
       await sendMembershipDeactivated({ membership, pgdb, t })
     }
   })


### PR DESCRIPTION
do not send end of membership transactionals in case a new subscription is bought in the grace period