### PR TITLE
chore: make ProLitteris IDs only visible to selected roles

### DIFF
--- a/packages/backend-modules/contributors/graphql/resolvers/ArticleContributor.ts
+++ b/packages/backend-modules/contributors/graphql/resolvers/ArticleContributor.ts
@@ -2,13 +2,22 @@ import Auth from '@orbiting/backend-modules-auth'
 import { GraphqlContext } from '@orbiting/backend-modules-types'
 
 export = {
-  prolitterisId: (root: any, _args: never, _ctx: GraphqlContext) => {
+  prolitterisId: (root: any, _args: never, ctx: GraphqlContext) => {
+    if (!Auth.Roles.userIsInRoles(ctx.user, ['admin', 'editor', 'producer'])) {
+      return null
+    }
     return root.prolitteris_id
   },
-  prolitterisFirstname: (root: any, _args: never, _ctx: GraphqlContext) => {
+  prolitterisFirstname: (root: any, _args: never, ctx: GraphqlContext) => {
+    if (!Auth.Roles.userIsInRoles(ctx.user, ['admin', 'editor', 'producer'])) {
+      return null
+    }
     return root.prolitteris_first_name
   },
-  prolitterisLastname: (root: any, _args: never, _ctx: GraphqlContext) => {
+  prolitterisLastname: (root: any, _args: never, ctx: GraphqlContext) => {
+    if (!Auth.Roles.userIsInRoles(ctx.user, ['admin', 'editor', 'producer'])) {
+      return null
+    }
     return root.prolitteris_last_name
   },
   userId: (root: any, _args: never, _ctx: GraphqlContext) => {


### PR DESCRIPTION
While the ProLitteris ID is not protected private information, there is also no reason to have it publicly visible.