### PR TITLE
remove negative margin rule in paynote

### DIFF
--- a/apps/www/src/components/paynotes/campaign-paynote/campaign-overlay.tsx
+++ b/apps/www/src/components/paynotes/campaign-paynote/campaign-overlay.tsx
@@ -286,7 +286,6 @@ function PaynoteOverlayDialog({ isExpanded = false }) {
                 className={css({
                   py: '6',
                   mt: '2',
-                  mx: '-8',
                   textAlign: 'center',
                   borderTopWidth: 1,
                   borderTopStyle: 'solid',


### PR DESCRIPTION
fixes a bug causing the overlay to overflow the body of the page.