### PR TITLE
Campaign fixes

### DIFF
--- a/apps/www/src/app/(campaign)/components/campaign-offers.tsx
+++ b/apps/www/src/app/(campaign)/components/campaign-offers.tsx
@@ -106,7 +106,7 @@ export function Offers({
       action={`${process.env.NEXT_PUBLIC_SHOP_BASE_URL}/angebot/MONTHLY`}
       onSubmit={() => {
         trackEvent({
-          action: `Go to ${selectedPromoCode} shop`,
+          action: `Go to MONTHLY shop`,
         })
       }}
     >

--- a/apps/www/src/app/(campaign)/components/campaign-offers.tsx
+++ b/apps/www/src/app/(campaign)/components/campaign-offers.tsx
@@ -116,6 +116,7 @@ export function Offers({
       ))}
 
       <div
+        data-theme='light'
         className={css({
           display: 'flex',
           gap: '4',

--- a/apps/www/src/app/(campaign)/components/campaign-offers.tsx
+++ b/apps/www/src/app/(campaign)/components/campaign-offers.tsx
@@ -109,7 +109,9 @@ export function Offers({
         })
       }}
     >
-      {customAmount && <input type='hidden' name='promo_code' value={option} />}
+      {customAmount && option && (
+        <input type='hidden' name='promo_code' value={option} />
+      )}
 
       {Object.entries(allHiddenParams).map(([k, v]) => (
         <input type='hidden' hidden key={k} name={k} value={v} />

--- a/apps/www/src/app/(campaign)/components/campaign-offers.tsx
+++ b/apps/www/src/app/(campaign)/components/campaign-offers.tsx
@@ -86,7 +86,8 @@ export function Offers({
 }: {
   additionalShopParams?: Record<string, string>
 }) {
-  const [option, setOption] = useState<DiscountOption['promoCode']>(undefined)
+  const [selectedPromoCode, setSelectedPromoCode] =
+    useState<DiscountOption['promoCode']>(undefined)
   const [customAmount, setCustomAmount] = useState<number | undefined>()
 
   const utmParams = getUTMSessionStorage()
@@ -105,13 +106,17 @@ export function Offers({
       action={`${process.env.NEXT_PUBLIC_SHOP_BASE_URL}/angebot/MONTHLY`}
       onSubmit={() => {
         trackEvent({
-          action: `Go to ${option} shop`,
+          action: `Go to ${selectedPromoCode} shop`,
         })
       }}
     >
-      {customAmount && option && (
-        <input type='hidden' name='promo_code' value={option} />
-      )}
+      {
+        // Only include hidden input when custom amount is used and a promo code is found
+        // Otherwise the promo_code value is used from the OfferOption below
+        customAmount && selectedPromoCode && (
+          <input type='hidden' name='promo_code' value={selectedPromoCode} />
+        )
+      }
 
       {Object.entries(allHiddenParams).map(([k, v]) => (
         <input type='hidden' hidden key={k} name={k} value={v} />
@@ -150,9 +155,11 @@ export function Offers({
                 key={promoCode}
                 name='promo_code'
                 value={promoCode}
-                checked={option === promoCode && customAmount === undefined}
+                checked={
+                  selectedPromoCode === promoCode && customAmount === undefined
+                }
                 onChange={() => {
-                  setOption(promoCode)
+                  setSelectedPromoCode(promoCode)
                   setCustomAmount(undefined)
                 }}
                 className='peer'
@@ -203,13 +210,13 @@ export function Offers({
               const value = e.currentTarget.valueAsNumber
               if (isNaN(value)) {
                 setCustomAmount(undefined)
-                setOption(undefined)
+                setSelectedPromoCode(undefined)
               } else {
                 setCustomAmount(value)
                 const promoCode = DISCOUNT_OPTIONS.find(
                   (offer) => offer.amount === value,
                 )?.promoCode
-                setOption(promoCode)
+                setSelectedPromoCode(promoCode)
               }
             }}
           />

--- a/apps/www/src/components/paynotes/campaign-paynote/campaign-overlay.tsx
+++ b/apps/www/src/components/paynotes/campaign-paynote/campaign-overlay.tsx
@@ -18,17 +18,9 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Fragment, useEffect, useState } from 'react'
 import useResizeObserver from 'use-resize-observer'
-import { getMeteringData } from '../article-metering'
 import IosCTA from '../ios-cta'
-import { usePaynoteVariants } from '../paynote/use-paynotes'
-// import {
-//   CampaignHero,
-//   CampaignHeroMini,
-// } from '@app/components/paynotes/campaign-paynote/campaign-hero'
 
 const ARTICLE_SCROLL_THRESHOLD = 0.15 // how much of page has scrolled
-
-type ContentVariant = 'paynote' | 'offers-only'
 
 function MiniPaynoteMessage({
   message,
@@ -96,11 +88,9 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
   const [expanded, setExpanded] = useState<boolean>(false)
   const [scrollThresholdReached, setScrollThresholdReached] =
     useState<boolean>(false)
-  const [variant, setVariant] = useState<ContentVariant>('offers-only')
-  const paynotes = usePaynoteVariants()
   const trackEvent = useTrackEvent()
   const pathname = usePathname()
-  const { me, trialStatus } = useMe()
+  const { me } = useMe()
   const { setPaynoteInlineHeight } = usePaynotes()
   const { scrollYProgress } = useScroll()
 
@@ -118,26 +108,15 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
   })
 
   useEffect(() => {
-    if (paynotes && scrollThresholdReached) {
+    if (scrollThresholdReached) {
       if (isExpanded) {
-        setVariant('paynote')
         setExpanded(true)
         trackEvent({
           action: 'Opened on scroll',
-          paynoteTitle: paynotes?.paynote.title,
         })
       }
     }
-  }, [isExpanded, scrollThresholdReached, trackEvent, paynotes])
-
-  if (!paynotes) {
-    return null
-  }
-
-  const { paynote, miniPaynote } = paynotes
-
-  const paynoteVariantForAnalytics =
-    variant === 'paynote' ? paynote.title : miniPaynote.message
+  }, [isExpanded, scrollThresholdReached, trackEvent])
 
   return (
     <Dialog.Root open={expanded} onOpenChange={setExpanded}>
@@ -181,7 +160,6 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
             'Und Ihnen? Die Republik für alle ab CHF 1.- im ersten Monat.'
           }
           onClick={() => {
-            setVariant('offers-only')
             trackEvent({ action: 'Opened on click' })
           }}
         />
@@ -210,13 +188,11 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
             onEscapeKeyDown={() =>
               trackEvent({
                 action: 'Closed via escape key',
-                paynoteTitle: variant === 'paynote' ? paynote.title : undefined,
               })
             }
             onPointerDownOutside={() =>
               trackEvent({
                 action: 'Closed via click outside',
-                paynoteTitle: variant === 'paynote' ? paynote.title : undefined,
               })
             }
             aria-describedby={undefined}
@@ -282,10 +258,7 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
 
               <Offers
                 additionalShopParams={{
-                  rep_ui_component: 'paynote-overlay',
-                  rep_paynote_title: paynoteVariantForAnalytics,
-                  rep_trial_status: trialStatus,
-                  ...getMeteringData('rep_'),
+                  rep_ui_component: 'campaign-overlay',
                 }}
               />
 
@@ -301,8 +274,6 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
                 onClick={() => {
                   trackEvent({
                     action: 'Closed via "Not now"',
-                    paynoteTitle:
-                      variant === 'paynote' ? paynote.title : undefined,
                   })
                 }}
               >
@@ -348,8 +319,6 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
               onClick={() => {
                 trackEvent({
                   action: 'Closed via icon',
-                  paynoteTitle:
-                    variant === 'paynote' ? paynote.title : undefined,
                 })
               }}
             >

--- a/apps/www/src/components/paynotes/paynotes-context.tsx
+++ b/apps/www/src/components/paynotes/paynotes-context.tsx
@@ -105,27 +105,35 @@ export const PaynotesProvider = ({ children }) => {
   const isCampaignActive = campaign?.isActive
 
   useEffect(() => {
-    if (meLoading) return
+    if (meLoading) {
+      return
+    }
     // console.log({ template, trialStatus, pathname, searchParams })
 
     // Active membership: no paynote
-    if (trialStatus === 'MEMBER') return setPaynoteKind(null)
-
+    if (trialStatus === 'MEMBER') {
+      return setPaynoteKind(null)
+    }
     // ANYTHING THAT'S NOT AN ARTICLE:
     //
     // special pages without any paynote
-    if (isPaynoteOverlayHidden(pathname, searchParams))
+    if (isPaynoteOverlayHidden(pathname, searchParams)) {
       return setPaynoteKind(null)
-
+    }
     // dialog page: we show a special paynote
-    if (isDialogPage(pathname, searchParams) || template === 'discussion')
+    if (isDialogPage(pathname, searchParams) || template === 'discussion') {
       return setPaynoteKind('DIALOG')
+    }
+
+    // Campaign active and *not* an article
+    if (isCampaignActive && template !== 'article') {
+      return setPaynoteKind('CAMPAIGN_OVERLAY_CLOSED')
+    }
 
     // anything else that's not an article: minimized paynote overlay
-    if (template !== 'article')
-      return setPaynoteKind(
-        isCampaignActive ? 'CAMPAIGN_OVERLAY_CLOSED' : 'OVERLAY_CLOSED',
-      )
+    if (template !== 'article') {
+      return setPaynoteKind('OVERLAY_CLOSED')
+    }
 
     // ARTICLES:
     //
@@ -133,48 +141,57 @@ export const PaynotesProvider = ({ children }) => {
     // but we show the overlay (in case someone is
     // spoofing the user agent to read our content, we still
     // want to show these clever foxes the paywall)
-    if (isSearchBot)
-      return setPaynoteKind(
-        isCampaignActive ? 'CAMPAIGN_OVERLAY_OPEN' : 'OVERLAY_OPEN',
-      )
+
+    // When a campaign is active:
+    if (isCampaignActive) {
+      return setPaynoteKind('CAMPAIGN_OVERLAY_OPEN')
+    }
+
+    if (isSearchBot) {
+      return setPaynoteKind('OVERLAY_OPEN')
+    }
 
     // just signed up for a trial: welcome banner
-    if (trialStatus.includes('TRIAL_GROUP') && searchParams.has('trialSignup'))
+    if (
+      trialStatus.includes('TRIAL_GROUP') &&
+      searchParams.has('trialSignup')
+    ) {
       return setPaynoteKind('WELCOME_BANNER')
-
+    }
     // one trial group (group A) is shown an inline paynote
-    if (trialStatus === 'TRIAL_GROUP_A') return setPaynoteKind('PAYNOTE_INLINE')
-
+    if (trialStatus === 'TRIAL_GROUP_A') {
+      return setPaynoteKind('PAYNOTE_INLINE')
+    }
     // the other group (group B) is shown the more prominent overlay
-    if (trialStatus === 'TRIAL_GROUP_B')
-      return setPaynoteKind(
-        isCampaignActive ? 'CAMPAIGN_OVERLAY_OPEN' : 'OVERLAY_OPEN',
-      )
+    if (trialStatus === 'TRIAL_GROUP_B') {
+      return setPaynoteKind('OVERLAY_OPEN')
+    }
 
     // abo teilen users are shown the inline paynote
-    if (trialStatus === 'TRIAL_GROUP_TEILEN')
+    if (trialStatus === 'TRIAL_GROUP_TEILEN') {
       return setPaynoteKind('PAYNOTE_INLINE')
-
+    }
     // exception for marked articles (via metadata)
-    if (isPaywallExcluded)
-      return setPaynoteKind(
-        isCampaignActive ? 'CAMPAIGN_OVERLAY_CLOSED' : 'OVERLAY_CLOSED',
-      )
+    if (isPaywallExcluded) {
+      return setPaynoteKind('OVERLAY_CLOSED')
+    }
 
     // trial expired: show paywall
-    if (trialStatus === 'NOT_TRIAL_ELIGIBLE') return setPaynoteKind('PAYWALL')
+    if (trialStatus === 'NOT_TRIAL_ELIGIBLE') {
+      return setPaynoteKind('PAYWALL')
+    }
 
     // CAVEAT: we don't ever want the "template" state to be set to something
     // wrong (notably: "article") after the pathname has changed. Otherwise some funny
     // pages (eg "/feed") may count towards the metering.
     const { meteringStatus } = updateArticleMetering(pathname)
-    if (meteringStatus === 'READING_GRANTED')
-      return setPaynoteKind(
-        isCampaignActive ? 'CAMPAIGN_OVERLAY_OPEN' : 'OVERLAY_OPEN',
-      )
-
+    if (meteringStatus === 'READING_GRANTED') {
+      return setPaynoteKind('OVERLAY_OPEN')
+    }
     // trial eligible users see the regwall
-    if (trialStatus === 'TRIAL_ELIGIBLE') return setPaynoteKind('REGWALL')
+    if (trialStatus === 'TRIAL_ELIGIBLE') {
+      return setPaynoteKind('REGWALL')
+    }
 
     // catch-all: do nothing
     return setPaynoteKind(null)


### PR DESCRIPTION
Fixes an issue where the Regwall would show up if the user was assigned a trial status already. Bonus: the campaign-related paynote logic should be easier to understand now :)

Also:

- Fixes wrong offer highlight color in dark mode on the campaign page
- Removes some unnecessary paynote data loading and event tracking data (there's only 1 variant for the campaign and no relevant trial/metering data)