### PR TITLE
Proxy GraphQL Requests

### DIFF
--- a/apps/www/instrumentation-client.ts
+++ b/apps/www/instrumentation-client.ts
@@ -22,7 +22,7 @@ if (process.env.NEXT_PUBLIC_SENTRY_DISABLED !== 'true') {
     integrations: [
       // Include GraphQL queries in error spans
       Sentry.graphqlClientIntegration({
-        endpoints: [process.env.NEXT_PUBLIC_API_URL],
+        endpoints: [process.env.NEXT_PUBLIC_API_URL, '/graphql'],
       }),
 
       Sentry.extraErrorDataIntegration({ depth: 5 }),

--- a/apps/www/lib/apollo/index.ts
+++ b/apps/www/lib/apollo/index.ts
@@ -9,7 +9,7 @@ import { createAppWorkerLink } from './appWorkerLink'
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
   name: '@orbiting/www-app',
   version: process.env.BUILD_ID,
-  apiUrl: API_URL,
+  apiUrl: typeof window === 'undefined' ? API_URL : '/graphql',
   wsUrl: API_WS_URL,
   mobileConfigOptions: {
     isInMobileApp: inNativeAppBrowser && inNativeAppBrowserLegacy,

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -103,6 +103,10 @@ const nextConfig = {
           source: '/_ssr/:path*',
           destination: '/404',
         },
+        {
+          source: '/graphql',
+          destination: process.env.NEXT_PUBLIC_API_URL,
+        },
       ],
       afterFiles: [
         // impossible route via file system path

--- a/apps/www/src/lib/apollo/provider.tsx
+++ b/apps/www/src/lib/apollo/provider.tsx
@@ -10,7 +10,10 @@ import {
 
 function makeClient() {
   const httpLink = new HttpLink({
-    uri: process.env.NEXT_PUBLIC_API_URL,
+    uri:
+      typeof window === 'undefined'
+        ? process.env.NEXT_PUBLIC_API_URL
+        : '/graphql',
     credentials: 'include',
   })
 


### PR DESCRIPTION
Fixes an issue where Safari limits the cookie expiry date to 7 days because it assumes CNAME cloaking on requests to api.republik.ch from www.republik.ch