### PR TITLE
add "createdAt" desc index to collectionDocumentItems

### DIFF
--- a/packages/backend-modules/collections/migrations/sqls/20250616113324-add-collection-items-created-at-index-down.sql
+++ b/packages/backend-modules/collections/migrations/sqls/20250616113324-add-collection-items-created-at-index-down.sql
@@ -1,0 +1,1 @@
+DROP INDEX collection_document_item_created_at_idx;

--- a/packages/backend-modules/collections/migrations/sqls/20250616113324-add-collection-items-created-at-index-up.sql
+++ b/packages/backend-modules/collections/migrations/sqls/20250616113324-add-collection-items-created-at-index-up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX collection_document_item_created_at_idx ON public."collectionDocumentItems" ("createdAt" DESC);

--- a/packages/backend-modules/migrations/migrations/20250616113324-add-collection-items-created-at-index.js
+++ b/packages/backend-modules/migrations/migrations/20250616113324-add-collection-items-created-at-index.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/backend-modules/collections/migrations/sqls/'
+const file = '20250616113324-add-collection-items-created-at-index'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
In most of our analytics queries for the collectionDocumentItems we sort the data by date, the query planner showed that most of the time is spent on sorting the entries. Adding an index for the common sort should drastically improve performance.