### PR TITLE
Fix upsertDocumentProgress

### DIFF
--- a/apps/www/components/ActionBar/UserProgress.js
+++ b/apps/www/components/ActionBar/UserProgress.js
@@ -28,7 +28,8 @@ const UserProgress = ({
 
   // Once consent has been given or not return null if there is no user progress object
   // or displayminutes are below 1min
-  if (!userProgress || displayMinutes < 1) {
+  // or the document hasn't been loaded (yet)
+  if (!userProgress || displayMinutes < 1 || !documentId) {
     return null
   }
 

--- a/apps/www/components/Article/Progress/index.js
+++ b/apps/www/components/Article/Progress/index.js
@@ -23,7 +23,7 @@ const Progress = ({ children, documentPath }) => {
   const { upsertDocumentProgress, useDocumentProgress } = useProgress()
 
   const { getMediaProgress, saveMediaProgress } = useMediaProgress()
-  
+
   const { data } = useDocumentProgress({ path: documentPath })
   const { userProgress, id: documentId } = data?.document || {}
 
@@ -89,7 +89,7 @@ const Progress = ({ children, documentPath }) => {
   }
 
   refSaveProgress.current = debounce(() => {
-    if (!documentPath || !progressConsent) {
+    if (!documentId || !progressConsent) {
       return
     }
 


### PR DESCRIPTION
Occasionally `upsertDocumentProgress` would be called with an undefined `documentId`, which isn't allowed by the schema.