### PR TITLE
Use materialised views for cockpit cache

### DIFF
--- a/apps/api/server.js
+++ b/apps/api/server.js
@@ -82,6 +82,7 @@ const MailScheduler = require('@orbiting/backend-modules-mail/lib/scheduler')
 const mail = require('@orbiting/backend-modules-republik-crowdfundings/lib/Mail')
 
 const { Queue, GlobalQueue } = require('@orbiting/backend-modules-job-queue')
+const { CockpitWorker } = require('./workers/cockpit')
 
 function setupQueue(context, monitorQueueState = undefined) {
   const queue = Queue.createInstance(GlobalQueue, {
@@ -104,6 +105,7 @@ function setupQueue(context, monitorQueueState = undefined) {
     SyncMailchimpSetupWorker,
     SyncMailchimpUpdateWorker,
     SyncMailchimpEndedWorker,
+    CockpitWorker,
   ])
 
   return queue
@@ -361,6 +363,10 @@ const runOnce = async () => {
   const queue = setupQueue(connectionContext, 120)
   await queue.start()
   await queue.startWorkers()
+  await queue.schedule(
+    'cockpit:refresh',
+    '*/30 * * * *', // cron for every 30 minutes
+  )
 
   const close = async () => {
     await Promise.all(

--- a/apps/api/workers/cockpit.js
+++ b/apps/api/workers/cockpit.js
@@ -1,0 +1,21 @@
+const { BaseWorker } = require('@orbiting/backend-modules-job-queue')
+
+class CockpitWorker extends BaseWorker {
+  constructor(pgboss, context) {
+    super(pgboss, context)
+    this.queue = 'cockpit:refresh'
+  }
+
+  async perform(_) {
+    await this.context.pgdb.query(`
+      REFRESH MATERIALIZED VIEW cockpit_membership_evolution;
+      REFRESH MATERIALIZED VIEW cockpit_membership_last_seen;
+      REFRESH MATERIALIZED VIEW cockpit_discussions_evolution;
+      REFRESH MATERIALIZED VIEW cockpit_collections_evolution;
+    `)
+  }
+}
+
+module.exports = {
+  CockpitWorker,
+}

--- a/apps/api/workers/cockpit.js
+++ b/apps/api/workers/cockpit.js
@@ -7,7 +7,7 @@ class CockpitWorker extends BaseWorker {
   }
 
   async perform(_) {
-    await this.context.pgdb.query(`
+    return this.context.pgdb.run(`
       REFRESH MATERIALIZED VIEW cockpit_membership_evolution;
       REFRESH MATERIALIZED VIEW cockpit_membership_last_seen;
       REFRESH MATERIALIZED VIEW cockpit_discussions_evolution;

--- a/apps/www/pages/cockpit.js
+++ b/apps/www/pages/cockpit.js
@@ -219,7 +219,7 @@ const Page = ({
         error={data.error}
         style={{ minHeight: `calc(90vh)` }}
         render={() => {
-          if (!data.membershipStats) {
+          if (!data.membershipStats?.bucket?.length) {
             return 'Die Cockpit-Daten konnten nicht geladen werden :('
           }
 

--- a/packages/backend-modules/collections/graphql/resolvers/CollectionsStats/evolution.js
+++ b/packages/backend-modules/collections/graphql/resolvers/CollectionsStats/evolution.js
@@ -1,18 +1,21 @@
 const moment = require('moment')
 
-const { createCache } = require('../../../lib/stats/evolution')
-
 module.exports = async (_, args, context) => {
   const { name } = args
 
   const collection = await context.loaders.Collection.byKeyObj.load({ name })
 
-  if (!name) {
+  if (!collection) {
     throw new Error(`Collection "${name}" not found`)
   }
 
   // Fetch pre-populated data
-  const data = await createCache(context).get()
+  const data = await context.pgdb.query(
+    `select * from cockpit_collections_evolution where "collectionId" = :collectionId`,
+    {
+      collectionId: collection.id,
+    },
+  )
 
   // In case pre-populated data is not available...
   if (!data) {
@@ -20,9 +23,6 @@ module.exports = async (_, args, context) => {
       'Unable to retrieve pre-populated data for Collection.CollectionsStats.evolution',
     )
   }
-
-  // Retrieve pre-populated data.
-  const { result = [], updatedAt } = data
 
   // A list of desired bucket keys to return
   const keys = []
@@ -37,10 +37,7 @@ module.exports = async (_, args, context) => {
   }
 
   return {
-    buckets: result
-      .filter(({ key }) => keys.includes(key))
-      .filter(({ collectionId }) => collectionId === collection.id)
-      .map((r) => ({ ...r, updatedAt })),
-    updatedAt,
+    buckets: data.filter(({ key }) => keys.includes(key)),
+    updatedAt: data[0]?.updatedAt || new Date(),
   }
 }

--- a/packages/backend-modules/collections/graphql/resolvers/CollectionsStats/evolution.js
+++ b/packages/backend-modules/collections/graphql/resolvers/CollectionsStats/evolution.js
@@ -17,13 +17,6 @@ module.exports = async (_, args, context) => {
     },
   )
 
-  // In case pre-populated data is not available...
-  if (!data) {
-    throw new Error(
-      'Unable to retrieve pre-populated data for Collection.CollectionsStats.evolution',
-    )
-  }
-
   // A list of desired bucket keys to return
   const keys = []
 

--- a/packages/backend-modules/discussions/graphql/resolvers/DiscussionsStats/evolution.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/DiscussionsStats/evolution.js
@@ -20,6 +20,6 @@ module.exports = async (_, args, context) => {
 
   return {
     buckets: data.filter(({ key }) => keys.includes(key)),
-    updatedAt: data[0]?.updatedAt,
+    updatedAt: data[0]?.updatedAt || new Date(),
   }
 }

--- a/packages/backend-modules/discussions/graphql/resolvers/DiscussionsStats/evolution.js
+++ b/packages/backend-modules/discussions/graphql/resolvers/DiscussionsStats/evolution.js
@@ -1,20 +1,10 @@
 const moment = require('moment')
 
-const { createCache } = require('../../../lib/stats/evolution')
-
 module.exports = async (_, args, context) => {
   // Fetch pre-populated data
-  const data = await createCache(context).get()
-
-  // In case pre-populated data is not available...
-  if (!data) {
-    throw new Error(
-      'Unable to retrieve pre-populated data for DiscussionsStats.evolution',
-    )
-  }
-
-  // Retrieve pre-populated data.
-  const { result = [], updatedAt = new Date() } = data
+  const data = await context.pgdb.query(
+    'select * from cockpit_discussions_evolution;',
+  )
 
   // A list of desired bucket keys to return
   const keys = []
@@ -29,9 +19,7 @@ module.exports = async (_, args, context) => {
   }
 
   return {
-    buckets: result
-      .filter(({ key }) => keys.includes(key))
-      .map((r) => ({ ...r, updatedAt })),
-    updatedAt,
+    buckets: data.filter(({ key }) => keys.includes(key)),
+    updatedAt: data[0]?.updatedAt,
   }
 }

--- a/packages/backend-modules/migrations/migrations/20250604102839-cockpit-materialized-view.js
+++ b/packages/backend-modules/migrations/migrations/20250604102839-cockpit-materialized-view.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/republik/migrations/sqls'
+const file = '20250604102839-cockpit-materialized-view'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/backend-modules/republik/graphql/resolvers/MembershipStats/evolution.js
+++ b/packages/backend-modules/republik/graphql/resolvers/MembershipStats/evolution.js
@@ -1,20 +1,14 @@
 const moment = require('moment')
 
-const { createCache } = require('../../../lib/MembershipStats/evolution')
-
 module.exports = async (_, args, context) => {
   // Fetch pre-populated data
-  const data = await createCache(context).get()
+  const data = await context.pgdb.query(
+    'select * from cockpit_membership_evolution;',
+  )
 
-  // In case pre-populated data is not available...
-  if (!data) {
-    throw new Error(
-      'Unable to retrieve pre-populated data for MembershipStats.evolution',
-    )
+  if (!data.length) {
+    throw new Error('membership stats evolution not loaded')
   }
-
-  // Retrieve pre-populated data.
-  const { result = [], updatedAt = new Date() } = data
 
   // A list of desired bucket keys to return
   const keys = []
@@ -29,7 +23,7 @@ module.exports = async (_, args, context) => {
   }
 
   return {
-    buckets: result.filter(({ key }) => keys.includes(key)),
-    updatedAt,
+    buckets: data.filter(({ key }) => keys.includes(key)),
+    updatedAt: data[0].updatedAt,
   }
 }

--- a/packages/backend-modules/republik/graphql/resolvers/MembershipStats/evolution.js
+++ b/packages/backend-modules/republik/graphql/resolvers/MembershipStats/evolution.js
@@ -5,11 +5,6 @@ module.exports = async (_, args, context) => {
   const data = await context.pgdb.query(
     'select * from cockpit_membership_evolution;',
   )
-
-  if (!data.length) {
-    throw new Error('membership stats evolution not loaded')
-  }
-
   // A list of desired bucket keys to return
   const keys = []
 
@@ -24,6 +19,6 @@ module.exports = async (_, args, context) => {
 
   return {
     buckets: data.filter(({ key }) => keys.includes(key)),
-    updatedAt: data[0].updatedAt,
+    updatedAt: data[0]?.updatedAt || new Date(),
   }
 }

--- a/packages/backend-modules/republik/graphql/resolvers/MembershipStats/lastSeen.js
+++ b/packages/backend-modules/republik/graphql/resolvers/MembershipStats/lastSeen.js
@@ -6,10 +6,6 @@ module.exports = async (_, args, context) => {
     'select * from cockpit_membership_last_seen;',
   )
 
-  if (!data.length) {
-    throw new Error('membership stats last seen not loaded')
-  }
-
   // A list of desired bucket keys to return
   const keys = []
 
@@ -24,6 +20,6 @@ module.exports = async (_, args, context) => {
 
   return {
     buckets: data.filter(({ key }) => keys.includes(key)),
-    updatedAt: data[0].updatedAt,
+    updatedAt: data[0]?.updatedAt || new Date(),
   }
 }

--- a/packages/backend-modules/republik/graphql/resolvers/MembershipStats/lastSeen.js
+++ b/packages/backend-modules/republik/graphql/resolvers/MembershipStats/lastSeen.js
@@ -1,20 +1,14 @@
 const moment = require('moment')
 
-const { createCache } = require('../../../lib/MembershipStats/lastSeen')
-
 module.exports = async (_, args, context) => {
   // Fetch pre-populated data
-  const data = await createCache(context).get()
+  const data = await context.pgdb.query(
+    'select * from cockpit_membership_last_seen;',
+  )
 
-  // In case pre-populated data is not available...
-  if (!data) {
-    throw new Error(
-      'Unable to retrieve pre-populated data for MembershipStats.lastSeen',
-    )
+  if (!data.length) {
+    throw new Error('membership stats last seen not loaded')
   }
-
-  // Retrieve pre-populated data.
-  const { result, updatedAt = new Date() } = data
 
   // A list of desired bucket keys to return
   const keys = []
@@ -29,7 +23,7 @@ module.exports = async (_, args, context) => {
   }
 
   return {
-    buckets: result.filter(({ key }) => keys.includes(key)),
-    updatedAt,
+    buckets: data.filter(({ key }) => keys.includes(key)),
+    updatedAt: data[0].updatedAt,
   }
 }

--- a/packages/backend-modules/republik/lib/MembershipStats/evolution.js
+++ b/packages/backend-modules/republik/lib/MembershipStats/evolution.js
@@ -336,10 +336,8 @@ const sumBucketProps = async (
     { key },
   )
 
-  if (!bucket) {
-    throw new Error(
-      `Unable to sum bucket: Bucket "${key}" not in pre-populated data available`,
-    )
+  if (!bucket.length) {
+    return 0
   }
 
   const { add = ['active', 'overdue'], subtract = [] } = props

--- a/packages/backend-modules/republik/lib/MembershipStats/evolution.js
+++ b/packages/backend-modules/republik/lib/MembershipStats/evolution.js
@@ -331,19 +331,10 @@ const sumBucketProps = async (
   props,
 ) => {
   // Fetch pre-populated data
-  const data = await createCache(context).get()
-
-  if (!data) {
-    throw new Error(
-      'Unable to sum bucket: Pre-populated data is not available. Did you run `yarn populate`?',
-    )
-  }
-
-  // Retrieve pre-populated result from data.
-  const { result = [] } = data
-
-  // Find desired bucket
-  const bucket = result.find((bucket) => bucket.key === key)
+  const bucket = await context.pgdb.queryOne(
+    'select * from cockpit_membership_evolution where key = :key;',
+    { key },
+  )
 
   if (!bucket) {
     throw new Error(

--- a/packages/backend-modules/republik/migrations/sqls/20250604102839-cockpit-materialized-view-down.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20250604102839-cockpit-materialized-view-down.sql
@@ -1,0 +1,5 @@
+-- migrate down here: DROP TABLE...
+DROP MATERIALIZED VIEW IF EXISTS cockpit_membership_evolution;
+DROP MATERIALIZED VIEW IF EXISTS cockpit_membership_last_seen;
+DROP MATERIALIZED VIEW IF EXISTS cockpit_discussions_evolution;
+DROP MATERIALIZED VIEW IF EXISTS cockpit_collections_evolution;

--- a/packages/backend-modules/republik/migrations/sqls/20250604102839-cockpit-materialized-view-up.sql
+++ b/packages/backend-modules/republik/migrations/sqls/20250604102839-cockpit-materialized-view-up.sql
@@ -1,0 +1,365 @@
+-- migrate up here: CREATE TABLE...
+CREATE MATERIALIZED VIEW IF NOT EXISTS cockpit_membership_evolution AS (
+  WITH query_variables AS (
+  	select
+  	'Europe/Zurich' as tz,
+  	'2018-01-01' as min,
+  	date_trunc('month', current_date + INTERVAL '2 years', 'Europe/Zurich') as max,
+  	'2017-05-01 00:00:00+02' as CROWDFUNDER_THRESHOLD_DATE,
+  	'2018-01-16 00:00:00+02' as LOYALIST_THRESHOLD_DATE,
+    'f0512927-7e03-4ecc-b14f-601386a2a249'::uuid as tumbstone_user_id,
+    now() as updated_at
+  ),
+  "minMaxDates" AS (
+    WITH "periods" AS (
+  	SELECT
+  		m.id,
+  		m.active,
+  		m.renew,
+  		m."autoPay",
+  		mt.name "membershipTypeName",
+  		mp."beginDate",
+  		mp."endDate",
+  		m."userId",
+  		um."createdAt"
+  	FROM
+  		"memberships" m
+  		JOIN "membershipPeriods" mp ON mp."membershipId" = m.id
+  		JOIN "membershipTypes" mt ON mt.id = m."membershipTypeId"
+  		-- all memberships belonging to user with periods
+  		JOIN "memberships" um ON um."userId" = m."userId"
+  		JOIN "membershipPeriods" ump ON ump."membershipId" = um.id
+  	WHERE
+  		m."userId" != (select tumbstone_user_id from query_variables)
+  	UNION ALL
+  	SELECT
+  		s.id,
+  		s.status IN ('active', 'past_due', 'unpaid', 'paused') "active",
+  		s."canceledAt" IS NULL "renew",
+  		TRUE "autoPay",
+  		s.type::text "membershipTypeName",
+  		i."periodStart" "beginDate",
+  		i."periodEnd" "endDate",
+  		s."userId",
+  		us."createdAt"
+  	FROM
+  		payments.subscriptions s
+  		JOIN payments.invoices i ON i."subscriptionId" = s.id
+  		-- all subscriptions belonging to user with periods
+  		JOIN payments.subscriptions us ON us."userId" = s."userId"
+  		JOIN payments.invoices ui ON ui."subscriptionId" = us.id
+  	WHERE
+  		s."userId" != (select tumbstone_user_id from query_variables)
+  )
+  SELECT
+  	id,
+  	every("active") "active",
+  	every("renew") "renew",
+  	every("autoPay") "autoPay",
+  	"membershipTypeName",
+  	min("beginDate") "minBeginDate",
+  	max("endDate") "maxEndDate",
+  	min("userId"::text) "userId",
+  	MIN("createdAt") "minCreatedAt"
+  FROM
+  	periods
+  GROUP BY
+  	id,
+  	"membershipTypeName"
+  ), "membershipDonation" AS (
+    WITH "pledgeMembership" AS (
+      SELECT p."createdAt", p.donation, COALESCE(pom.id, pm.id) "membershipId"
+      FROM "pledges" p
+      JOIN "pledgeOptions" po ON po."pledgeId" = p.id AND po.amount > 0
+      LEFT JOIN "memberships" pom ON pom.id = po."membershipId" AND pom."userId" = p."userId"
+      LEFT JOIN "memberships" pm ON pm."pledgeId" = p.id AND pm."userId" = p."userId"
+      WHERE p.donation > 0
+        AND (pom.id IS NOT NULL OR pm.id IS NOT NULL)
+        AND p.status != 'DRAFT'
+    )
+
+    SELECT pm.donation, pm."membershipId"
+    FROM (
+      SELECT "membershipId", MAX("createdAt") AS "createdAt"
+      FROM "pledgeMembership"
+      GROUP BY "membershipId"
+    ) AS lpm
+    JOIN "pledgeMembership" pm
+      ON pm."membershipId" = lpm."membershipId"
+      AND pm."createdAt" = lpm."createdAt"
+    GROUP BY pm."membershipId", pm.donation
+  ), range AS (
+    SELECT
+      unit at time zone (SELECT tz from query_variables) "first",
+      (unit + '1 month'::interval - '1 second'::interval) at time zone (SELECT tz from query_variables) "last"
+
+    FROM generate_series(
+      (SELECT min from query_variables)::timestamp,
+      (SELECT max from query_variables)::timestamp,
+      '1 month'
+    ) unit
+  )
+
+  SELECT
+    to_char("first" at time zone (SELECT tz from query_variables), 'YYYY-MM') "key",
+    (select updated_at from query_variables) "updatedAt",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "minBeginDate" < "first"
+    ) "activeBeginningOfMonth",
+
+    COUNT(id) FILTER (
+      WHERE "minBeginDate" >= "first"
+      AND "minBeginDate" <= "last"
+    ) "gaining",
+
+    COUNT(id) FILTER (
+      WHERE "minBeginDate" >= "first"
+      AND "minBeginDate" <= "last"
+      AND "membershipDonation"."membershipId" IS NOT NULL
+    ) "gainingWithDonation",
+
+    COUNT(id) FILTER (
+      WHERE "minBeginDate" >= "first"
+      AND "minBeginDate" <= "last"
+      AND "membershipDonation"."membershipId" IS NULL
+    ) "gainingWithoutDonation",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= "last"
+
+    ) "ending",
+
+    -- Data up until now
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= LEAST(NOW(), "last")
+      AND active = FALSE
+    ) "ended",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= LEAST(NOW(), "last")
+      AND active = FALSE
+      AND renew = TRUE
+    ) "expired",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= LEAST(NOW(), "last")
+      AND active = FALSE
+      AND renew = FALSE
+    ) "cancelled",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= LEAST(NOW(), "last")
+      AND "minBeginDate" < LEAST(NOW(), "last")
+    ) "active",
+
+    COUNT(DISTINCT "userId") FILTER (
+      WHERE "maxEndDate" >= LEAST(NOW(), "last")
+      AND "minBeginDate" < LEAST(NOW(), "last")
+      AND "minCreatedAt" < (SELECT CROWDFUNDER_THRESHOLD_DATE from query_variables)::timestamp
+    ) "activeCrowdfunders",
+
+    COUNT(DISTINCT "userId") FILTER (
+      WHERE "maxEndDate" >= LEAST(NOW(), "last")
+      AND "minBeginDate" < LEAST(NOW(), "last")
+      AND "minCreatedAt" < (SELECT LOYALIST_THRESHOLD_DATE from query_variables)::timestamp
+    ) "activeLoyalists",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= (SELECT min from query_variables)::timestamp
+      AND "maxEndDate" <= LEAST(NOW(), "last")
+      AND active = TRUE
+      AND renew = TRUE
+    ) "overdue",
+
+    -- Data to end of month
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= "last"
+    ) "endedEndOfMonth",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= "last"
+      AND renew = TRUE
+    ) "expiredEndOfMonth",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= "last"
+      AND renew = FALSE
+    ) "cancelledEndOfMonth",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "last"
+      AND "minBeginDate" < "last"
+    ) "activeEndOfMonth",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "last"
+      AND "minBeginDate" < "last"
+      AND "membershipDonation"."membershipId" IS NOT NULL
+    ) "activeEndOfMonthWithDonation",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "last"
+      AND "minBeginDate" < "last"
+      AND "membershipDonation"."membershipId" IS NULL
+    ) "activeEndOfMonthWithoutDonation",
+
+    COUNT(DISTINCT "userId") FILTER (
+      WHERE "maxEndDate" >= "last"
+      AND "minBeginDate" < "last"
+      AND "minCreatedAt" < (SELECT CROWDFUNDER_THRESHOLD_DATE from query_variables)::timestamp
+    ) "activeCrowdfundersEndOfMonth",
+
+    COUNT(DISTINCT "userId") FILTER (
+      WHERE "maxEndDate" >= "last"
+      AND "minBeginDate" < "last"
+      AND "minCreatedAt" < (SELECT LOYALIST_THRESHOLD_DATE from query_variables)::timestamp
+    ) "activeLoyalistsEndOfMonth",
+
+    -- Data based on membership active state
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= "first"
+      AND "maxEndDate" <= "last"
+      AND active = TRUE
+      AND renew = TRUE
+    ) "prolongable",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= (SELECT min from query_variables)::timestamp
+      AND "maxEndDate" <= "last"
+      AND active = TRUE
+      AND renew = TRUE
+    ) "pending",
+
+    COUNT(id) FILTER (
+      WHERE "maxEndDate" >= (SELECT min from query_variables)::timestamp
+      AND "maxEndDate" <= "last"
+      AND active = TRUE
+      AND renew = TRUE
+      AND "membershipTypeName" IN ('MONTHLY_ABO')
+    ) "pendingSubscriptionsOnly"
+
+  FROM range, "minMaxDates"
+
+  LEFT JOIN "membershipDonation"
+    ON "membershipDonation"."membershipId" = "minMaxDates".id
+
+  GROUP BY 1
+  ORDER BY 1
+) WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cockpit_membership_evolution_idx" ON "cockpit_membership_evolution" ("key");
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS "cockpit_membership_last_seen" AS (
+    WITH "sessionsLastSeen" AS (
+        WITH "members" AS (
+     	    SELECT "userId"
+     	    FROM "memberships"
+     	    WHERE "active" = TRUE
+              UNION
+     	    SELECT "userId"
+     	    FROM "payments"."subscriptions"
+     	    WHERE "status" IN ('active', 'past_due', 'unpaid', 'paused')
+        )
+        SELECT ("sess" -> 'passport' ->> 'user')::uuid "userId",
+   	    GREATEST (
+            -- Default max-age on a session (7 days)
+            CASE WHEN "expire" - '365 days'::interval <= now()::timestamp(0) + '10 seconds'::interval THEN
+              "expire" - '365 days'::interval
+            ELSE
+              NULL
+            END,
+            -- Short max-age on a session (7 days)
+            CASE WHEN "expire" - '7 days'::interval <= now()::timestamp(0) + '10 seconds'::interval THEN
+              "expire" - '7 days'::interval
+            ELSE
+              NULL
+            END) "lastSeenAt"
+          FROM "sessions"
+   	    INNER JOIN "members" ON "members"."userId" = ("sess" -> 'passport' ->> 'user')::uuid
+    )
+  SELECT to_char(now(), 'YYYY-MM') "key", now() "updatedAt", COUNT(DISTINCT "userId") "users"
+  FROM "sessionsLastSeen"
+  WHERE "lastSeenAt" >= now()::timestamp(0) - '30 days'::interval
+) WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cockpit_membership_last_seen_idx" ON "cockpit_membership_last_seen" ("key");
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS "cockpit_discussions_evolution" AS (
+  WITH "commentsVotes" AS (
+    SELECT
+      to_char(c."createdAt", 'YYYY-MM') "key",
+      c.id "commentId",
+      c."discussionId",
+      c."userId",
+      'comment' "engagement"
+
+    FROM "comments" c
+    WHERE c."userId" IS NOT NULL
+
+    UNION
+
+    SELECT
+      to_char(c."createdAt", 'YYYY-MM') "key",
+      c.id "commentId",
+      c."discussionId",
+      v."userId",
+      'vote' "engagement"
+
+    FROM "comments" c, jsonb_to_recordset(c.votes) AS v("userId" uuid)
+    WHERE v."userId" IS NOT NULL
+  )
+
+  SELECT
+    cv.key,
+    now() "updatedAt",
+    COUNT(DISTINCT cv."commentId") "comments",
+    COUNT(DISTINCT cv."discussionId") "discussions",
+    COUNT(DISTINCT cv."userId") "users",
+    COUNT(DISTINCT cv."userId") FILTER (WHERE cv.engagement = 'comment') "usersPosted",
+    COUNT(DISTINCT cv."userId") FILTER (WHERE cv.engagement = 'vote') "usersVoted"
+
+  FROM "commentsVotes" cv
+
+  GROUP BY 1
+) WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cockpit_discussions_evolution_idx" ON "cockpit_discussions_evolution" ("key");
+
+CREATE MATERIALIZED VIEW cockpit_collections_evolution AS (
+  WITH "documentsMedias" AS (
+    SELECT
+      to_char(cdi."createdAt", 'YYYY-MM') "key",
+      cdi."collectionId",
+      cdi."repoId" "id",
+      cdi."userId",
+      'document' "type"
+
+    FROM "collectionDocumentItems" cdi
+  )
+
+  SELECT
+    dm.key,
+    dm."collectionId",
+    COUNT(*) "records",
+    COUNT(DISTINCT dm.id) FILTER (WHERE dm.type = 'document') "documents",
+    COUNT(DISTINCT dm.id) FILTER (WHERE dm.type = 'media') "medias",
+    COUNT(DISTINCT dm."userId") "users",
+    now() "updatedAt"
+
+  FROM "documentsMedias" dm
+  GROUP BY 1, 2
+) WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "cockpit_collections_evolution_idx" ON "cockpit_collections_evolution" ("key", "collectionId");


### PR DESCRIPTION
Updates the resolvers used by the `/cockpit` page to fetch the data from materialised views instead of the Redis cache.

## WHY?
- Main benefit is that the data is no longer being evicted from the cache preventing the cockpit form breaking randomly.
- The views can also be used in our metabase queries.

## Testing
The current cockpit on staging fetches the data from materialised views already

## Not part of this PR:
- removal of the populate scripts for the redis cache
- removal of unused resolvers.
