### PR TITLE
fix: filter out incomplete_expired in hasUserActiveMembership

### DIFF
--- a/packages/backend-modules/utils/hasUserActiveMembership.js
+++ b/packages/backend-modules/utils/hasUserActiveMembership.js
@@ -4,7 +4,7 @@ module.exports = async (user, pgdb) => {
         (
           (
             SELECT COUNT(*) FROM payments.subscriptions s
-            WHERE s."userId" = :userId and s.status not in ('paused', 'canceled', 'incomplete')
+            WHERE s."userId" = :userId and s.status not in ('paused', 'canceled', 'incomplete', 'incomplete_expired')
           )
           +
           (


### PR DESCRIPTION
Fixes the hasUserActiveMembership check to exclude subscriptions in the incomplete_expired state.

Subscriptions that are incomplete change to the incomplete_expired state after 24 hours.