### PR TITLE
fix native cta

### DIFF
--- a/apps/www/src/app/components/paynotes/paynote/paynote-offers.tsx
+++ b/apps/www/src/app/components/paynotes/paynote/paynote-offers.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/app/components/ui/button'
 import { useTrackEvent } from '@/app/lib/analytics/event-tracking'
 import { getUTMSessionStorage } from '@/app/lib/analytics/utm-session-storage'
 import { usePlatformInformation } from '@/app/lib/hooks/usePlatformInformation'
+import { useInNativeApp } from '@/lib/withInNativeApp'
 import { css } from '@republik/theme/css'
 import { useState } from 'react'
 import NativeCta from '../native-cta'
@@ -21,7 +22,8 @@ export function Offers({
   const trackEvent = useTrackEvent()
 
   const { isNativeApp } = usePlatformInformation()
-  if (isNativeApp) {
+  const { inNativeApp } = useInNativeApp()
+  if (isNativeApp || inNativeApp) {
     return <NativeCta />
   }
 

--- a/apps/www/src/app/components/paynotes/paynotes-in-trial/account.tsx
+++ b/apps/www/src/app/components/paynotes/paynotes-in-trial/account.tsx
@@ -1,9 +1,9 @@
 import { useTrackEvent } from '@/app/lib/analytics/event-tracking'
 
 import { getUTMSessionStorage } from '@/app/lib/analytics/utm-session-storage'
-import { usePlatformInformation } from '@/app/lib/hooks/usePlatformInformation'
 import { css } from '@republik/theme/css'
 
+import { useInNativeApp } from '@/lib/withInNativeApp'
 import { useMe } from '@/lib/context/MeContext'
 import { timeFormat } from '@/lib/utils/format'
 import { useTranslation } from '@/lib/withT'
@@ -17,10 +17,10 @@ const dayFormat = timeFormat('%e. %B %Y')
 function AccountCta() {
   const utmParams = getUTMSessionStorage()
   const trackEvent = useTrackEvent()
-  const { isNativeApp } = usePlatformInformation()
+  const { inNativeApp } = useInNativeApp()
   const { t } = useTranslation()
 
-  if (isNativeApp) return <NativeCta />
+  if (inNativeApp) return <NativeCta />
 
   return (
     <form


### PR DESCRIPTION
In the current implementation the paynote in the account is rendered with the client side check "isNativeApp", which introduces a flicker of showing the actual paynote in the native apps before the value is true. This likely causes google play store to flag our app as allowing external purchases.