### PR TITLE
fix: update refresh_member_role to check for subscriptions

### DIFF
--- a/packages/backend-modules/migrations/migrations/20250317141543-update-refresh-member-role.js
+++ b/packages/backend-modules/migrations/migrations/20250317141543-update-refresh-member-role.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/payments/migrations/sql'
+const file = '20250317141543-update-refresh-member-role'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/payments/lib/handlers/stripe/subscriptionDeleted.ts
+++ b/packages/backend-modules/payments/lib/handlers/stripe/subscriptionDeleted.ts
@@ -9,7 +9,6 @@ import {
   REPUBLIK_PAYMENTS_MAIL_SETTINGS_KEY,
 } from '../../mail-settings'
 import { secondsToMilliseconds } from './utils'
-import { REPUBLIK_PAYMENTS_CANCEL_REASON } from '../../shop/gifts'
 
 export async function processSubscriptionDeleted(
   paymentService: PaymentService,
@@ -27,9 +26,6 @@ export async function processSubscriptionDeleted(
       endedAt: new Date(endTimestamp),
       canceledAt: new Date(canceledAtTimestamp),
     },
-    event.data.object.metadata[REPUBLIK_PAYMENTS_CANCEL_REASON] === 'UPGRADE'
-      ? { keepMembership: true }
-      : undefined,
   )
 
   const customerId = event.data.object.customer as string

--- a/packages/backend-modules/payments/migrations/sql/20250317141543-update-refresh-member-role-down.sql
+++ b/packages/backend-modules/payments/migrations/sql/20250317141543-update-refresh-member-role-down.sql
@@ -1,0 +1,27 @@
+-- migrate down here: DROP TABLE...
+CREATE OR REPLACE FUNCTION public.refresh_member_role(user_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+   _active boolean;
+   _role text := 'member';
+BEGIN
+  -- Revert to checking only active memberships
+  SELECT
+    COALESCE(bool_or(active), false) INTO _active
+  FROM
+    memberships m
+  JOIN
+    users u
+    ON m."userId"=u.id
+  WHERE
+    u.id = user_id;
+
+  IF _active = true THEN
+    PERFORM add_user_to_role(user_id, _role);
+  ELSE
+    PERFORM remove_user_from_role(user_id, _role);
+  END IF;
+END;
+$function$

--- a/packages/backend-modules/payments/migrations/sql/20250317141543-update-refresh-member-role-up.sql
+++ b/packages/backend-modules/payments/migrations/sql/20250317141543-update-refresh-member-role-up.sql
@@ -1,0 +1,34 @@
+-- migrate up here: CREATE TABLE...
+
+-- replace refresh_member_role in packages/backend-modules/republik/migrations/sqls/20180402175144-fix-membership-trigger-up.sql
+-- to keep the member role if the user has an active subscription.
+CREATE OR REPLACE FUNCTION public.refresh_member_role(user_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+   _active boolean;
+   _role text := 'member';
+BEGIN
+  -- Check if the user has an active membership or an active subscription
+  SELECT
+    COALESCE(bool_or(m.active), false) OR
+    EXISTS (
+      SELECT 1 FROM payments.subscriptions s
+      WHERE s."userId" = user_id
+      AND s.status NOT IN ('paused', 'canceled', 'incomplete', 'incomplete_expired')
+    ) INTO _active
+  FROM
+    users u
+  LEFT JOIN
+    memberships m ON m."userId" = u.id
+  WHERE
+    u.id = user_id;
+
+  IF _active = true THEN
+    PERFORM add_user_to_role(user_id, _role);
+  ELSE
+    PERFORM remove_user_from_role(user_id, _role);
+  END IF;
+END;
+$function$


### PR DESCRIPTION
updates the refresh_member_role postgres function to check for the existence of a active subscription to determine if it should remove the `member` role