### PR TITLE
feat(backend): improve gql error logging

### DIFF
--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -9,7 +9,6 @@ const { transformUser } = require('@orbiting/backend-modules-auth')
 const {
   COOKIE_NAME,
 } = require('@orbiting/backend-modules-auth/lib/CookieOptions')
-const util = require('util')
 
 const { NODE_ENV, WS_KEEPALIVE_INTERVAL } = process.env
 
@@ -98,7 +97,6 @@ module.exports = async (
       connection
         ? connection.context
         : createContext({ user: req.user, req, res, scope: 'request' }),
-    debug: true,
     cache: 'bounded',
     introspection: true,
     playground: false, // see ./graphiql.js
@@ -106,16 +104,6 @@ module.exports = async (
     subscriptions: {
       onConnect: webSocketOnConnect,
       keepAlive: WS_KEEPALIVE_INTERVAL || 40000,
-    },
-    formatError: (error) => {
-      console.log(
-        `graphql error in ${this.operationName} (${JSON.stringify(
-          this.variables,
-        )}):`,
-        util.inspect(error, { depth: null, colors: true, breakLength: 300 }),
-      )
-      delete error.extensions.exception
-      return error
     },
     formatResponse: (response, { context }) => {
       // strip problematic character (\u2028) for requests from our iOS app
@@ -131,6 +119,20 @@ module.exports = async (
       }
       return response
     },
+    plugins: [
+      {
+        async requestDidStart() {
+          return {
+            async didEncounterErrors({ context, errors }) {
+              console.error('GRAPHQL REQUEST ERROR', {
+                ...context.req._log(),
+                graphQLErrors: errors,
+              })
+            },
+          }
+        },
+      },
+    ],
   })
 
   // setup websocket server

--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -125,7 +125,7 @@ module.exports = async (
           return {
             async didEncounterErrors({ context, errors }) {
               console.error('GRAPHQL REQUEST ERROR', {
-                ...context.req._log(),
+                req: context.req._log(),
                 graphQLErrors: errors,
               })
             },

--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -9,7 +9,7 @@ const { transformUser } = require('@orbiting/backend-modules-auth')
 const {
   COOKIE_NAME,
 } = require('@orbiting/backend-modules-auth/lib/CookieOptions')
-
+const util = require('util')
 const { NODE_ENV, WS_KEEPALIVE_INTERVAL } = process.env
 
 const documentApiKeyScheme = 'DocumentApiKey'
@@ -124,10 +124,16 @@ module.exports = async (
         async requestDidStart() {
           return {
             async didEncounterErrors({ context, errors }) {
-              console.error('GRAPHQL REQUEST ERROR', {
-                req: context.req._log(),
-                graphQLErrors: errors,
-              })
+              console.error(
+                'GRAPHQL REQUEST ERROR',
+                util.inspect(
+                  {
+                    req: context.req._log(),
+                    graphQLErrors: errors,
+                  },
+                  { depth: null, colors: true, breakLength: 300 },
+                ),
+              )
             },
           }
         },

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -104,7 +104,7 @@ const start = async (
   if (REQ_TIMEOUT) {
     server.use(timeout(REQ_TIMEOUT, { respond: false }), (req, res, next) => {
       req.on('timeout', () => {
-        console.log('request timedout:', req._log())
+        console.error('REQUEST TIMEOUT ERROR', { req: req._log() })
       })
       next()
     })

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -104,7 +104,7 @@ const start = async (
   if (REQ_TIMEOUT) {
     server.use(timeout(REQ_TIMEOUT, { respond: false }), (req, res, next) => {
       req.on('timeout', () => {
-        console.error('REQUEST TIMEOUT ERROR', { req: req._log() })
+        console.error('REQUEST TIMEOUT ERROR', req._log())
       })
       next()
     })


### PR DESCRIPTION
- Don't log errors in `formatError` – that's not what it's intended for 😓 
- Use a ApolloServer plugin for logging, which has access to the request context (and thus, the `req._log()` function)
- Remove `debug: true` and thus the need to delete the exception from the client response. This way, it's [automatically omitted in production](https://www.apollographql.com/docs/apollo-server/v3/data/errors#omitting-or-including-stacktrace)