### PR TITLE
fix employees being fetched for following authors/users

### DIFF
--- a/apps/www/components/Notifications/SubscribedAuthors.js
+++ b/apps/www/components/Notifications/SubscribedAuthors.js
@@ -71,11 +71,21 @@ const SubscribedAuthors = ({
       loading={loading}
       error={error}
       render={() => {
-        const subscribedUsers = myUserSubscriptions.subscribedTo.nodes
+        const allSubscribedUsers = myUserSubscriptions.subscribedTo.nodes
+        
+        const subscribedAuthors = allSubscribedUsers
+          .filter((user) => user.userDetails.documents.totalCount > 0)
+          .sort((a, b) => a.object.name.localeCompare(b.object.name))
+        
+          const subscribedUsers = allSubscribedUsers
+          .filter((user) => user.userDetails.documents.totalCount === 0)
+          .sort((a, b) => a.object.name.localeCompare(b.object.name))
+
+        const susbcribedAuthorsAndUsersSorted = subscribedAuthors.concat(subscribedUsers)
 
         const totalSubs =
-          subscribedUsers &&
-          subscribedUsers.filter((user) => user.active).length
+          allSubscribedUsers &&
+          allSubscribedUsers.filter((user) => user.active).length
 
         return (
           <>
@@ -85,7 +95,7 @@ const SubscribedAuthors = ({
               })}
             </Interaction.P>
             <div style={{ margin: '20px 0' }}>
-              {(subscribedUsers).map((user) => (
+              {susbcribedAuthorsAndUsersSorted.map((user) => (
                 <div
                   {...styles.authorContainer}
                   {...authorContainerRule}

--- a/apps/www/components/Notifications/enhancers.js
+++ b/apps/www/components/Notifications/enhancers.js
@@ -178,24 +178,6 @@ export const possibleSubscriptions = gql`
 
 export const myUserSubscriptions = gql`
   query getMyUserSubscriptions {
-    authors: employees(onlyPromotedAuthors: true) {
-      name
-      user {
-        id
-        subscribedByMe {
-          ...subInfo
-          userDetails: object {
-            ... on User {
-              id
-              slug
-              documents {
-                totalCount
-              }
-            }
-          }
-        }
-      }
-    }
     myUserSubscriptions: me {
       id
       subscribedTo(objectType: User) {

--- a/apps/www/components/Onboarding/Page.js
+++ b/apps/www/components/Onboarding/Page.js
@@ -276,7 +276,7 @@ class Page extends Component {
               return <Loader loading={loading} error={error} />
             }
 
-            const { employees, sections, roleStats } = data
+            const { sections } = data
 
             return (
               <Center>


### PR DESCRIPTION
Previously the employees were fetched from the gsheets table to show the above the "normal" users. This is not possible anymore. Instead of doing some complex merge of datocms data and user data, I opted to just render the list of subscribed users alphabetically and do aways with the distinction. Since we're tackling authors next, this should be an acceptable solution until we have a more robust author follow feature. 