### PR TITLE
log problematic data in the console

### DIFF
--- a/apps/publikator/components/editor/modules/document/createPasteHtml.js
+++ b/apps/publikator/components/editor/modules/document/createPasteHtml.js
@@ -66,7 +66,11 @@ const createPasteHtml = (centerModule) => (event, change, editor) => {
       change.insertFragment(pastedAst.document)
       return true
     } catch (e) {
-      console.log('Error pasting html, falling back to text', e)
+      console.log('Error pasting html, falling back to text', e, {
+        html,
+        hast,
+        mdast,
+      })
       change.insertText(transfer.text.replace(/\n+/g, '\n'))
       return true
     }


### PR DESCRIPTION
Since the copy-paste problems are highly dependent on the specific setup of the user, we log the problematic data to help with debugging.