### PR TITLE
only send metering status for regwall events

### DIFF
--- a/apps/www/src/components/paynotes/regwall/index.tsx
+++ b/apps/www/src/components/paynotes/regwall/index.tsx
@@ -26,11 +26,16 @@ const Regwall = () => {
     })
   }, [trackEvent])
 
+  const analyticsProps = {
+    variation,
+    ...getMeteringData(),
+  }
+
   return (
     <PaynoteContainer>
-      <Trial analyticsProps={{ variation }} />
+      <Trial analyticsProps={analyticsProps} />
       <Offers
-        analyticsProps={{ variation }}
+        analyticsProps={analyticsProps}
         additionalShopParams={{
           rep_ui_component: 'regwall',
           rep_regwall_variation: variation,

--- a/apps/www/src/lib/analytics/provider.tsx
+++ b/apps/www/src/lib/analytics/provider.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { getMeteringData } from '@app/components/paynotes/article-metering'
 import { useMe } from 'lib/context/MeContext'
 import PlausibleProvider from 'next-plausible'
 
@@ -10,8 +9,6 @@ type AnalyticsProviderProps = Omit<
 
 export const AnalyticsProvider = (props: AnalyticsProviderProps) => {
   const { me, hasActiveMembership, trialStatus, meLoading } = useMe()
-  const meteringData = getMeteringData()
-  // console.log('provider', { meteringData })
 
   return (
     <PlausibleProvider
@@ -25,7 +22,6 @@ export const AnalyticsProvider = (props: AnalyticsProviderProps) => {
           ? 'logged in'
           : 'anonymous',
         trial_status: trialStatus, // keeping the user_type too, as not to break compatibilty by deleting  the "user_type" prop.
-        ...meteringData,
       }}
       // Defer enabling analytics until me query has been loaded. This should still reliably track the 1st page view, just a bit later.
       enabled={!meLoading}


### PR DESCRIPTION
We were sending the metering cohort in the analytics provider, which caused only techincal issues, as i suspect the provider would read the values before the window object and localstorage were defined. also if the metering object was created once the provider already existed, this update wouldn't propagate to the provider without some changes to the code.

**As a fix:** we only send the metering cohort where it's relevant, aka as data for the regwall events.