### PR TITLE
Add browserslist config to www for Safari 15 support

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -29,6 +29,12 @@
     "url": "https://github.com/republik/plattform/issues"
   },
   "homepage": "https://github.com/republik/plattform#readme",
+  "browserslist": [
+    "chrome 111",
+    "edge 111",
+    "firefox 111",
+    "safari 15.4"
+  ],
   "devDependencies": {
     "@datocms/cli": "^1.2.3",
     "@graphql-codegen/cli": "5.0.2",


### PR DESCRIPTION
Next.js 16 supports Safari 16.4+ by default, adding explicit Safari 15.4 support should fix JavaScript not running.

See https://nextjs.org/docs/architecture/supported-browsers