### PR TITLE
permanent https redirects

### DIFF
--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -118,7 +118,9 @@ function redirectToHTTPS(req: NextRequest): NextResponse | null {
   reqURL.protocol = 'https:'
   reqURL.port = ''
 
-  return NextResponse.redirect(reqURL)
+  return NextResponse.redirect(reqURL, {
+    status: 308,
+  })
 }
 
 /**


### PR DESCRIPTION
The default NextResponse.redirect() function redirects with a temporary 307 status code, which is not good practice. https://redirect.li/http/?url=http%3A%2F%2Frepublik.ch