### PR TITLE
Add reading-position pill to Sanity articles

### DIFF
--- a/apps/www/graphql/republik-api/mutations/ReadingPositionMutations.gql
+++ b/apps/www/graphql/republik-api/mutations/ReadingPositionMutations.gql
@@ -1,0 +1,22 @@
+# Deliberately narrower than `upsertDocumentProgress` in ProgressMutations.gql,
+# which selects through `document { userProgress { … } }`: Sanity-backed items
+# resolve to a null `Document` by design, so there is nothing to read back there.
+#
+# `nodeId` is `String!` in the schema and can't be omitted. Positions here are
+# percentage-only — the Sanity renderer emits no `[data-pos]` anchors to name —
+# so it goes out empty, the same way mark-as-read always has.
+mutation UpsertReadingPosition(
+  $documentId: ID!
+  $percentage: Float!
+  $nodeId: String!
+) {
+  upsertDocumentProgress(
+    documentId: $documentId
+    percentage: $percentage
+    nodeId: $nodeId
+  ) {
+    id
+    percentage
+    updatedAt
+  }
+}

--- a/apps/www/graphql/republik-api/queries/UserDocumentProgressQuery.gql
+++ b/apps/www/graphql/republik-api/queries/UserDocumentProgressQuery.gql
@@ -1,0 +1,12 @@
+query UserDocumentProgress($documentId: ID!) {
+  userDocumentProgress(documentId: $documentId) {
+    id
+    percentage
+    updatedAt
+    max {
+      id
+      percentage
+      updatedAt
+    }
+  }
+}

--- a/apps/www/src/app/(sanity)/[...path]/components/article-document.tsx
+++ b/apps/www/src/app/(sanity)/[...path]/components/article-document.tsx
@@ -1,5 +1,8 @@
 import { ArticleBottomActions } from '@/app/(sanity)/components/article-actions/article-bottom-actions'
 import { ArticleTopActions } from '@/app/(sanity)/components/article-actions/article-top-actions'
+import { JumpToReadingPosition } from '@/app/(sanity)/components/article-actions/continue-reading-action'
+import { collectionsDocumentId } from '@/app/(sanity)/components/article-actions/document-id'
+import { ReadingPositionTracker } from '@/app/(sanity)/components/article-actions/reading-position-tracker'
 import { ContentWall } from '@/app/(sanity)/[...path]/components/content-wall'
 import { EditLink } from '@/app/(sanity)/components/edit-link'
 import FollowArticle from '@/app/(sanity)/components/follow/follow-article'
