### PR TITLE
Make repo resolver nullable

### DIFF
--- a/apps/publikator/components/Files/index.js
+++ b/apps/publikator/components/Files/index.js
@@ -33,11 +33,22 @@ const styles = {
   }),
 }
 
-const FilesPage = ({ router }) => {
+const FilesPage = ({ router, t }) => {
   const repoId = getRepoIdFromQuery(router.query)
   const variables = { id: repoId }
 
-  const { data, loading, error } = useQuery(GET_FILES, { variables })
+  const {
+    data,
+    loading,
+    error: queryError,
+  } = useQuery(GET_FILES, { variables })
+
+  const error =
+    data?.repo === null
+      ? t('repo/warn/missing', {
+          repoId,
+        })
+      : queryError
 
   return (
     <Frame>

--- a/apps/publikator/components/editor/enhancers.js
+++ b/apps/publikator/components/editor/enhancers.js
@@ -66,6 +66,19 @@ export const withCommitData = graphql(getCommitById, {
       commitId: router.query.commitId,
     },
   }),
+  props: ({ data, ownProps: { router, t } }) => {
+    if (data?.repo === null) {
+      return {
+        data: {
+          error: t('repo/warn/missing', {
+            repoId: getRepoIdFromQuery(router.query),
+          }),
+        },
+      }
+    }
+
+    return { data }
+  },
 })
 
 export const withLatestCommit = graphql(getLatestCommit, {
@@ -88,6 +101,15 @@ export const withLatestCommit = graphql(getLatestCommit, {
         }
       }
       return {}
+    }
+    if (data?.repo === null) {
+      return {
+        data: {
+          error: t('repo/warn/missing', {
+            repoId: getRepoIdFromQuery(router.query),
+          }),
+        },
+      }
     }
     return {
       data,

--- a/apps/publikator/lib/translations.json
+++ b/apps/publikator/lib/translations.json
@@ -117,6 +117,10 @@
       "value": "Zugelassene Rollen: {roles}"
     },
     {
+      "key": "repo/warn/missing",
+      "value": "Repo {repoId} nicht gefunden."
+    },
+    {
       "key": "repo/add/title",
       "value": "Neues Dokument"
     },

--- a/apps/publikator/pages/repo/[owner]/[repo]/files.js
+++ b/apps/publikator/pages/repo/[owner]/[repo]/files.js
@@ -6,7 +6,8 @@ import withAuthorization from '../../../../components/Auth/withAuthorization'
 import Files from '../../../../components/Files'
 
 import { withRouter } from 'next/router'
+import withT from '../../../../lib/withT'
 
 export default withDefaultSSR(
-  compose(withAuthorization(['editor']), withRouter)(Files),
+  compose(withAuthorization(['editor']), withRouter, withT)(Files),
 )

--- a/apps/publikator/pages/repo/[owner]/[repo]/tree.js
+++ b/apps/publikator/pages/repo/[owner]/[repo]/tree.js
@@ -276,7 +276,16 @@ export default withDefaultSSR(
           fetchPolicy: 'cache-and-network',
         }
       },
-      props: ({ data }) => {
+      props: ({ data, ownProps: { t, router } }) => {
+        if (data?.repo === null) {
+          return {
+            data: {
+              error: t('repo/warn/missing', {
+                repoId: getRepoIdFromQuery(router.query),
+              }),
+            },
+          }
+        }
         return {
           data,
           commits:

--- a/packages/backend-modules/publikator/graphql/resolvers/_queries/repo.js
+++ b/packages/backend-modules/publikator/graphql/resolvers/_queries/repo.js
@@ -8,7 +8,7 @@ module.exports = async (_, args, context) => {
 
   const repo = await loaders.Repo.byId.load(args.id)
   if (!repo) {
-    throw new Error(`repo "${args.id}" does not exist`)
+    return null
   }
 
   const phase = getPhase(repo.currentPhase)

--- a/packages/backend-modules/publikator/graphql/schema.js
+++ b/packages/backend-modules/publikator/graphql/schema.js
@@ -6,7 +6,7 @@ schema {
 }
 
 type queries {
-  repo(id: ID!): Repo!
+  repo(id: ID!): Repo
 
   """
   This query is a cached version of repos query. It uses cached information


### PR DESCRIPTION
A repo query for a non-existent repo should return null instead of throwing an error. This fixes excessive error logging when Publikator polls for uncommited changes on a repo that hasn't been created yet.