### PR TITLE
chore: remove pdf purge code for old pdf renderer

### DIFF
--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
@@ -23,7 +23,6 @@ const {
 const {
   Redirections: { get: getRedirections },
 } = require('@orbiting/backend-modules-redirections')
-const { purgeUrls } = require('@orbiting/backend-modules-keyCDN')
 
 const {
   maybeDelcareMilestonePublished,
@@ -402,16 +401,6 @@ module.exports = async (_, args, context) => {
       id: repoId,
     },
   })
-
-  // purge pdfs in CDN
-  const purgeQueries = [
-    '',
-    '?download=1',
-    '?images=0',
-    '?images=0&download=1',
-    '?download=1&images=0',
-  ]
-  await purgeUrls(purgeQueries.map((q) => `/pdf${newPath}.pdf${q}`))
 
   if (!prepublication && !scheduledAt && notifyFilters) {
     await notifyPublish(repoId, notifyFilters, context)

--- a/packages/backend-modules/publikator/package.json
+++ b/packages/backend-modules/publikator/package.json
@@ -20,7 +20,6 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@orbiting/backend-modules-keyCDN": "*",
     "@orbiting/backend-modules-assets": "*",
     "@orbiting/graphql-list-fields": "^2.0.2",
     "@republik/remark-preset": "*",


### PR DESCRIPTION
Removes KeyCDN purge code for pdfs from the publish mutation.

Since the introduction of https://github.com/republik/plattform/pull/996 PDF versions of Articles are no longer hosted on KeyCDN.