### PR TITLE
add text only option to gender script

### DIFF
--- a/packages/backend-modules/statistics/script/analyzeCredits.js
+++ b/packages/backend-modules/statistics/script/analyzeCredits.js
@@ -119,9 +119,12 @@ PgDb.connect()
 
         let { contributors } = analysis
 
+        // console.log('----------CONTRIBUTORS----------')
+        // console.log(contributors)
         if (textOnly) {
-          contributors = contributors.filter((c) => c.kind === 'Text')
+          contributors = contributors.filter((c) => c.kind?.includes('Text'))
         }
+        // console.log(contributors)
 
         // Unable to determine an author
         if (!contributors.length) {


### PR DESCRIPTION
Add option `text-only` to gender script. When switched on, this option filters out any roles which aren't `Text`