### PR TITLE
fix(scheduler): limit the time reange for the yearly prolong mail

### DIFF
--- a/packages/backend-modules/republik-crowdfundings/lib/scheduler/owners.js
+++ b/packages/backend-modules/republik-crowdfundings/lib/scheduler/owners.js
@@ -220,7 +220,7 @@ const createJobs = (now) => [
     name: 'membership_owner_prolong_yearly_abo_notice_0',
     prolongBefore: {
       minDate: getMinEndDate(now, -3),
-      maxDate: getMaxEndDate(now, 0),
+      maxDate: moment(now),
     },
     payload: {
       templateName: 'membership_owner_prolong_yearly_abo_notice_0',


### PR DESCRIPTION
# Notes about the date range of this job

The result of the `getMinEndDate` function should not have a real effect considering that this job is run every 10 minutes.
Unless someone edited a membership in the database directly, there should never be a case where a `YEARLY_ABO` is 3 days past due and has not received this mail. The behaviour is left in place to cover these edge cases.

Since the new shop only allows purchasing a new subscription if there is no active membership, the `maxEndDate` has been set to the time when this job is run to prevent users from receiving this email before their membership runs out.