### PR TITLE
feat(backend): log gql and timeout errors as single-line json

### DIFF
--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -123,16 +123,13 @@ module.exports = async (
       {
         async requestDidStart() {
           return {
-            async didEncounterErrors({ context, errors }) {
+            async didEncounterErrors({ context }) {
               console.error(
-                'GRAPHQL REQUEST ERROR',
-                util.inspect(
-                  {
-                    req: context.req._log(),
-                    graphQLErrors: errors,
-                  },
-                  { depth: null, colors: true, breakLength: 300 },
-                ),
+                JSON.stringify({
+                  req: context.req._log(),
+                  message: `GraphQL Request Error`,
+                  level: 'ERROR',
+                }),
               )
             },
           }

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -104,7 +104,13 @@ const start = async (
   if (REQ_TIMEOUT) {
     server.use(timeout(REQ_TIMEOUT, { respond: false }), (req, res, next) => {
       req.on('timeout', () => {
-        console.error('REQUEST TIMEOUT ERROR', req._log())
+        console.error(
+          JSON.stringify({
+            req: req._log(),
+            message: 'Request Timeout',
+            level: 'ERROR',
+          }),
+        )
       })
       next()
     })


### PR DESCRIPTION
Logging errors as a single-line JSON is vastly better than logging multi-line messages to the console.

Mezmo can automatically parse this JSON, and will extract the `message` and `level` automatically.