### PR TITLE
Sanity darkmode clean

### DIFF
--- a/apps/www/src/app/(sanity)/articles/[...path]/page.tsx
+++ b/apps/www/src/app/(sanity)/articles/[...path]/page.tsx
@@ -102,6 +102,8 @@ export default async function ArticlePage({
       <Theme theme={theme} />
       {seriesId && <SeriesMenu slug={slug} />}
       <article
+        // Puts the whole app in dark mode (see the `dark` condition in preset-republik.ts).
+        data-force-theme={theme?.darkMode ? 'dark' : undefined}
         className={editorialContent({
           theme: theme?.name,
         })}

--- a/apps/www/src/app/(sanity)/components/preview-theme-listener.tsx
+++ b/apps/www/src/app/(sanity)/components/preview-theme-listener.tsx
@@ -5,10 +5,8 @@ import { useSetManualTheme } from '@/app/components/theme-provider'
 
 /**
  * Receives the dark-mode toggle from the Sanity Studio preview header and turns
- * it into a manual `forcedTheme` override. The Studio and this app run on
- * different origins, so the toggle can only reach us via `postMessage` (see the
- * PreviewHeader component in the studio repo). The message shape is the shared
- * contract between the two repos; `theme` is `'dark'` or `undefined` (off).
+ * it into a manual `forcedTheme` override. The message shape is the shared
+ * contract between the two repos; `theme` is `'dark'` or `'light'`.
  */
 export function PreviewThemeListener() {
   const setManual = useSetManualTheme()

--- a/apps/www/src/app/(sanity)/components/preview-theme-listener.tsx
+++ b/apps/www/src/app/(sanity)/components/preview-theme-listener.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSetManualTheme } from '@/app/components/theme-provider'
+
+/**
+ * Receives the dark-mode toggle from the Sanity Studio preview header and turns
+ * it into a manual `forcedTheme` override. The Studio and this app run on
+ * different origins, so the toggle can only reach us via `postMessage` (see the
+ * PreviewHeader component in the studio repo). The message shape is the shared
+ * contract between the two repos; `theme` is `'dark'` or `undefined` (off).
+ */
+export function PreviewThemeListener() {
+  const setManual = useSetManualTheme()
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== window.parent) return
+      if (event.data?.type === 'republik/preview-theme') {
+        setManual(event.data.theme)
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [setManual])
+  return null
+}

--- a/apps/www/src/app/(sanity)/components/theme.tsx
+++ b/apps/www/src/app/(sanity)/components/theme.tsx
@@ -1,14 +1,7 @@
-'use client'
-
-import { useForceTheme } from '@/app/components/theme-provider'
 import type { Theme } from '@/sanity.types'
 
 export function Theme({ theme }: { theme?: Omit<Theme, '_type'> }) {
   if (!theme) return null
-
-  if (theme.darkMode) {
-    useForceTheme('dark')
-  }
 
   return (
     <style>{`:root { --page-theme-accent-color: ${theme?.accentColor?.hex}; }`}</style>

--- a/apps/www/src/app/(sanity)/layout.tsx
+++ b/apps/www/src/app/(sanity)/layout.tsx
@@ -1,0 +1,17 @@
+import { PreviewThemeListener } from '@/app/(sanity)/components/preview-theme-listener'
+
+// Group-level layout for all preview routes. Mounts the dark-mode listener once
+// so the Studio preview toggle works across articles/front/pages, without
+// duplicating the per-section SanityLive/VisualEditing setup.
+export default function SanityGroupLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      <PreviewThemeListener />
+      {children}
+    </>
+  )
+}

--- a/apps/www/src/app/(sanity)/pages/[...path]/page.tsx
+++ b/apps/www/src/app/(sanity)/pages/[...path]/page.tsx
@@ -90,6 +90,8 @@ export default async function PostPage({
       <Theme theme={theme} />
 
       <div
+        // Puts the whole app in dark mode (see the `dark` condition in preset-republik.ts).
+        data-force-theme={theme?.darkMode ? 'dark' : undefined}
         className={editorialContent({
           theme: theme?.name,
         })}

--- a/apps/www/src/app/components/theme-provider.tsx
+++ b/apps/www/src/app/components/theme-provider.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider as NextThemeProvider } from 'next-themes'
 import {
   createContext,
   ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -11,44 +12,52 @@ import {
 
 export { useTheme } from 'next-themes'
 
-const ForceThemeCtx = createContext<(t: 'dark' | 'light' | undefined) => void>(
+type Theme = 'dark' | 'light' | undefined
+
+// Two force sources with fixed precedence: an explicit `manual` toggle (the
+// Sanity preview dark-mode button) wins over a `content` force (an article/page
+// whose theme.darkMode is set). Both only affect the visual theme, never content.
+type ForceSource = 'content' | 'manual'
+
+const ForceThemeCtx = createContext<(source: ForceSource, theme: Theme) => void>(
   () => {},
 )
 
-// A manual theme override, separate from the content-driven force above. Used by
-// the Sanity preview dark-mode toggle. It takes precedence over the content
-// force (`manual ?? forced`), so an editor's explicit toggle wins.
-const ManualThemeCtx = createContext<
-  (t: 'dark' | 'light' | undefined) => void
->(() => {})
-
-export function useForceTheme(theme: 'dark' | 'light' | undefined) {
-  const setForced = useContext(ForceThemeCtx)
+export function useForceTheme(theme: Theme) {
+  const setForce = useContext(ForceThemeCtx)
   useEffect(() => {
-    setForced(theme)
-    return () => setForced(undefined)
-  }, [theme, setForced])
+    setForce('content', theme)
+    return () => setForce('content', undefined)
+  }, [theme, setForce])
 }
 
-export const useSetManualTheme = () => useContext(ManualThemeCtx)
+export const useSetManualTheme = () => {
+  const setForce = useContext(ForceThemeCtx)
+  return useCallback((theme: Theme) => setForce('manual', theme), [setForce])
+}
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [forced, setForced] = useState<'dark' | 'light' | undefined>()
-  const [manual, setManual] = useState<'dark' | 'light' | undefined>()
+  const [forced, setForced] = useState<Record<ForceSource, Theme>>({
+    content: undefined,
+    manual: undefined,
+  })
+  const setForce = useCallback(
+    (source: ForceSource, theme: Theme) =>
+      setForced((prev) => ({ ...prev, [source]: theme })),
+    [],
+  )
   return (
-    <ForceThemeCtx.Provider value={setForced}>
-      <ManualThemeCtx.Provider value={setManual}>
-        <NextThemeProvider
-          attribute='data-theme'
-          disableTransitionOnChange
-          forcedTheme={manual ?? forced}
-        >
-          {/* <Head>
+    <ForceThemeCtx.Provider value={setForce}>
+      <NextThemeProvider
+        attribute='data-theme'
+        disableTransitionOnChange
+        forcedTheme={forced.manual ?? forced.content}
+      >
+        {/* <Head>
         <meta name='theme-color' content='var(--color-default)' />
       </Head> */}
-          {children}
-        </NextThemeProvider>
-      </ManualThemeCtx.Provider>
+        {children}
+      </NextThemeProvider>
     </ForceThemeCtx.Provider>
   )
 }

--- a/apps/www/src/app/components/theme-provider.tsx
+++ b/apps/www/src/app/components/theme-provider.tsx
@@ -4,9 +4,7 @@ import { ThemeProvider as NextThemeProvider } from 'next-themes'
 import {
   createContext,
   ReactNode,
-  useCallback,
   useContext,
-  useEffect,
   useState,
 } from 'react'
 
@@ -14,50 +12,27 @@ export { useTheme } from 'next-themes'
 
 type Theme = 'dark' | 'light' | undefined
 
-// Two force sources with fixed precedence: an explicit `manual` toggle (the
-// Sanity preview dark-mode button) wins over a `content` force (an article/page
-// whose theme.darkMode is set) — see `forcedTheme` below.
-type ForceSource = 'content' | 'manual'
+// Runtime theme override for the Sanity preview dark-mode toggle: the Studio
+// posts a message that `preview-theme-listener` turns into `forcedTheme`.
+//
+// Content-driven dark mode (`theme.darkMode` on an article/page) is not handled
+// here — the page renders a `data-force-theme="dark"` marker matched by the
+// `dark` Panda condition (see `preset-republik.ts`).
+const SetManualThemeCtx = createContext<(theme: Theme) => void>(() => {})
 
-const ForceThemeCtx = createContext<(source: ForceSource, theme: Theme) => void>(
-  () => {},
-)
-
-export function useForceTheme(theme: Theme) {
-  const setForce = useContext(ForceThemeCtx)
-  useEffect(() => {
-    setForce('content', theme)
-    return () => setForce('content', undefined)
-  }, [theme, setForce])
-}
-
-export const useSetManualTheme = () => {
-  const setForce = useContext(ForceThemeCtx)
-  return useCallback((theme: Theme) => setForce('manual', theme), [setForce])
-}
+export const useSetManualTheme = () => useContext(SetManualThemeCtx)
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [forced, setForced] = useState<Record<ForceSource, Theme>>({
-    content: undefined,
-    manual: undefined,
-  })
-  const setForce = useCallback(
-    (source: ForceSource, theme: Theme) =>
-      setForced((prev) => ({ ...prev, [source]: theme })),
-    [],
-  )
+  const [manual, setManual] = useState<Theme>(undefined)
   return (
-    <ForceThemeCtx.Provider value={setForce}>
+    <SetManualThemeCtx.Provider value={setManual}>
       <NextThemeProvider
         attribute='data-theme'
         disableTransitionOnChange
-        forcedTheme={forced.manual ?? forced.content}
+        forcedTheme={manual}
       >
-        {/* <Head>
-        <meta name='theme-color' content='var(--color-default)' />
-      </Head> */}
         {children}
       </NextThemeProvider>
-    </ForceThemeCtx.Provider>
+    </SetManualThemeCtx.Provider>
   )
 }

--- a/apps/www/src/app/components/theme-provider.tsx
+++ b/apps/www/src/app/components/theme-provider.tsx
@@ -15,6 +15,13 @@ const ForceThemeCtx = createContext<(t: 'dark' | 'light' | undefined) => void>(
   () => {},
 )
 
+// A manual theme override, separate from the content-driven force above. Used by
+// the Sanity preview dark-mode toggle. It takes precedence over the content
+// force (`manual ?? forced`), so an editor's explicit toggle wins.
+const ManualThemeCtx = createContext<
+  (t: 'dark' | 'light' | undefined) => void
+>(() => {})
+
 export function useForceTheme(theme: 'dark' | 'light' | undefined) {
   const setForced = useContext(ForceThemeCtx)
   useEffect(() => {
@@ -23,20 +30,25 @@ export function useForceTheme(theme: 'dark' | 'light' | undefined) {
   }, [theme, setForced])
 }
 
+export const useSetManualTheme = () => useContext(ManualThemeCtx)
+
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [forced, setForced] = useState<'dark' | 'light' | undefined>()
+  const [manual, setManual] = useState<'dark' | 'light' | undefined>()
   return (
     <ForceThemeCtx.Provider value={setForced}>
-      <NextThemeProvider
-        attribute='data-theme'
-        disableTransitionOnChange
-        forcedTheme={forced}
-      >
-        {/* <Head>
+      <ManualThemeCtx.Provider value={setManual}>
+        <NextThemeProvider
+          attribute='data-theme'
+          disableTransitionOnChange
+          forcedTheme={manual ?? forced}
+        >
+          {/* <Head>
         <meta name='theme-color' content='var(--color-default)' />
       </Head> */}
-        {children}
-      </NextThemeProvider>
+          {children}
+        </NextThemeProvider>
+      </ManualThemeCtx.Provider>
     </ForceThemeCtx.Provider>
   )
 }

--- a/apps/www/src/app/components/theme-provider.tsx
+++ b/apps/www/src/app/components/theme-provider.tsx
@@ -1,12 +1,7 @@
 'use client'
 
 import { ThemeProvider as NextThemeProvider } from 'next-themes'
-import {
-  createContext,
-  ReactNode,
-  useContext,
-  useState,
-} from 'react'
+import { createContext, ReactNode, useContext, useState } from 'react'
 
 export { useTheme } from 'next-themes'
 
@@ -18,21 +13,21 @@ type Theme = 'dark' | 'light' | undefined
 // Content-driven dark mode (`theme.darkMode` on an article/page) is not handled
 // here — the page renders a `data-force-theme="dark"` marker matched by the
 // `dark` Panda condition (see `preset-republik.ts`).
-const SetManualThemeCtx = createContext<(theme: Theme) => void>(() => {})
+const ForceThemeCtx = createContext<(theme: Theme) => void>(() => {})
 
-export const useSetManualTheme = () => useContext(SetManualThemeCtx)
+export const useSetManualTheme = () => useContext(ForceThemeCtx)
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [manual, setManual] = useState<Theme>(undefined)
+  const [forced, setForced] = useState<Theme>(undefined)
   return (
-    <SetManualThemeCtx.Provider value={setManual}>
+    <ForceThemeCtx.Provider value={setForced}>
       <NextThemeProvider
         attribute='data-theme'
         disableTransitionOnChange
-        forcedTheme={manual}
+        forcedTheme={forced}
       >
         {children}
       </NextThemeProvider>
-    </SetManualThemeCtx.Provider>
+    </ForceThemeCtx.Provider>
   )
 }

--- a/apps/www/src/app/components/theme-provider.tsx
+++ b/apps/www/src/app/components/theme-provider.tsx
@@ -16,7 +16,7 @@ type Theme = 'dark' | 'light' | undefined
 
 // Two force sources with fixed precedence: an explicit `manual` toggle (the
 // Sanity preview dark-mode button) wins over a `content` force (an article/page
-// whose theme.darkMode is set). Both only affect the visual theme, never content.
+// whose theme.darkMode is set) — see `forcedTheme` below.
 type ForceSource = 'content' | 'manual'
 
 const ForceThemeCtx = createContext<(source: ForceSource, theme: Theme) => void>(

--- a/packages/theme/presets/preset-republik.ts
+++ b/packages/theme/presets/preset-republik.ts
@@ -7,7 +7,11 @@ export const presetRepublik = definePreset({
   conditions: {
     extend: {
       light: '[data-theme="light"] &',
-      dark: '[data-theme="dark"] &',
+      // Dark applies when an ancestor is `[data-theme="dark"]`, or when a
+      // `data-force-theme="dark"` marker exists anywhere in the document — the
+      // latter puts the whole app in dark mode and outranks a `[data-theme]` set
+      // on `<html>` (e.g. by next-themes).
+      dark: ':is([data-theme="dark"], :root:has([data-force-theme="dark"])) &',
       stateOpen: '&[data-state="open"]',
       stateClosed: '&[data-state="closed"]',
     },


### PR DESCRIPTION
Changes the way theme.darkMode is handled. Not via useEffect but the page/article renders a `data-force-theme="dark"` marker on its content wrapper, and the Panda dark condition matches it from the root via `:root:has([data-force-theme="dark"])`.  `:has()` is anchored on , so it matches regardless of how deep the marker sits.
The sanity preview toggle is handled via useEffect and theme-provider

Tested and both the preview toggle and darkmode theme selection create the desired effect. darkmode theme requires refresh of the preview (expected), preview toggle is instant