### PR TITLE
fix news sitemap

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -123,6 +123,7 @@
     "isomorphic-dompurify": "^2.3.0",
     "jose": "^4.8.3",
     "jotai": "^2.2.0",
+    "jstoxml": "^7.0.1",
     "load-script": "^1.0.0",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.3",

--- a/apps/www/src/app/api/(sitemaps)/[year]/news-sitemap/route.ts
+++ b/apps/www/src/app/api/(sitemaps)/[year]/news-sitemap/route.ts
@@ -11,6 +11,16 @@ const SCHEMA_PUBLISHER = process.env.NEXT_PUBLIC_SCHEMA_PUBLISHER
 
 const publisher = parseJSONObject(SCHEMA_PUBLISHER)
 
+function escapeXml(unsafe: string): string {
+  if (typeof unsafe !== 'string') return ''
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
 function generateNewsSiteMap(
   articles: (NonNullable<SitemapByYearQuery['search']['nodes'][0]['entity']> & {
     __typename: 'Document'
@@ -32,7 +42,7 @@ ${articles
         <news:language>${publisher.knowsLanguage}</news:language>
       </news:publication>
       <news:publication_date>${meta.publishDate}</news:publication_date>
-      <news:title>${meta.title}</news:title>
+      <news:title>${escapeXml(meta.title)}</news:title>
     </news:news>
   </url>`
   })

--- a/apps/www/src/app/sitemap.xml/route.ts
+++ b/apps/www/src/app/sitemap.xml/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 
 const BASE_URL = process.env.PUBLIC_BASE_URL
-const START_YEAR = 2017
+const START_YEAR = 2018
 
 export async function GET(request: NextRequest) {
   const currentYear = new Date().getFullYear()

--- a/yarn.lock
+++ b/yarn.lock
@@ -14871,6 +14871,11 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
+jstoxml@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/jstoxml/-/jstoxml-7.0.1.tgz#b6fd20b42e61e1f3737d2001b524017462e116a6"
+  integrity sha512-yqCv6FoW1uTqtqO/wqQzvdRhVp+iIFwu153pLdSmJwlRRW3+eRWwfHjCE1E+06hB17s934iFDZI1GW0g4QvA8w==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"


### PR DESCRIPTION
Two news-sitemaps were failing because they add the title of an article to the sitemap, not just the path. And in rare cases, we had characters in the titles that should be be escaped for XML. For example: & should be &amp;

I added back the jstoxml library I had removed, which escapes all necessary characters.

Also sets the START_YEAR to 2018, since we didn't publish in 2017.