### PR TITLE
add republik-utm-conversion cookie

### DIFF
--- a/apps/www/src/lib/analytics/provider.tsx
+++ b/apps/www/src/lib/analytics/provider.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { useMe } from 'lib/context/MeContext'
 import PlausibleProvider from 'next-plausible'
+import { updateUTMConversionCookie } from './utm-cookie-storage'
+import { useEffect } from 'react'
 
 type AnalyticsProviderProps = Omit<
   Parameters<typeof PlausibleProvider>[0],
@@ -9,6 +11,13 @@ type AnalyticsProviderProps = Omit<
 
 export const AnalyticsProvider = (props: AnalyticsProviderProps) => {
   const { me, hasActiveMembership, trialStatus, meLoading } = useMe()
+
+  useEffect(() => {
+    if (hasActiveMembership) {
+      return
+    }
+    updateUTMConversionCookie()
+  }, [trialStatus])
 
   return (
     <PlausibleProvider

--- a/apps/www/src/lib/analytics/utm-cookie-storage.tsx
+++ b/apps/www/src/lib/analytics/utm-cookie-storage.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { PUBLIC_BASE_URL } from 'lib/constants'
+const CONVERSION_COOKIE_NAME = 'republik-utm-conversion'
+const COOKIE_EXPIRY_DAYS = 30
+
+function setCookie(name: string, value: string, days: number): void {
+  const expires = new Date()
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000)
+  const baseDomain = new URL(PUBLIC_BASE_URL).hostname
+    .split('.')
+    .slice(-2)
+    .join('.')
+
+  let cookieString = `${name}=${encodeURIComponent(
+    value,
+  )}; expires=${expires.toUTCString()}; path=/`
+
+  cookieString += `; domain=.${baseDomain}`
+  cookieString += '; SameSite=Lax'
+
+  document.cookie = cookieString
+}
+
+function getCookie(name: string): string | null {
+  const nameEQ = name + '='
+  const cookies = document.cookie.split(';')
+
+  for (let cookie of cookies) {
+    cookie = cookie.trim()
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+
+  return null
+}
+
+function getUTMParametersFromURL(): Record<string, string> {
+  const utmParams: Record<string, string> = {}
+
+  try {
+    for (const [key, value] of new URLSearchParams(window.location.search)) {
+      if (key.startsWith('utm_')) {
+        utmParams[key] = value
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return utmParams
+}
+
+export function updateUTMConversionCookie(): void {
+  const currentUTMParams = getUTMParametersFromURL()
+
+  if (Object.keys(currentUTMParams).length === 0) {
+    return
+  }
+
+  // Check if cookie already exists
+  const existingCookieValue = getCookie(CONVERSION_COOKIE_NAME)
+  let shouldUpdateCookie = true
+
+  if (existingCookieValue) {
+    const existingData = JSON.parse(existingCookieValue)
+    const cookieTimestamp = existingData.timestamp
+
+    const cookieAge = Date.now() - cookieTimestamp
+    const thirtyDaysInMs = 30 * 24 * 60 * 60 * 1000
+
+    // Don't update if cookie is less than 30 days old
+    if (cookieAge < thirtyDaysInMs) {
+      shouldUpdateCookie = false
+    }
+  }
+
+  if (shouldUpdateCookie) {
+    const cookieData = {
+      ...currentUTMParams,
+      timestamp: Date.now(),
+    }
+
+    setCookie(
+      CONVERSION_COOKIE_NAME,
+      JSON.stringify(cookieData),
+      COOKIE_EXPIRY_DAYS,
+    )
+  }
+}
+
+export function getUTMConversionCookie(): Record<string, string> {
+  const cookieValue = getCookie(CONVERSION_COOKIE_NAME)
+  if (cookieValue) {
+    const cookieData = JSON.parse(cookieValue)
+    const { timestamp, ...utmParams } = cookieData
+    return utmParams
+  }
+
+  return {}
+}


### PR DESCRIPTION
This is a proof of concept implementation of using a domain shared cookie for utm_parameters instead of storing the utm's in a session and passing them along to the shop on an interaction with a paynote. 

To me this seems more robust since our sales journey also includes email marketing and is optimised for several touchpoints (read for 7 days for example). Of course we can never capture cases where users convert on different devices or on different browsers, but this could be a good step forward in more accurately measuring campaign success.

To do if we decide this is a valuable route:
- Read the utm cookie in the shop on a transaction
- Clean up the utm session code if it's not necessary anymore

Thoughts?

PS: The mechanism proposed - and discussed with marketing - is to set a cookie for 30 days and only update it after that time. This corresponds to a "first-entry" measurement approach in a 30 day window. Not yet implemented is wiping the cookie after 30 days (regardless of new utms).