@@ -33,6 +36,7 @@ export default function ArticleDocument({
     readingAccess,
   } = article
   const seriesId = articleCollection?.series && articleCollection?._id
+  const documentId = collectionsDocumentId(article)
 
   return (
     <EventTrackingContext category='Article'>
@@ -69,6 +73,10 @@ export default function ArticleDocument({
 
         <ArticleTopActions article={article} />
 
+        {/* Floating, viewport-anchored — but inside the <article> it measures
+            against, and early in the tab order for an offer made on arrival. */}
+        <JumpToReadingPosition documentId={documentId} />
+
         <div>
           <EditLink documentId={article._id} documentType='article' />
         </div>
@@ -78,6 +86,9 @@ export default function ArticleDocument({
           excerpt={<ArticlePortableText value={article.content?.slice(0, 5)} />}
           fullContent={<ArticlePortableText value={article.content} />}
         />
+
+        {/* End of the text: everything below is outside the measured region. */}
+        <ReadingPositionTracker documentId={documentId} />
 
         <ArticleBottomActions article={article} />
 

--- a/apps/www/src/app/(sanity)/components/article-actions/action-style.ts
+++ b/apps/www/src/app/(sanity)/components/article-actions/action-style.ts
@@ -29,3 +29,15 @@ export const actionLabelStyle = css({
   display: 'none',
   md: { display: 'inline' },
 })
+
+// For actions that always carry their label: play and continue-reading.
+export const pillStyle = css({
+  alignItems: 'center',
+  backgroundColor: 'hover',
+  borderRadius: '9999px',
+  display: 'inline-flex',
+  gap: '2',
+  paddingLeft: '2',
+  paddingRight: '3',
+  paddingY: '2',
+})

--- a/apps/www/src/app/(sanity)/components/article-actions/continue-reading-action.tsx
+++ b/apps/www/src/app/(sanity)/components/article-actions/continue-reading-action.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { useAudioContext } from '@/components/Audio/AudioProvider'
+import { useMe } from '@/lib/context/MeContext'
+import { useQuery } from '@apollo/client'
+import { UserDocumentProgressDocument } from '#graphql/republik-api/__generated__/gql/graphql'
+import { css, cx } from '@republik/theme/css'
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { ACTION_ICON_SIZE, actionStyle, pillStyle } from './action-style'
+import { readingRegion, scrollPaddingTop } from './reading-region'
+
+/** Tolerance for "at the very top", to survive sub-pixel scroll offsets. */
+const AT_TOP_THRESHOLD = 4
+
+const trackStyle = css({
+  color: 'divider',
+})
+
+const arcStyle = css({
+  transformBox: 'fill-box',
+  transformOrigin: 'center',
+  transform: 'rotate(-90deg)',
+  transition: 'stroke-dashoffset 0.35s',
+})
+
+/**
+ * Floating layer anchored to the bottom of the viewport, centred, and
+ * click-through everywhere but on the pill itself. It stays mounted while
+ * hidden so it can fade out; the delayed `visibility` and `inert` (see the
+ * component) keep it away from the pointer, the tab order and screen readers
+ * in between.
+ *
+ * Below the mini audio player (`ZINDEX_POPOVER + 1`) and the paynote bar
+ * (9998), above article content (`ZINDEX_CONTENT`) — see
+ * `src/components/constants.js`.
+ */
+const layerStyle = css({
+  bottom: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  left: 0,
+  opacity: 0,
+  paddingBottom: 'calc(15px + env(safe-area-inset-bottom))',
+  paddingX: '4',
+  pointerEvents: 'none',
+  position: 'fixed',
+  right: 0,
+  transform: 'translateY(0.5rem)',
+  transition:
+    'opacity 200ms ease-out, transform 200ms ease-out, visibility 0s linear 200ms',
+  visibility: 'hidden',
+  zIndex: 16,
+  '&[data-visible="true"]': {
+    opacity: 1,
+    transform: 'none',
+    transition: 'opacity 200ms ease-out, transform 200ms ease-out',
+    visibility: 'visible',
+  },
+  '@media print': {
+    display: 'none',
+  },
+})
+
+// The pill is the same as the play action's; only the layer around it is
+// click-through, so the button has to take pointer events back.
+const clickableStyle = css({
+  pointerEvents: 'auto',
+})
+
+/**
+ * Percentage ring, adapted from the legacy `ProgressCircle`
+ * (`packages/styleguide/src/components/Progress/Circle.tsx`): a `divider`
+ * track behind a `currentColor` arc that fills clockwise from 12 o'clock.
+ */
+function ReadingPositionIcon({ percent }: { percent: number }) {
+  const r = 10
+  const circumference = 2 * Math.PI * r
+  const clamped = Math.min(Math.max(percent, 0), 100)
+
+  return (
+    <svg
+      width={ACTION_ICON_SIZE}
+      height={ACTION_ICON_SIZE}
+      viewBox='0 0 24 24'
+      fill='none'
+    >
+      <circle
+        className={trackStyle}
+        cx='12'
+        cy='12'
+        r={r}
+        stroke='currentColor'
+        strokeWidth={2}
+      />
+      <circle
+        className={arcStyle}
+        cx='12'
+        cy='12'
+        r={r}
+        stroke='currentColor'
+        strokeWidth={2}
+        strokeLinecap='round'
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - (clamped / 100) * circumference}
+      />
+    </svg>
+  )
+}
+
+const subscribeToScroll = (onStoreChange: () => void) => {
+  window.addEventListener('scroll', onStoreChange, { passive: true })
+  return () => window.removeEventListener('scroll', onStoreChange)
+}
+
+const isAtScrollTop = () => window.scrollY <= AT_TOP_THRESHOLD
+
+// Server snapshot: there's never a position to offer before hydration anyway.
+const notAtScrollTop = () => false
+
+/**
+ * Whether the reader is at the very top of the page. Reading the offset through
+ * `useSyncExternalStore` makes the first client render already correct, so a
+ * reader who lands mid-article — restored scroll position, anchor link — never
+ * sees the action flash into view.
+ */
+function useAtScrollTop() {
+  return useSyncExternalStore(subscribeToScroll, isAtScrollTop, notAtScrollTop)
+}
+
+/**
+ * Percentage only — the counterpart to `ReadingPositionTracker`, measuring the
+ * same region. There is no anchor branch: positions on Sanity articles carry no
+ * `nodeId`, because the renderer emits no `[data-pos]` to name.
+ */
+function scrollToReadingPosition(container: Element, percentage: number) {
+  const { top, height } = readingRegion(container)
+
+  window.scrollTo({
+    top: window.scrollY + top + percentage * height - scrollPaddingTop(),
+    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ? 'auto'
+      : 'smooth',
+  })
+}
+
+/**
+ * Reading position of the current article, keyed by `sanity:<_id>` — the same
+ * reference bookmarks use (see `collectionsDocumentId`). `userDocumentProgress`
+ * accepts that id directly and returns the stored percentage without resolving a
+ * (Sanity-backed articles have none) GraphQL `Document`.
+ *
+ * Only members have anything to resume — logged-out readers hit the paywall
+ * before scrolling far enough to generate a position, and the query would
+ * just come back null for them.
+ */
+function useReadingPosition({ documentId }: { documentId?: string }) {
+  const { isMember, hasActiveMembership } = useMe()
+  const canTrack = isMember && hasActiveMembership
+  const skip = !documentId || !canTrack
+
+  const { data, refetch } = useQuery(UserDocumentProgressDocument, {
+    variables: { documentId },
+    skip,
+  })
+
+  const progress = data?.userDocumentProgress
+  // `max` is the furthest the reader ever got, `percentage` is where they last
+  // stopped. The ring reports the furthest — as the legacy action bar did —
+  // while the jump goes to the last position.
+  const furthest = progress?.max?.percentage ?? progress?.percentage
+
+  return {
+    /** Rounded percentage of the furthest position, undefined while there's none. */
+    percent: furthest === undefined ? undefined : Math.round(furthest * 100),
+    /** Where to scroll back to, 0…1. */
+    resumeAt: progress?.percentage,
+    /** Undefined while the query is skipped — `refetch` would run it anyway. */
+    refresh: skip ? undefined : refetch,
+  }
+}
+
+export function JumpToReadingPosition({ documentId }: { documentId?: string }) {
+  const ref = useRef<HTMLButtonElement>(null)
+  const { percent, resumeAt, refresh } = useReadingPosition({ documentId })
+  const atTop = useAtScrollTop()
+  // The mini player occupies the same corner of the viewport (full width on
+  // small screens), so it takes precedence.
+  const { audioPlayerVisible } = useAudioContext()
+
+  // The position moves while the reader reads, so the one this component
+  // mounted with goes stale. Re-read it every time they come back to the top,
+  // which is the only moment the action is offered again.
+  const wasAtTop = useRef(atTop)
+  useEffect(() => {
+    const returnedToTop = atTop && !wasAtTop.current
+    wasAtTop.current = atTop
+    if (returnedToTop) {
+      refresh?.()
+    }
+  }, [atTop, refresh])
+
+  // Nothing to resume, or nothing left to resume to.
+  if (percent === undefined || percent >= 100 || !resumeAt) {
+    return null
+  }
+
+  const visible = atTop && !audioPlayerVisible
+
+  return (
+    <div className={layerStyle} data-visible={visible} inert={!visible}>
+      <button
+        className={cx(
+          actionStyle,
+          pillStyle,
+          clickableStyle,
+          // Same shadow the mini audio player uses for its own fixed-bottom
+          // wrapper (`AudioPlayer.tsx`) — much lower alpha than `md`, which
+          // reads too heavy floating over arbitrary article content.
+          css({ boxShadow: 'overlay' }),
+        )}
+        onClick={() => {
+          // The layer renders inside the <article>, which is the element the
+          // stored position is measured against.
+          const container = ref.current?.closest('article')
+          if (container) {
+            scrollToReadingPosition(container, resumeAt)
+          }
+        }}
+        ref={ref}
+        title='Weiterlesen'
+        type='button'
+      >
+        <ReadingPositionIcon percent={percent} />
+        Weiterlesen
+      </button>
+    </div>
+  )
+}

--- a/apps/www/src/app/(sanity)/components/article-actions/play-action.tsx
+++ b/apps/www/src/app/(sanity)/components/article-actions/play-action.tsx
@@ -7,18 +7,7 @@ import type { AudioPlayerItem } from '@/components/Audio/types/AudioPlayerItem'
 import { CirclePlay, CirclePause } from 'lucide-react'
 import { css, cx } from '@republik/theme/css'
 import { useState } from 'react'
-import { actionStyle, ACTION_ICON_SIZE } from './action-style'
-
-const pillStyle = css({
-  alignItems: 'center',
-  backgroundColor: 'hover',
-  borderRadius: '9999px',
-  display: 'inline-flex',
-  gap: '2',
-  paddingLeft: '2',
-  paddingRight: '3',
-  paddingY: '2',
-})
+import { actionStyle, ACTION_ICON_SIZE, pillStyle } from './action-style'
 
 export function PlayAction({
   documentId,

--- a/apps/www/src/app/(sanity)/components/article-actions/reading-position-tracker.tsx
+++ b/apps/www/src/app/(sanity)/components/article-actions/reading-position-tracker.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useMe } from '@/lib/context/MeContext'
+import { useMutation } from '@apollo/client'
+import { UpsertReadingPositionDocument } from '#graphql/republik-api/__generated__/gql/graphql'
+import { css } from '@republik/theme/css'
+import debounce from 'lodash/debounce'
+import { useEffect, useRef } from 'react'
+import { readingEndAttribute, readingPercentage } from './reading-region'
+
+const SAVE_DEBOUNCE_MS = 300
+
+/**
+ * Below this, there is nothing worth coming back to — a reader who nudged the
+ * page shouldn't be offered a jump back to it. Stands in for the legacy
+ * tracker's `MIN_INDEX`, which ignored the first two content blocks.
+ */
+const MIN_SAVED_PERCENTAGE = 0.02
+
+// Purely a measuring point, not a block: the content grid spaces every direct
+// child with a top margin, which the utilities layer overrides back to zero.
+const markerStyle = css({
+  height: 0,
+  marginTop: 0,
+})
+
+/**
+ * Records how far the reader gets, and marks the end of the editorial content
+ * for `readingRegion`. Render it as a sibling of the content blocks, directly
+ * after them.
+ *
+ * Percentage only, no `nodeId`: the legacy tracker stored the closest
+ * `[data-pos]` anchor, and the Sanity portable-text renderer emits none. The
+ * mutation requires the field, so it goes out empty, and
+ * `JumpToReadingPosition` restores by percentage — the path it already took
+ * whenever an anchor had disappeared from a re-edited article.
+ */
+export function ReadingPositionTracker({ documentId }: { documentId: string }) {
+  const marker = useRef<HTMLDivElement>(null)
+  const [upsertReadingPosition] = useMutation(UpsertReadingPositionDocument)
+
+  // Writing is gated the same way reading is (`useReadingPosition`), plus the
+  // opt-out: readers who declined progress tracking in their settings are not
+  // tracked here either.
+  const { isMember, hasActiveMembership, progressConsent } = useMe()
+  const canTrack = isMember && hasActiveMembership && progressConsent
+
+  // The scroll handler stays mounted for the lifetime of the article and reads
+  // whatever is current here, rather than being torn down and rebuilt (losing
+  // its pending call) every time `me` resolves.
+  const latest = useRef({ canTrack, documentId, upsertReadingPosition })
+  useEffect(() => {
+    latest.current = { canTrack, documentId, upsertReadingPosition }
+  })
+
+  useEffect(() => {
+    let lastY: number | undefined
+    let lastSavedPercent: number | undefined
+
+    const save = debounce(() => {
+      const { canTrack, documentId, upsertReadingPosition } = latest.current
+      const container = marker.current?.closest('article')
+      if (!canTrack || !container) {
+        return
+      }
+
+      // Measured between debounced calls rather than per event, to handle bouncy
+      // upward scroll on iOS: y200 → y250 while scrolling, then a bounce back to
+      // y210. Only downward movement counts as reading.
+      const y = window.scrollY
+      const downwards = lastY === undefined || y > lastY
+      lastY = y
+      if (!downwards) {
+        return
+      }
+
+      const percentage = readingPercentage(container)
+      // Whole percent is the granularity the ring renders at, so anything finer
+      // would be another request for an identical picture.
+      const percent = Math.floor(percentage * 100)
+      if (percentage < MIN_SAVED_PERCENTAGE || percent === lastSavedPercent) {
+        return
+      }
+      lastSavedPercent = percent
+
+      upsertReadingPosition({
+        variables: { documentId, percentage, nodeId: '' },
+      }).catch((error) => {
+        // Let the next scroll retry this percentage. Failures are swallowed
+        // with a warning, as elsewhere in the action bar.
+        lastSavedPercent = undefined
+        console.warn('ReadingPosition: could not save position', error)
+      })
+    }, SAVE_DEBOUNCE_MS)
+
+    window.addEventListener('scroll', save, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', save)
+      save.cancel()
+    }
+  }, [])
+
+  return <div className={markerStyle} ref={marker} {...readingEndAttribute} />
+}

--- a/apps/www/src/app/(sanity)/components/article-actions/reading-region.ts
+++ b/apps/www/src/app/(sanity)/components/article-actions/reading-region.ts
@@ -1,0 +1,68 @@
+/**
+ * The stretch of the page reading positions are measured against: the top of
+ * the `<article>` down to the end of the editorial content, marked by
+ * `ReadingPositionTracker`. Everything after that mark — bottom actions, follow
+ * prompts, recommendations — stays outside, so a reader who finishes the text
+ * arrives at 100% instead of stalling somewhere in the eighties.
+ *
+ * The writer (`ReadingPositionTracker`) and the reader
+ * (`JumpToReadingPosition`) both measure through here: a stored percentage only
+ * means anything against the box it was recorded against.
+ */
+
+const READING_END_SELECTOR = '[data-reading-end]'
+
+/** Marks the end of the content. Spread onto the element, see the tracker. */
+export const readingEndAttribute = { 'data-reading-end': '' }
+
+export function readingRegion(container: Element) {
+  const { top, bottom } = container.getBoundingClientRect()
+  const end = container.querySelector(READING_END_SELECTOR)
+
+  return {
+    top,
+    // Guards the division below, and a `scrollTo` against a collapsed article.
+    height: Math.max((end?.getBoundingClientRect().top ?? bottom) - top, 1),
+  }
+}
+
+/**
+ * What the sticky header covers. `scroll-padding-top` applies to
+ * scroll-into-view and snapping, but not to programmatic `scrollTo` or to
+ * measurements — so read the same value rather than introducing a constant that
+ * would drift from it.
+ */
+export function scrollPaddingTop() {
+  return (
+    parseFloat(getComputedStyle(document.documentElement).scrollPaddingTop) || 0
+  )
+}
+
+/**
+ * How far the reader has got through the region, 0…1, mirroring the legacy
+ * tracker (`src/components/Article/Progress/index.js`): the position is where
+ * the reading line just below the header sits, and it snaps to 1 once the end of
+ * the text is on screen — the last screenful can never be scrolled above the
+ * reading line, so nothing would ever reach 100% otherwise.
+ *
+ * Where the legacy tracker leaned on `MIN_INDEX` to stay out of trouble, the
+ * guards here are explicit: a text that fits on one screen has its end in view
+ * from the start, and would otherwise report itself read on arrival.
+ */
+export function readingPercentage(container: Element) {
+  const { top, height } = readingRegion(container)
+
+  // Nothing to record: the reader can see the whole text without scrolling.
+  if (height <= window.innerHeight - scrollPaddingTop()) {
+    return 0
+  }
+
+  const read = Math.max(0, -top + scrollPaddingTop())
+  if (read === 0) {
+    return 0
+  }
+  if (-top + window.innerHeight > height) {
+    return 1
+  }
+  return Math.min(read / height, 1)
+}


### PR DESCRIPTION
Floating bottom-anchored button to resume reading, visible only at scroll top and hidden once the article is fully read. Percentage-only tracking (no per-block anchors) via a new ReadingPositionTracker.

<img width="815" height="537" alt="Screenshot 2026-07-31 at 16 15 09" src="https://github.com/user-attachments/assets/a86d3d50-5b82-44c9-9680-f17d76f71e64" />
