### PR TITLE
fix(publikator): catch parse/serialize error when committing document

### DIFF
--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -704,44 +704,56 @@ export class EditorPage extends Component {
 
     const isNew = commitId === 'new'
 
-    commitMutation({
-      repoId,
-      parentId: isNew ? null : commitId,
-      isTemplate: isNew ? isTemplate === 'true' : data?.repo?.isTemplate,
-      message: message,
-      document: {
-        content: parse(
-          stringify(
-            JSON.parse(
-              JSON.stringify(this.editor.serializer.serialize(editorState)),
+    try {
+      commitMutation({
+        repoId,
+        parentId: isNew ? null : commitId,
+        isTemplate: isNew ? isTemplate === 'true' : data?.repo?.isTemplate,
+        message: message,
+        document: {
+          content: parse(
+            stringify(
+              JSON.parse(
+                JSON.stringify(this.editor.serializer.serialize(editorState)),
+              ),
             ),
           ),
-        ),
-      },
-    })
-      .then(({ data }) => {
-        if (publishDate) {
-          editRepoMeta({
-            repoId,
-            publishDate,
-          }).then(() => {
+        },
+      })
+        .then(({ data }) => {
+          if (publishDate) {
+            editRepoMeta({
+              repoId,
+              publishDate,
+            }).then(() => {
+              this.commitCleanup(data)
+            })
+          } else {
             this.commitCleanup(data)
-          })
-        } else {
-          this.commitCleanup(data)
-        }
-      })
-      .catch((e) => {
-        console.error(e)
-        this.setState((state) => ({
-          committing: false,
-          ...addWarning(
-            t('commit/warn/failed', {
-              error: errorToString(e),
-            }),
-          )(state),
-        }))
-      })
+          }
+        })
+        .catch((e) => {
+          console.error(e)
+          this.setState((state) => ({
+            committing: false,
+            ...addWarning(
+              t('commit/warn/failed', {
+                error: errorToString(e),
+              }),
+            )(state),
+          }))
+        })
+    } catch (e) {
+      console.error(e)
+      this.setState((state) => ({
+        committing: false,
+        ...addWarning(
+          t('commit/warn/failed', {
+            error: errorToString(e),
+          }),
+        )(state),
+      }))
+    }
   }
 
   goToRaw(isTemplate) {


### PR DESCRIPTION
A quick and dirty fix for when a document cannot be parsed/serialized during a commit. The existing code would only catch GraphQL errors.

Instead of showing the spinner indefinitely, this is now displayed like other errors:

<img width="313" alt="image" src="https://github.com/user-attachments/assets/7e3802f4-0ad8-4877-b942-7b4cad10f66b" />


The real solution is to avoid transforming back-and-forth between Markdown and MDAST, like in #963