### PR TITLE
add pino logger

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -47,6 +47,7 @@
     "@orbiting/backend-modules-types": "*",
     "@orbiting/backend-modules-utils": "*",
     "@orbiting/backend-modules-voting": "*",
+    "@orbiting/backend-modules-logger": "*",
     "apollo-modules-node": "*",
     "d3-array": "^2.4.0",
     "d3-dsv": "^1.2.0",

--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -2,6 +2,7 @@ const { ApolloServer } = require('apollo-server-express')
 const { makeExecutableSchema } = require('@graphql-tools/schema')
 const { SubscriptionServer } = require('subscriptions-transport-ws')
 const { execute, subscribe } = require('graphql')
+const { logger } = require('@orbiting/backend-modules-logger')
 
 const cookie = require('cookie')
 const cookieParser = require('cookie-parser')
@@ -38,6 +39,7 @@ module.exports = async (
       req,
       scope,
       documentApiKey,
+      logger: req?.log || logger,
       user: global && global.testUser !== undefined ? global.testUser : user,
     })
     // prime User dataloader with me

--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -125,14 +125,27 @@ module.exports = async (
         async requestDidStart() {
           return {
             async didEncounterErrors({ context, request, errors }) {
-              console.error(
-                JSON.stringify({
-                  req: context.req._log(),
-                  message: `GraphQL error for operation '${request.operationName}'`,
-                  level: 'ERROR',
-                  graphQLErrors: errors,
-                }),
-              )
+              if (context.logger.isLevelEnabled('debug')) {
+                context.logger.debug(
+                  {
+                    graphqlRequest: {
+                      query: request.query,
+                      variables: request.variables,
+                      errors: errors,
+                    },
+                  },
+                  `GraphQL error for operation '${request.operationName}'`,
+                )
+              } else {
+                context.logger.error(
+                  {
+                    graphqlRequest: {
+                      errors: errors,
+                    },
+                  },
+                  `GraphQL error for operation '${request.operationName}'`,
+                )
+              }
             },
           }
         },

--- a/packages/backend-modules/base/lib/ConnectionContext.js
+++ b/packages/backend-modules/base/lib/ConnectionContext.js
@@ -2,6 +2,7 @@ const Elasticsearch = require('./Elasticsearch')
 const PgDb = require('./PgDb')
 const Redis = require('./Redis')
 const RedisPubSub = require('./RedisPubSub')
+const { logger } = require('@orbiting/backend-modules-logger')
 
 const Promise = require('bluebird')
 
@@ -10,6 +11,7 @@ const create = async (applicationName) => ({
   redis: Redis.connect(),
   pubsub: RedisPubSub.connect(),
   elastic: Elasticsearch.connect(),
+  logger: logger,
 })
 
 const close = ({ pgdb, redis, pubsub, elastic }) =>

--- a/packages/backend-modules/base/package.json
+++ b/packages/backend-modules/base/package.json
@@ -21,6 +21,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@orbiting/backend-modules-logger": "*",
     "@elastic/elasticsearch": "7.13.0",
     "@graphql-tools/schema": "^10.0.2",
     "apollo-modules-node": "*",

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -107,13 +107,7 @@ const start = async (
   if (REQ_TIMEOUT) {
     server.use(timeout(REQ_TIMEOUT, { respond: false }), (req, res, next) => {
       req.on('timeout', () => {
-        console.error(
-          JSON.stringify({
-            req: req._log(),
-            message: 'Request Timeout',
-            level: 'ERROR',
-          }),
-        )
+        req.log.error('Request Timeout')
       })
       next()
     })

--- a/packages/backend-modules/base/server.js
+++ b/packages/backend-modules/base/server.js
@@ -6,6 +6,7 @@ const compression = require('compression')
 const timeout = require('connect-timeout')
 const helmet = require('helmet')
 const sleep = require('await-sleep')
+const { httpLogger } = require('@orbiting/backend-modules-logger')
 
 const graphql = require('./express/graphql')
 const graphiql = require('./express/graphiql')
@@ -47,6 +48,8 @@ const start = async (
 
   const server = express()
   const httpServer = createServer(server)
+
+  server.use(httpLogger)
 
   server.use(
     helmet({

--- a/packages/backend-modules/gen-backend-module/templates/package.json.hbs
+++ b/packages/backend-modules/gen-backend-module/templates/package.json.hbs
@@ -10,6 +10,10 @@
   "private": true,
   "main": "build/index.js",
   "types": "build/@types",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --w"
+  },
   "dependencies": {
     "@orbiting/backend-modules-scalars": "*",
     "@orbiting/backend-modules-types": "*",

--- a/packages/backend-modules/job-queue/lib/workers/base.ts
+++ b/packages/backend-modules/job-queue/lib/workers/base.ts
@@ -1,19 +1,22 @@
 import PgBoss, { Job, ScheduleOptions, SendOptions } from 'pg-boss'
 import { BasePayload, Worker, WorkerQueue } from '../types'
 import { ConnectionContext } from '@orbiting/backend-modules-types'
+import { Logger } from '@orbiting/backend-modules-logger'
 
 export abstract class BaseWorker<T extends Omit<BasePayload, '$version'>>
   implements Worker<T>
 {
   protected pgBoss: PgBoss
+  protected readonly logger: Logger
   protected readonly context: ConnectionContext
   abstract readonly queue: WorkerQueue
   readonly options: SendOptions = { retryLimit: 3, retryDelay: 1000 }
   // abstract performOptions?: PgBoss.WorkOptions | undefined
 
-  constructor(pgBoss: PgBoss, context: ConnectionContext) {
+  constructor(pgBoss: PgBoss, logger: Logger, context: ConnectionContext) {
     this.pgBoss = pgBoss
     this.context = context
+    this.logger = logger
   }
 
   abstract perform(jobs: Job<T>[]): Promise<void>

--- a/packages/backend-modules/job-queue/package.json
+++ b/packages/backend-modules/job-queue/package.json
@@ -7,6 +7,7 @@
   "types": "build/@types",
   "dependencies": {
     "@orbiting/backend-modules-types": "*",
+    "@orbiting/backend-modules-logger": "*",
     "pg-boss": "^10.1.1",
     "debug": "^4.3.5"
   },

--- a/packages/backend-modules/logger/.gitignore
+++ b/packages/backend-modules/logger/.gitignore
@@ -1,0 +1,2 @@
+build
+build/*

--- a/packages/backend-modules/logger/index.ts
+++ b/packages/backend-modules/logger/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/index'

--- a/packages/backend-modules/logger/index.ts
+++ b/packages/backend-modules/logger/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/index'
+export * from './lib/logger'

--- a/packages/backend-modules/logger/lib/index.ts
+++ b/packages/backend-modules/logger/lib/index.ts
@@ -1,0 +1,69 @@
+import { pino, type Logger as PinoLogger } from 'pino'
+import { pinoHttp } from 'pino-http'
+import { randomUUID } from 'node:crypto'
+
+export type Logger = PinoLogger
+
+const TRANSPORTS = {
+  DEV: { target: 'pino-pretty' },
+  HEKOKU_LOGDNA: {
+    target: 'pino-logdna',
+    options: {
+      key: LOGDNA_KEY(),
+    },
+  },
+  DEFAULT: undefined,
+}
+
+function LOGDNA_KEY() {
+  try {
+    if (process.env.LOGDNA_KEY) {
+      const key = JSON.parse(process.env.LOGDNA_KEY)
+      if (Array.isArray(key)) {
+        return key[0]
+      }
+      return key
+    }
+  } catch (error) {
+    console.error('Error fetching LOGDNA_KEY:', error)
+    return false
+  }
+}
+
+function getENV(): 'DEV' | 'HEKOKU_LOGDNA' | 'DEFAULT' {
+  if (process.env.NODE_ENV !== 'production') return 'DEV'
+  if (process.env.NODE_ENV === 'production' && LOGDNA_KEY())
+    return 'HEKOKU_LOGDNA'
+  return 'DEFAULT'
+}
+
+export const logger = pino({
+  // Use pino-pretty for development
+  transport: TRANSPORTS[getENV()],
+})
+
+export const httpLogger = pinoHttp({
+  logger,
+  redact: {
+    paths: [
+      'req.headers.authorization',
+      'req.headers.cookie',
+      'res.headers["set-cookie"]',
+    ],
+    censor: 'REDACTED',
+  },
+  genReqId: function (req: any, res: any) {
+    const existingID = req.id ?? req.headers['x-request-id']
+    if (existingID) return existingID
+    const id = randomUUID()
+    res.setHeader('X-Request-Id', id)
+    return id
+  },
+  // Define custom serializers
+  serializers: {
+    // Exclude sensitive headers
+    // req(req: any) {
+    //   return req
+    // },
+  },
+})

--- a/packages/backend-modules/logger/lib/logger.ts
+++ b/packages/backend-modules/logger/lib/logger.ts
@@ -24,18 +24,20 @@ const LOG_LABELS = new Map([
 ])
 
 export const logger = pino({
-  // Use pino-pretty for development
   transport: TRANSPORTS[getENV()],
-  level: process.env.PINO_LOG_LEVEL || 'info',
+  level: process.env.LOG_LEVEL || (getENV() === 'DEV' ? 'debug' : 'info'),
   formatters: {
     level(label: string, number: number) {
       return { level: LOG_LABELS.get(number) || label }
     },
   },
+  // make msg key logDNA compliant
+  messageKey: 'message',
 })
 
 export const httpLogger = pinoHttp({
   logger,
+  msgPrefix: '[HTTP] ',
   redact: {
     paths: [
       'req.headers.authorization',
@@ -51,11 +53,6 @@ export const httpLogger = pinoHttp({
     res.setHeader('X-Request-Id', id)
     return id
   },
-  // Define custom serializers
-  serializers: {
-    // Exclude sensitive headers
-    // req(req: any) {
-    //   return req
-    // },
-  },
+  // only log requestID for child logs
+  quietReqLogger: true,
 })

--- a/packages/backend-modules/logger/package.json
+++ b/packages/backend-modules/logger/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@orbiting/backend-modules-logger",
+  "version": "0.1.0",
+  "private": true,
+  "main": "build/index.js",
+  "types": "build/@types",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --w"
+  },
+  "dependencies": {
+    "pino": "^9.7.0",
+    "pino-http": "^10.5.0",
+    "pino-logdna": "^3.0.4",
+    "pino-pretty": "^13.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.16.1"
+  }
+}

--- a/packages/backend-modules/logger/package.json
+++ b/packages/backend-modules/logger/package.json
@@ -5,13 +5,12 @@
   "main": "build/index.js",
   "types": "build/@types",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --w"
+    "dev": "tsc --w",
+    "build": "tsc"
   },
   "dependencies": {
     "pino": "^9.7.0",
     "pino-http": "^10.5.0",
-    "pino-logdna": "^3.0.4",
     "pino-pretty": "^13.0.0"
   },
   "devDependencies": {

--- a/packages/backend-modules/logger/tsconfig.json
+++ b/packages/backend-modules/logger/tsconfig.json
@@ -1,0 +1,14 @@
+{
+   "extends": "@orbiting/backend-modules-types/tsconfig-backend.json",
+   "compilerOptions": {
+     "outDir": "build",
+     "target": "ES2022",
+     "module": "Node16",
+     "moduleResolution": "Node16",
+     "declaration": true,
+     "declarationDir": "build/@types",
+     "declarationMap": true
+   },
+   "include": ["."],
+   "exclude": ["node_modules", "__test__", "build"]
+ }

--- a/packages/backend-modules/types/index.d.ts
+++ b/packages/backend-modules/types/index.d.ts
@@ -11,6 +11,7 @@ export interface ConnectionContext {
   pgdb: PgDb
   redis: any
   pubsub: any
+  logger: Logger
 }
 export interface GraphqlContext extends ConnectionContext {
   t: any
@@ -19,7 +20,6 @@ export interface GraphqlContext extends ConnectionContext {
   scope?: 'request' | 'socket' | 'middleware' | 'scheduler'
   loaders: any
   user?: any
-  logger: Logger
 }
 
 /**

--- a/packages/backend-modules/types/index.d.ts
+++ b/packages/backend-modules/types/index.d.ts
@@ -1,4 +1,5 @@
 import { PgDb } from 'pogi'
+import type { Logger } from 'pino'
 
 declare const __brand: unique symbol
 type Brand<B> = { [__brand]: B }
@@ -18,6 +19,7 @@ export interface GraphqlContext extends ConnectionContext {
   scope?: 'request' | 'socket' | 'middleware' | 'scheduler'
   loaders: any
   user?: any
+  logger: Logger
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,22 +2850,6 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
-"@logdna/logger@^2.6.8":
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/@logdna/logger/-/logger-2.6.11.tgz#937a576d9a608fcb53cf4e98d0b6f153e381a55f"
-  integrity sha512-/6rOQ+jQI/mK7uPO09516sapiWFhPwZGk615aC9yUrbr0A1ws3imjypQFwDIbzlBDyB++uKI1u0N1MpGKjR2Pg==
-  dependencies:
-    "@logdna/stdlib" "^1.2.3"
-    agentkeepalive "^4.1.3"
-    axios "^1.7.4"
-    https-proxy-agent "^7.0.2"
-    json-stringify-safe "^5.0.1"
-
-"@logdna/stdlib@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@logdna/stdlib/-/stdlib-1.2.3.tgz#a95b4cc74f0c4378769e41c06b69151058d6a26e"
-  integrity sha512-67aauh8AY395vtgAADIPZTHjDtiCJBrNb2sM13zb2lWRJWAPVdiEBcgQValDR4OuwOdkr4kAMiTMBuMziATKiA==
-
 "@mapbox/hast-util-table-cell-style@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
@@ -7936,15 +7920,6 @@ axios@^1.0.0, axios@^1.6.5:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.7.4:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
-  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axobject-query@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.4.tgz#6dfba930294ea14d7d2fc68b9d007211baedb94c"
@@ -11229,7 +11204,7 @@ duplexer@^0.1.1, duplexer@^0.1.2:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-duplexify@^4.0.0, duplexify@^4.1.2, duplexify@^4.1.3:
+duplexify@^4.0.0, duplexify@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
   integrity sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==
@@ -12750,11 +12725,6 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8, fol
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
-
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 fontkit@^1.8.1:
   version "1.9.0"
@@ -19760,14 +19730,6 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pino-abstract-transport@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz#4b54348d8f73713bfd14e3dc44228739aa13d9c0"
-  integrity sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==
-  dependencies:
-    duplexify "^4.1.2"
-    split2 "^4.0.0"
-
 pino-abstract-transport@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
@@ -19792,15 +19754,6 @@ pino-http@^10.5.0:
     pino "^9.0.0"
     pino-std-serializers "^7.0.0"
     process-warning "^5.0.0"
-
-pino-logdna@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/pino-logdna/-/pino-logdna-3.0.4.tgz#acbed14d7d06dd1681d5a3c9c357995ff99176c1"
-  integrity sha512-p6RMhOqKCYYlNLjle6FALxJdLNRjQhnoj8+48aXZpASCO7tsencSZNUQBjKxIvjt3ayzBSuCUvz9BV3x2I1XLA==
-  dependencies:
-    "@logdna/logger" "^2.6.8"
-    nopt "^5.0.0"
-    pino-abstract-transport "^0.5.0"
 
 pino-pretty@^13.0.0:
   version "13.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,6 +2850,22 @@
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
 
+"@logdna/logger@^2.6.8":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@logdna/logger/-/logger-2.6.11.tgz#937a576d9a608fcb53cf4e98d0b6f153e381a55f"
+  integrity sha512-/6rOQ+jQI/mK7uPO09516sapiWFhPwZGk615aC9yUrbr0A1ws3imjypQFwDIbzlBDyB++uKI1u0N1MpGKjR2Pg==
+  dependencies:
+    "@logdna/stdlib" "^1.2.3"
+    agentkeepalive "^4.1.3"
+    axios "^1.7.4"
+    https-proxy-agent "^7.0.2"
+    json-stringify-safe "^5.0.1"
+
+"@logdna/stdlib@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@logdna/stdlib/-/stdlib-1.2.3.tgz#a95b4cc74f0c4378769e41c06b69151058d6a26e"
+  integrity sha512-67aauh8AY395vtgAADIPZTHjDtiCJBrNb2sM13zb2lWRJWAPVdiEBcgQValDR4OuwOdkr4kAMiTMBuMziATKiA==
+
 "@mapbox/hast-util-table-cell-style@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
@@ -5936,6 +5952,16 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.3.tgz#a8ef894305af28d1fc6d2dfdfc98e899591ea529"
   integrity sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==
 
+"@types/express-serve-static-core@*":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz#2fa94879c9d46b11a5df4c74ac75befd6b283de6"
+  integrity sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
 "@types/express-serve-static-core@4.17.31":
   version "4.17.31"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
@@ -5983,6 +6009,15 @@
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
+  integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
 "@types/geojson@*":
@@ -7901,6 +7936,15 @@ axios@^1.0.0, axios@^1.6.5:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.7.4:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.4.tgz#6dfba930294ea14d7d2fc68b9d007211baedb94c"
@@ -9202,7 +9246,7 @@ color@^4.0.1, color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colorette@^2.0.16:
+colorette@^2.0.16, colorette@^2.0.7:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
@@ -10558,6 +10602,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
+
 datocms-listen@^0.1.9:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/datocms-listen/-/datocms-listen-0.1.15.tgz#fc9d970ac9754f6f21b7f9e7a31ec7db1b0247f1"
@@ -11180,7 +11229,7 @@ duplexer@^0.1.1, duplexer@^0.1.2:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-duplexify@^4.0.0, duplexify@^4.1.3:
+duplexify@^4.0.0, duplexify@^4.1.2, duplexify@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
   integrity sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==
@@ -12292,6 +12341,11 @@ farmhash-modern@^1.1.0:
   resolved "https://registry.yarnpkg.com/farmhash-modern/-/farmhash-modern-1.1.0.tgz#c36b34ad196290d57b0b482dc89e637d0b59835f"
   integrity sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==
 
+fast-copy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
+  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
+
 fast-decode-uri-component@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
@@ -12696,6 +12750,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8, fol
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 fontkit@^1.8.1:
   version "1.9.0"
@@ -13871,6 +13930,11 @@ helmet@^3.22.0:
     nocache "2.1.0"
     referrer-policy "1.2.0"
     x-xss-protection "1.3.0"
+
+help-me@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
+  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
 
 hexoid@^1.0.0:
   version "1.0.0"
@@ -19696,6 +19760,21 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pino-abstract-transport@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz#4b54348d8f73713bfd14e3dc44228739aa13d9c0"
+  integrity sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==
+  dependencies:
+    duplexify "^4.1.2"
+    split2 "^4.0.0"
+
+pino-abstract-transport@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
+  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
+  dependencies:
+    split2 "^4.0.0"
+
 pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
@@ -19704,10 +19783,53 @@ pino-abstract-transport@v1.1.0:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
+pino-http@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/pino-http/-/pino-http-10.5.0.tgz#6a4fd8df93a181fc89f7f89979b8a2146aad29f2"
+  integrity sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA==
+  dependencies:
+    get-caller-file "^2.0.5"
+    pino "^9.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^5.0.0"
+
+pino-logdna@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pino-logdna/-/pino-logdna-3.0.4.tgz#acbed14d7d06dd1681d5a3c9c357995ff99176c1"
+  integrity sha512-p6RMhOqKCYYlNLjle6FALxJdLNRjQhnoj8+48aXZpASCO7tsencSZNUQBjKxIvjt3ayzBSuCUvz9BV3x2I1XLA==
+  dependencies:
+    "@logdna/logger" "^2.6.8"
+    nopt "^5.0.0"
+    pino-abstract-transport "^0.5.0"
+
+pino-pretty@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-13.0.0.tgz#21d57fe940e34f2e279905d7dba2d7e2c4f9bf17"
+  integrity sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.2"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
+    pump "^3.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^4.0.1"
+    strip-json-comments "^3.1.1"
+
 pino-std-serializers@^6.0.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
   integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
+
+pino-std-serializers@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
+  integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
 
 pino@8.18.0:
   version "8.18.0"
@@ -19725,6 +19847,23 @@ pino@8.18.0:
     safe-stable-stringify "^2.3.1"
     sonic-boom "^3.7.0"
     thread-stream "^2.0.0"
+
+pino@^9.0.0, pino@^9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-9.7.0.tgz#ff7cd86eb3103ee620204dbd5ca6ffda8b53f645"
+  integrity sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^5.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^3.0.0"
 
 pirates@^4.0.1, pirates@^4.0.4:
   version "4.0.6"
@@ -20035,6 +20174,11 @@ process-warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-3.0.0.tgz#96e5b88884187a1dce6f5c3166d611132058710b"
   integrity sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==
+
+process-warning@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-5.0.0.tgz#566e0bf79d1dff30a72d8bbbe9e8ecefe8d378d7"
+  integrity sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==
 
 process@^0.11.10:
   version "0.11.10"
@@ -22463,6 +22607,13 @@ sonic-boom@^3.7.0:
   dependencies:
     atomic-sleep "^1.0.0"
 
+sonic-boom@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
+  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -22820,7 +22971,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22837,15 +22988,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@~2.1.1:
   version "2.1.1"
@@ -22979,7 +23121,7 @@ stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22999,13 +23141,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -23499,6 +23634,13 @@ thread-stream@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.4.1.tgz#6d588b14f0546e59d3f306614f044bc01ce43351"
   integrity sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==
+  dependencies:
+    real-require "^0.2.0"
+
+thread-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-3.1.0.tgz#4b2ef252a7c215064507d4ef70c05a5e2d34c4f1"
+  integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
   dependencies:
     real-require "^0.2.0"
 
@@ -25406,7 +25548,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25419,15 +25561,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Our homegrown logger setup hasn't aged well. This PR introduces the pino logger to our backend.

By using the pino-http plugin we can make sure that all logs that happen in the HTTP layer are connected to a request id.
In production pino generates structured json logs that reduce the clutter in our log drain.

- [x]: added pino-http to all http requests
- [x]: inject pino into the pgboss queue

TODO: refactor console and debug calls to pino