### PR TITLE
remove audio buttons for non-members when they don't make sense

### DIFF
--- a/apps/www/components/ActionBar/index.js
+++ b/apps/www/components/ActionBar/index.js
@@ -1,11 +1,7 @@
 import { useState, Fragment } from 'react'
 import { css } from 'glamor'
 import compose from 'lodash/flowRight'
-import {
-  IconButton,
-  Interaction,
-  shouldIgnoreClick,
-} from '@project-r/styleguide'
+import { IconButton, shouldIgnoreClick } from '@project-r/styleguide'
 import withT from '../../lib/withT'
 
 import { postMessage } from '../../lib/withInNativeApp'
@@ -25,7 +21,7 @@ import SubscribeMenu from '../Notifications/SubscribeMenu'
 import BookmarkButton from './BookmarkButton'
 import DiscussionLinkButton from './DiscussionLinkButton'
 import UserProgress from './UserProgress'
-import { canReadFreely, useMe } from '../../lib/context/MeContext'
+import { useMe } from '../../lib/context/MeContext'
 import useAudioQueue from '../Audio/hooks/useAudioQueue'
 import { usePlatformInformation } from '@app/lib/hooks/usePlatformInformation'
 
@@ -72,8 +68,7 @@ const ActionBar = ({
   isCentered,
   shareParam,
 }) => {
-  const { me, meLoading, isEditor, trialStatus } = useMe()
-  const hasAccess = canReadFreely(trialStatus)
+  const { me, meLoading, isEditor, isMember } = useMe()
   const [pdfOverlayVisible, setPdfOverlayVisible] = useState(false)
   const [fontSizeOverlayVisible, setFontSizeOverlayVisible] = useState(false)
   const [shareOverlayVisible, setShareOverlayVisible] = useState(false)
@@ -319,7 +314,7 @@ const ActionBar = ({
         setPdfOverlayVisible(!pdfOverlayVisible)
       },
       modes: ['articleTop', 'articleBottom'],
-      show: hasPdf && hasAccess,
+      show: hasPdf && isMember,
     },
     {
       title: t('article/actionbar/fontSize/title'),
@@ -391,7 +386,7 @@ const ActionBar = ({
         'bookmark',
         'seriesEpisode',
       ],
-      show: !notBookmarkable && (meLoading || hasAccess),
+      show: !notBookmarkable && (meLoading || isMember),
     },
     {
       title: t('article/actionbar/share'),
@@ -500,7 +495,7 @@ const ActionBar = ({
           : play
         : toggleAudioPlayback,
       modes: ['feed', 'seriesEpisode'],
-      show: meta.audioSource?.mp3,
+      show: isMember && meta.audioSource?.mp3,
       group: 'audio',
     },
     {
@@ -532,7 +527,7 @@ const ActionBar = ({
         }
       },
       modes: ['feed', 'seriesEpisode'],
-      show: isAudioQueueAvailable && meta.audioSource?.mp3,
+      show: isMember && isAudioQueueAvailable && meta.audioSource?.mp3,
       group: 'audio',
     },
     {
@@ -569,7 +564,7 @@ const ActionBar = ({
 
   return (
     <div
-      {...(!hasAccess && mode !== 'articleOverlay' && styles.bottomMargin)}
+      {...(!isMember && mode !== 'articleOverlay' && styles.bottomMargin)}
       {...styles.hidePrint}
     >
       <div

--- a/apps/www/components/Audio/AudioPlayer/ArticleAudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/ArticleAudioPlayer.tsx
@@ -100,7 +100,7 @@ export const ArticleAudioPlayer = ({ document }: PlayerProps) => {
 
   const { currentTime } = useGlobalAudioState()
   const { checkIfInQueue } = useAudioQueue()
-  const { hasAccess } = useMe()
+  const { isMember } = useMe()
 
   const isActiveAudioItem = checkIfActivePlayerItem(document.id)
   const itemPlaying = isPlaying && isActiveAudioItem
@@ -199,7 +199,7 @@ export const ArticleAudioPlayer = ({ document }: PlayerProps) => {
         )}
       </div>
 
-      {hasAccess && (
+      {isMember && (
         <IconButton
           Icon={itemInAudioQueue ? IconPlaylistRemove : IconPlaylistAdd}
           title={

--- a/apps/www/components/Audio/AudioPlayer/MiniAudioPlayer.tsx
+++ b/apps/www/components/Audio/AudioPlayer/MiniAudioPlayer.tsx
@@ -14,6 +14,7 @@ import AudioPlayerTitle from './ui/AudioPlayerTitle'
 import AudioCover from '../AudioPlayer/ui/AudioCover'
 import AudioError from './ui/AudioError'
 import { IconClose, IconExpandLess, IconPause, IconPlay } from '@republik/icons'
+import { useMe } from 'lib/context/MeContext'
 
 export const MINI_AUDIO_PLAYER_HEIGHT = 68
 
@@ -88,6 +89,7 @@ const MiniAudioPlayer = ({
   hasError,
 }: MiniAudioPlayerProps) => {
   const isDesktop = useMediaQuery(mediaQueries.mUp)
+  const { isMember } = useMe()
 
   if (!activeItem) {
     handleClose()
@@ -137,13 +139,15 @@ const MiniAudioPlayer = ({
               <Time currentTime={currentTime} duration={duration} />
             </div>
             <div {...styles.buttonWrapper}>
-              <IconButton
-                Icon={IconExpandLess}
-                size={32}
-                fillColorName='text'
-                title={t(`styleguide/AudioPlayer/expand`)}
-                onClick={handleExpand}
-              />
+              {isMember && (
+                <IconButton
+                  Icon={IconExpandLess}
+                  size={32}
+                  fillColorName='text'
+                  title={t(`styleguide/AudioPlayer/expand`)}
+                  onClick={handleExpand}
+                />
+              )}
               <IconButton
                 Icon={IconClose}
                 size={24}

--- a/apps/www/components/Front/index.js
+++ b/apps/www/components/Front/index.js
@@ -251,7 +251,7 @@ const Front = ({
                     href='#'
                     style={{ color: colors.negative.text }}
                     onClick={(event) => {
-                      event && event.preventDefault()
+                      event?.preventDefault()
                       setInfiniteScroll(true)
                     }}
                   >

--- a/apps/www/lib/context/MeContext.tsx
+++ b/apps/www/lib/context/MeContext.tsx
@@ -70,9 +70,6 @@ css.global(`:root [${CLIMATELAB_ONLY_ITEM_ATTRIBUTE}="true"]`, {
 
 export type MeObjectType = MeQuery['me']
 
-export const canReadFreely = (trialStatus?: TrialStatusType): boolean =>
-  ['MEMBER', 'TRIAL_GROUP_A', 'TRIAL_GROUP_B'].includes(trialStatus)
-
 export type TrialStatusType =
   | 'MEMBER' // could also be null
   | 'TRIAL_ELIGIBLE'


### PR DESCRIPTION
for non-members:

- remove play/audio queue buttons from feed
- remove audio queue button from article audio element (anonymous users don't have an audio queue)
- remove expand button from audio player (it expands into the queue manager, which doesn't make sense here)

bonus fix:

- remove clunky `canReadFreely` function and use better `isMember` attribute on `me`.