### PR TITLE
add back characterCount to workflow tab

### DIFF
--- a/apps/publikator/components/VersionControl/index.js
+++ b/apps/publikator/components/VersionControl/index.js
@@ -107,7 +107,14 @@ class EditSidebar extends Component {
   }
 
   render() {
-    const { t, commit, hasUncommittedChanges, isNew, data = {} } = this.props
+    const {
+      t,
+      commit,
+      hasUncommittedChanges,
+      isNew,
+      characterCount,
+      data = {},
+    } = this.props
     const { loading, error, repo } = data
 
     if (isNew) {
@@ -120,6 +127,10 @@ class EditSidebar extends Component {
         error={error}
         render={() => (
           <div {...styles.container}>
+            <p style={{ margin: '0 0 10px 0', fontSize: '12px' }}>
+              {characterCount}
+              {' Zeichen'}
+            </p>
             {!!repo && !!repo.commits && !!repo.commits.nodes && (
               <BaseCommit
                 repoId={repo.id}

--- a/apps/publikator/components/editor/MdastPage.js
+++ b/apps/publikator/components/editor/MdastPage.js
@@ -65,7 +65,6 @@ import {
 } from '../Edit/enhancers'
 import Preview from '../Preview'
 
-
 const getTemplateById = gql`
   query getLatestCommit($repoId: ID!) {
     templateRepo: repo(id: $repoId) {
@@ -988,7 +987,9 @@ export class EditorPage extends Component {
                       editorRef={this.editor}
                       onChange={this.uiChangeHandler}
                       value={editorState}
-                      serializedState={this.editor.serializer.serialize(editorState)}
+                      serializedState={this.editor.serializer.serialize(
+                        editorState,
+                      )}
                       onSaveSearchAndReplace={this.persistChanges.bind(this)}
                       onGoToRaw={() => this.goToRaw(isTemplate)}
                     />
@@ -998,6 +999,7 @@ export class EditorPage extends Component {
               {!showPreview && (
                 <Sidebar.Tab tabId='workflow' label='Workflow'>
                   <VersionControl
+                    characterCount={editorState?.document.text.length}
                     repoId={repoId}
                     commit={commit}
                     isNew={isNew}


### PR DESCRIPTION
I accidentally removed the character count from the workflow tab because i couldn't imagine why you'd need it on both tabs. Turns out you do because if someone else is in the doc, you can't see the edit tab. 