### PR TITLE
transactions empty state

### DIFF
--- a/apps/www/src/components/Account/Transactions.tsx
+++ b/apps/www/src/components/Account/Transactions.tsx
@@ -1,9 +1,11 @@
 import { TransactionsDocument } from '#graphql/republik-api/__generated__/gql/graphql'
+import { useTranslation } from '@/lib/withT'
 import { useQuery } from '@apollo/client'
 import { Loader } from '@project-r/styleguide'
 import { css } from '@republik/theme/css'
 
 export function Transactions() {
+  const { t } = useTranslation()
   const { data, loading, error } = useQuery(TransactionsDocument)
 
   return (
@@ -12,6 +14,14 @@ export function Transactions() {
       error={error}
       render={() => {
         const transactions = data.me?.transactions ?? []
+
+        if (transactions.length === 0) {
+          return (
+            <p className={css({ color: 'textSoft' })}>
+              {t('account/transactions/empty')}
+            </p>
+          )
+        }
 
         return (
           <table className={css({ width: 'full' })}>

--- a/apps/www/src/lib/translations.json
+++ b/apps/www/src/lib/translations.json
@@ -750,6 +750,10 @@
       "value": "Erstellt am {formattedDate} um {formattedTime}"
     },
     {
+      "key": "account/transactions/empty",
+      "value": "Sie haben noch keine Transaktionen."
+    },
+    {
       "key": "pages/account/newsletter/lead",
       "value": "Abonnieren Sie unsere Newsletter per E-Mail, um auf dem Laufenden zu bleiben."
     },


### PR DESCRIPTION
Our transactions list has no empty state. This can confuse users in trials who just see an empty page if they click the tab. 