### PR TITLE
Configure database migrations to have a lock_timeout

### DIFF
--- a/.db-migraterc
+++ b/.db-migraterc
@@ -1,0 +1,7 @@
+{
+  "driver": "pg",
+  "connectionString": "${DATABASE_URL}?lock_timeout=5000",
+  "migrationsTable": "migrations",
+  "schema": "public",
+  "charset": "utf8"
+}


### PR DESCRIPTION
Because of recurring issues with database locks (due to long running queries), it would make sense to set a lock_timeout for database migrations. 
Docs on our db-migrate module: https://db-migrate.readthedocs.io/en/latest/Getting%20Started/configuration/#database_url
