### PR TITLE
remove email plausible tracking

### DIFF
--- a/apps/www/src/app/api/email-open/route.ts
+++ b/apps/www/src/app/api/email-open/route.ts
@@ -10,38 +10,6 @@ const pixel =
  * Embed in emails as an image and add the `url` param. E.g. <img src="https://www.republik.ch/api/email-open?url=<encoded_url>">
  */
 export async function GET(request: NextRequest) {
-  const url = request.nextUrl.searchParams.get('url')
-
-  // If url param is not set, just do nothing
-  if (url) {
-    // See https://plausible.io/docs/events-api
-    try {
-      const plausibleRes = await fetch('https://plausible.io/api/event', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'user-agent': request.headers.get('user-agent'),
-          'x-forwarded-for': request.headers.get('x-forwarded-for'),
-        },
-        body: JSON.stringify({
-          domain: process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN,
-          name: 'pageview',
-          url,
-          props: {
-            type: 'email-open',
-            user_type: 'email',
-          },
-        }),
-      })
-
-      if (!plausibleRes.ok) {
-        console.error('Email tracking failed', await plausibleRes.text())
-      }
-    } catch (err) {
-      console.error('Email tracking failed', err)
-    }
-  }
-
   const img = await (await fetch(pixel)).blob()
   const res = new Response(img, {
     headers: {

--- a/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_mutations/publish.js
@@ -349,7 +349,7 @@ module.exports = async (_, args, context) => {
   // do the mailchimp update
   if (campaignId) {
     // Update campaign configuration
-    const { title, emailSubject, path } = doc.content.meta
+    const { title, emailSubject } = doc.content.meta
     if (!title || !emailSubject) {
       throw new Error('Mailchimp: missing title or subject', {
         title,
@@ -373,17 +373,7 @@ module.exports = async (_, args, context) => {
       throw new Error(t('api/publish/error/updateCampaign'))
     })
 
-    // Update campaign content (HTML)
-    let html = getHTML(resolvedDoc)
-
-    // Plausible beacon
-    const plausibleBeacon = new URL(`/api/email-open`, FRONTEND_BASE_URL)
-    plausibleBeacon.searchParams.set('url', FRONTEND_BASE_URL + path)
-    // TODO: Should we add the UTM parameters here like in the Matomo implementation? Shouldn't they just be used in links in the email?
-    html = html.replace(
-      '</body>',
-      `<img alt="" src="${plausibleBeacon}" height="1" width="1"></body>`,
-    )
+    const html = getHTML(resolvedDoc)
 
     await updateCampaignContent({ campaignId, html }).catch((error) => {
       console.error(error)


### PR DESCRIPTION
1. Doesn't inject the image into the mailchimp html on publishing a newsletter
2. Only returns the image o the email-open route, without sending the request to plausible. We do this because if we return nothing, email clients will complain that the email content couldn't be loaded properly. We can remove this route in the future, when it's unlikely that older emails are being openend anymore. 