### PR TITLE
Fix/websocket endpoint

### DIFF
--- a/packages/backend-modules/base/express/graphql.js
+++ b/packages/backend-modules/base/express/graphql.js
@@ -171,7 +171,7 @@ module.exports = async (
     },
     {
       server: httpServer,
-      path: apolloServer.graphqlPath,
+      path: '/graphql',
     },
   )
 

--- a/packages/backend-modules/base/package.json
+++ b/packages/backend-modules/base/package.json
@@ -45,7 +45,7 @@
     "helmet": "^3.22.0",
     "pogi": "^2.11.1",
     "redis": "^3.0.2",
-    "subscriptions-transport-ws": "^0.9.16"
+    "subscriptions-transport-ws": "^0.11.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24975,6 +24975,17 @@ stylis@^4.3.6:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.6.tgz#7c7b97191cb4f195f03ecab7d52f7902ed378320"
   integrity sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 subscriptions-transport-ws@^0.9.16, subscriptions-transport-ws@^0.9.17, subscriptions-transport-ws@^0.9.19:
   version "0.9.19"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz#10ca32f7e291d5ee8eb728b9c02e43c52606cdcf"


### PR DESCRIPTION
- subscriptions-transport-ws 0.9 did not support graphql 16
- the websocket path was not set correctly because `apolloServer.graphqlPath` no longer exists 