### PR TITLE
Add iOs15 safari browserlist target

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -150,5 +150,12 @@
     "uuid": "^9.0.1",
     "validator": "^13.7.0",
     "zod": "3.22.2"
-  }
+  },
+  "browserslist": [
+    "chrome 111",
+    "edge 111",
+    "firefox 111",
+    "safari >= 15",
+    "ios_saf >= 15"
+  ]
 }


### PR DESCRIPTION
NextJS increases the default browser compatibility to Safari 16. We have user reporting that the app doesn't work anymore in iOS 15 - Still works in the browser though. This preview deployment could help us see if setting the minimum target to Safari 15 fixes the App. 