### PR TITLE
Fix Comment Submissions

### DIFF
--- a/apps/www/components/Discussion/hooks/actions/useSubmitCommentHandler.ts
+++ b/apps/www/components/Discussion/hooks/actions/useSubmitCommentHandler.ts
@@ -52,31 +52,40 @@ function useSubmitCommentHandler(): SubmitCommentHandlerFunction {
       },
       // Write the result of the query into the DiscussionQuery cache
       update: (cache, { data: { submitComment: comment } }) => {
-        const variables: DiscussionQueryVariables = {
-          discussionPath: discussion?.path,
-          orderBy: orderBy,
-          depth: depth,
-          focusId: focusId,
-          activeTag: activeTag,
+        try {
+          cache.updateQuery<DiscussionQuery, DiscussionQueryVariables>(
+            {
+              query: DISCUSSION_QUERY,
+              variables: {
+                discussionPath: discussion?.path,
+                orderBy: orderBy,
+                depth: depth,
+                focusId: focusId,
+                activeTag: activeTag,
+              },
+            },
+            (data) => {
+              // If no cached query data exists, don't do anything.
+              if (!data) {
+                return
+              }
+              return produce(
+                data,
+                mergeComment({
+                  comment,
+                  activeTag: activeTag,
+                  initialParentId: parentId,
+                }),
+              )
+            },
+          )
+        } catch (e) {
+          // If the cache update fails, the mutation still succeeded, so we don't have to do anything else.
+          console.warn(
+            "Couldn't update client cache after comment submit mutation",
+            e,
+          )
         }
-
-        const readQueries = cache.readQuery<
-          DiscussionQuery,
-          DiscussionQueryVariables
-        >({ query: DISCUSSION_QUERY, variables })
-
-        cache.writeQuery<DiscussionQuery, DiscussionQueryVariables>({
-          query: DISCUSSION_QUERY,
-          variables,
-          data: produce(
-            readQueries,
-            mergeComment({
-              comment,
-              activeTag: activeTag,
-              initialParentId: parentId,
-            }),
-          ),
-        })
       },
     }).catch(toRejectedString)
   }


### PR DESCRIPTION
In some cases, updating the cache after a comment submission doesn't work because the cache is empty. Then, we just do nothing.

Also updates to the more recent [`cache.updateQuery`](https://www.apollographql.com/docs/react/caching/cache-interaction#using-updatequery-and-updatefragment) instead of using `readQuery` and `writeQuery`.