### PR TITLE
show device info

### DIFF
--- a/apps/admin/components/Users/Sessions.js
+++ b/apps/admin/components/Users/Sessions.js
@@ -84,7 +84,12 @@ class SessionOverview extends Component {
                     {displayDateTime(session.device.lastSeen)}
                   </Interaction.P>
                 ) : (
-                  <Interaction.P>{session.userAgent}</Interaction.P>
+                  <>
+                    <Interaction.P>{session.userAgent}</Interaction.P>
+                    <Label>
+                      Geräte und Betriebssysteminformationen dieser Session können veraltet sein.
+                    </Label>
+                  </>
                 )}
                 <TextButton
                   onClick={() => {

--- a/apps/admin/components/Users/Sessions.js
+++ b/apps/admin/components/Users/Sessions.js
@@ -24,6 +24,15 @@ const sessionQuery = gql`
         country
         ipAddress
         userAgent
+        device {
+          information {
+            appVersion
+            os
+            osVersion
+            model
+          }
+          lastSeen
+        }
       }
     }
   }
@@ -66,7 +75,17 @@ class SessionOverview extends Component {
                 <Interaction.P>
                   {session.city} {session.country}
                 </Interaction.P>
-                <Interaction.P>{session.userAgent}</Interaction.P>
+                {session.device ? (
+                  <Interaction.P>
+                    {session.device.information.os.toUpperCase()}{' '}
+                    {session.device.information.osVersion} ·{' '}
+                    {session.device.information.model} · App{' '}
+                    {session.device.information.appVersion} · zuletzt gesehen{' '}
+                    {displayDateTime(session.device.lastSeen)}
+                  </Interaction.P>
+                ) : (
+                  <Interaction.P>{session.userAgent}</Interaction.P>
+                )}
                 <TextButton
                   onClick={() => {
                     this.props.clearSession({

--- a/apps/admin/components/Zat/User/Sessions.js
+++ b/apps/admin/components/Zat/User/Sessions.js
@@ -7,6 +7,15 @@ export const fragments = gql`
     sessions {
       id
       userAgent
+      device {
+        information {
+          appVersion
+          os
+          osVersion
+          model
+        }
+        lastSeen
+      }
     }
   }
 `
@@ -14,8 +23,12 @@ export const fragments = gql`
 export const Sessions = ({ sessions }) =>
   !!sessions?.length && (
     <div {...styles.part}>
-      {sessions.map(({ id, userAgent }) => (
-        <div key={id}>{userAgent}</div>
+      {sessions.map(({ id, userAgent, device }) => (
+        <div key={id}>
+          {device
+            ? `${device.information.os.toUpperCase()} ${device.information.osVersion} · ${device.information.model} · App ${device.information.appVersion}`
+            : userAgent}
+        </div>
       ))}
     </div>
   )


### PR DESCRIPTION
Uses the device table for session view in admin tool instead of the session user agent, which is only set once:

<img width="851" height="453" alt="Screenshot 2026-06-24 at 11 39 41" src="https://github.com/user-attachments/assets/cdad4649-7980-426b-b4f1-9bf60b80658f" />
