### PR TITLE
remove podcast buttons from android

### DIFF
--- a/apps/www/src/components/ActionBar/index.js
+++ b/apps/www/src/components/ActionBar/index.js
@@ -25,7 +25,7 @@ import { useMe } from '@/lib/context/MeContext'
 
 import { splitByTitle } from '@/lib/utils/mdast'
 
-import { postMessage } from '@/lib/withInNativeApp'
+import { postMessage, useInNativeApp } from '@/lib/withInNativeApp'
 import withT from '@/lib/withT'
 import PdfOverlay, { getPdfUrl } from '../Article/PdfOverlay'
 import { useAudioContext } from '../Audio/AudioProvider'
@@ -81,6 +81,7 @@ const ActionBar = ({
   } = useAudioContext()
   const { isAudioQueueAvailable, checkIfInQueue } = useAudioQueue()
   const { isNativeApp, isIOS, isAndroid } = usePlatformInformation()
+  const { inNativeAndroidApp } = useInNativeApp()
 
   const handleShareClick = async (e, shareData = {}) => {
     e.preventDefault()
@@ -502,7 +503,7 @@ const ActionBar = ({
         setPodcastOverlayVisible(!podcastOverlayVisible)
       },
       label: t('PodcastButtons/title'),
-      show: !!podcast && meta.template !== 'format',
+      show: !!podcast && meta.template !== 'format' && !inNativeAndroidApp,
       modes: ['articleBottom'],
       group: mode === 'articleTop' ? 'audio' : undefined,
     },

--- a/apps/www/src/components/Article/Page.js
+++ b/apps/www/src/components/Article/Page.js
@@ -67,6 +67,7 @@ const ArticlePage = ({
   markAsReadMutation,
   serverContext,
   clientRedirection,
+  inNativeAndroidApp,
 }) => {
   const actionBarRef = useRef()
   const bottomActionBarRef = useRef()
@@ -398,7 +399,8 @@ const ArticlePage = ({
             (!hasPaywall && meta.template === 'article') ||
             isEditorialNewsletter
 
-          const showPodcastButtons = !!podcast && meta.template !== 'article'
+          const showPodcastButtons =
+            !!podcast && meta.template !== 'article' && !inNativeAndroidApp
 
           return (
             <>


### PR DESCRIPTION
Google has rejected our appeal that linking to Spotify doesn't violate their terms of services, so I have to hide all Podcast Buttons from android apps: ActionBar and end of article page.