### PR TITLE
disallow meta training bot, allow ai search bots and user bots

### DIFF
--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -1,34 +1,60 @@
 User-Agent: *
 Disallow: 
 
+User-agent: AI2Bot
+User-agent: Ai2Bot-Dolma
+User-agent: aiHitBot
 User-agent: Amazonbot
 User-agent: anthropic-ai
 User-agent: Applebot-Extended
 User-agent: AwarioRssBot
 User-agent: AwarioSmartBot
+User-agent: Brightbot 1.0
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ClaudeBot
 User-agent: cohere-ai
+User-agent: cohere-training-data-crawler
+User-agent: Cotoyogi
+User-agent: Crawlspace
 User-agent: DataForSeoBot
 User-agent: Diffbot
 User-agent: FacebookBot
+User-agent: Factset_spyderbot
 User-agent: FriendlyCrawler
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GPTBot
-User-agent: img2dataset
+User-agent: ICC-Crawler
 User-agent: ImagesiftBot
+User-agent: img2dataset
+User-agent: imgproxy
+User-agent: ISSCyberRiskCrawler
+User-agent: Kangaroo Bot
 User-agent: magpie-crawler
 User-agent: Meltwater
 User-agent: meta-externalagent
+User-agent: Meta-ExternalAgent
+User-agent: NovaAct
 User-agent: omgili
 User-agent: omgilibot
+User-agent: Operator
+User-agent: PanguBot
 User-agent: peer39_crawler
 User-agent: peer39_crawler/1.0
-User-agent: PerplexityBot
+User-agent: PetalBot
 User-agent: PiplBot
+User-agent: QualifiedBot
+User-agent: Scrapy
 User-agent: scoop.it
 User-agent: Seekr
+User-agent: SemrushBot-OCOB
+User-agent: SemrushBot-SWA
+User-agent: Sidetrade indexer bot
+User-agent: TikTokSpider
+User-agent: Timpibot
+User-agent: VelenPublicWebCrawler
+User-agent: Webzio-Extended
+User-agent: wpbot
 User-agent: YouBot
 Disallow: /

--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -3,15 +3,12 @@ Disallow:
 
 User-agent: Amazonbot
 User-agent: anthropic-ai
-User-agent: Applebot
 User-agent: Applebot-Extended
 User-agent: AwarioRssBot
 User-agent: AwarioSmartBot
 User-agent: Bytespider
 User-agent: CCBot
-User-agent: ChatGPT-User
 User-agent: ClaudeBot
-User-agent: Claude-Web
 User-agent: cohere-ai
 User-agent: DataForSeoBot
 User-agent: Diffbot
@@ -24,6 +21,7 @@ User-agent: img2dataset
 User-agent: ImagesiftBot
 User-agent: magpie-crawler
 User-agent: Meltwater
+User-agent: meta-externalagent
 User-agent: omgili
 User-agent: omgilibot
 User-agent: peer39_crawler


### PR DESCRIPTION
Tries to make the robot.txt file more coherent by disallowing all training and allowing indexing for search by AI search engines and models to provide users with links to our content in those platforms.

**Disallows**
- [Meta-ExternalAgent](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/), meta's bot for trainig
- A bunch of AI crawlers from: https://github.com/ai-robots-txt/ai.robots.txt/blob/main/robots.txt

**Allows**
- Applebot: Apples search bot. [Only Applebot-Extended is used to train models](https://support.apple.com/en-us/119829):
- ChatGPT-User:  [Not used for training](https://platform.openai.com/docs/bots) but for delivering results from within ChatGPT.
- Claude-Web and Claude-User:[Used for web results in Claude](https://support.anthropic.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler)
- PerplexityBot: [Does not crawl for training.](https://docs.perplexity.ai/guides/bots)