### PR TITLE
Server Side Profile fetching

### DIFF
--- a/apps/www/pages/~/[slug].js
+++ b/apps/www/pages/~/[slug].js
@@ -49,7 +49,7 @@ export const getServerSideProps = createGetServerSideProps(
         }
       }
 
-      return { props: { publicUser: user } }
+      return { props: { slug } }
     }
 
     // check if a redirect is registered for this path


### PR DESCRIPTION
Previously, then navigating to ~slug, the server would fetch a users slug if that user had a public profile. That slug was then handed over to the profile component who would fetch userdata client side. This had the issue that if a search engine tried to index a site it would always receive an empty page even for users with public profiles. 

Since we now don't have to prevent links to articles to be displayed, we can query data server-side. The new implementation fetches the entire user profile server-side (not just a slug). This ensures that the page is SEO readable.

If no user is returned server side (private profile), the behaviour remains the same as before: a 404 page is shown. 

To enable the fetchMore function, an apollo client is initialized with the server-side fetched data as a cache, so that no duplicate request are made on page load.

In addition it adds structured data to help the public user sites being discovered and understood by search engines.
