### PR TITLE
handle cases where CENTER isn't the first element

### DIFF
--- a/apps/www/lib/utils/mdast.js
+++ b/apps/www/lib/utils/mdast.js
@@ -14,7 +14,12 @@ const splitChildrenTruncated = (
   start,
   charsCutoff = TRUNCATE_AFTER_CHARS,
 ) => {
-  const center = content.children[start]
+  const center = content.children.find((node) => node.identifier === 'CENTER')
+
+  if (!center) {
+    return splitChildren(content, start)
+  }
+
   const centerChildren = center.children.reduce(
     (acc, node) => {
       if (acc.chars < charsCutoff) {


### PR DESCRIPTION
to render the article, we split the mdast of the article between "title" and "content" (basically the rest of the article). previously we assumed that the first node of "content" was always a "center". that's obviously not true and led to problems.

this pr fixes the bug by actively searching for the "center" node in the "content."