### PR TITLE
improve error message when backend is unavailable

### DIFF
--- a/apps/www/src/lib/translations.json
+++ b/apps/www/src/lib/translations.json
@@ -217,6 +217,10 @@
       "value": "Bei Ihrer Anfrage ist ein Fehler aufgetreten: «{error}». Erste-Hilfe-Team: kontakt@republik.ch."
     },
     {
+      "key": "network-error/backend-unavailable",
+      "value": "Ein Fehler ist aufgetreten. Unser Tech-Team wurde benachrichtigt und arbeitet an einer Lösung. Bitte versuchen Sie es später nochmal."
+    },
+    {
       "key": "signIn/button",
       "value": "Anmelden"
     },

--- a/apps/www/src/lib/utils/errors.js
+++ b/apps/www/src/lib/utils/errors.js
@@ -2,6 +2,11 @@ import { t } from '../withT'
 
 export const errorToString = (error) => {
   if (error.networkError) {
+    console.log(error.networkError.statusCode, error.toString())
+    // Because we proxy to the backend, any status >= 500 means something's wrong there.
+    if (error.networkError.statusCode >= 500) {
+      return t('network-error/backend-unavailable')
+    }
     if (error.toString().match(/failed/i)) {
       return t('network-error/failed')
     }


### PR DESCRIPTION
Before: we showed an unhelpful, cryptic error message which results in a lot of support requests (because we explicitly mention the support email).

<img width="482" height="183" alt="image" src="https://github.com/user-attachments/assets/4f7c9b7f-9294-4df6-91e3-2495e6a4fbbd" />

After: When the backend is unavailable (503), we are alerted automatically and there is nothing for the user or support to do, so ask for patience.

<img width="547" height="142" alt="image" src="https://github.com/user-attachments/assets/7c5c80e3-ecb0-4de5-b2e5-576f1f16c132" />


