### PR TITLE
add external-link to account page

### DIFF
--- a/apps/www/components/Account/Memberships/index.js
+++ b/apps/www/components/Account/Memberships/index.js
@@ -13,7 +13,7 @@ import AccessGrants from '../../Access/Grants'
 import withMembership from '../../Auth/withMembership'
 import Box from '../../Frame/Box'
 
-import { Interaction, useColorContext } from '@project-r/styleguide'
+import { Interaction, useColorContext, A } from '@project-r/styleguide'
 
 import belongingsQuery from '../belongingsQuery'
 import MembershipList from '../Memberships/List'
@@ -37,7 +37,7 @@ const Memberships = ({
   activeMagazineSubscription,
 }) => {
   const { query } = useRouter()
-  const { inNativeIOSApp } = useInNativeApp()
+  const { inNativeIOSApp, isMinimalNativeAppVersion } = useInNativeApp()
   const [colorScheme] = useColorContext()
 
   useEffect(() => {
@@ -73,10 +73,28 @@ const Memberships = ({
                 <UserGuidance />
               </div>
             )}
-            {inNativeIOSApp && (
+            {inNativeIOSApp(
               <AccountBox>
-                <P>{t('account/ios/box')}</P>
-              </AccountBox>
+                {isMinimalNativeAppVersion('2.3.0') ? (
+                  <P>
+                    Verwalten Sie Ihr Konto im Web.
+                    <br />
+                    <A
+                      href='#'
+                      onClick={(e) => {
+                        e.preventDefault()
+                        postMessage({
+                          type: 'external-link',
+                        })
+                      }}
+                    >
+                      shop.republik.ch
+                    </A>
+                  </P>
+                ) : (
+                  <P>{t('account/ios/box')}</P>
+                )}
+              </AccountBox>,
             )}
 
             {/* Account Section, hide in iOS */}

--- a/apps/www/components/Account/Memberships/index.js
+++ b/apps/www/components/Account/Memberships/index.js
@@ -73,7 +73,7 @@ const Memberships = ({
                 <UserGuidance />
               </div>
             )}
-            {inNativeIOSApp(
+            {inNativeIOSApp && (
               <AccountBox>
                 {isMinimalNativeAppVersion('2.3.0') ? (
                   <P>
@@ -94,7 +94,7 @@ const Memberships = ({
                 ) : (
                   <P>{t('account/ios/box')}</P>
                 )}
-              </AccountBox>,
+              </AccountBox>
             )}
 
             {/* Account Section, hide in iOS */}

--- a/apps/www/components/Account/Memberships/index.js
+++ b/apps/www/components/Account/Memberships/index.js
@@ -4,7 +4,7 @@ import compose from 'lodash/flowRight'
 import { graphql } from '@apollo/client/react/hoc'
 
 import withT from '../../../lib/withT'
-import { useInNativeApp } from '../../../lib/withInNativeApp'
+import { useInNativeApp, postMessage } from '../../../lib/withInNativeApp'
 
 import Loader from '../../Loader'
 import UserGuidance from '../UserGuidance'


### PR DESCRIPTION
Shows a link to shop only in iOS Apps with version 2.3 or higher.
<img width="346" alt="Screenshot 2025-04-23 at 08 01 14" src="https://github.com/user-attachments/assets/95c9593e-44fc-4fb1-a101-62ebd7e678bd" />
