### PR TITLE
Font size article implementation

### DIFF
--- a/apps/www/src/app/(sanity)/[...path]/layout.tsx
+++ b/apps/www/src/app/(sanity)/[...path]/layout.tsx
@@ -1,4 +1,3 @@
-import { PreviewPageLayout } from '@/app/(sanity)/components/preview/preview-page-layout'
 import { FontSizeStyle } from '@/app/components/font-size-style'
 import { FontSizeSync } from '@/app/components/font-size-sync'
 import { PageLayout } from '@/app/components/layout'
@@ -11,8 +10,6 @@ export default async function RootLayout({
 }>) {
   return (
     <PageLayout>
-      {/* Reader font size: applied server-side before paint, then kept in sync
-          on the client. Scoped to the reading views, as in the Pages Router. */}
       <FontSizeStyle />
       <FontSizeSync />
       <div

--- a/apps/www/src/app/(sanity)/[...path]/layout.tsx
+++ b/apps/www/src/app/(sanity)/[...path]/layout.tsx
@@ -1,3 +1,6 @@
+import { PreviewPageLayout } from '@/app/(sanity)/components/preview/preview-page-layout'
+import { FontSizeStyle } from '@/app/components/font-size-style'
+import { FontSizeSync } from '@/app/components/font-size-sync'
 import { PageLayout } from '@/app/components/layout'
 import { css } from '@republik/theme/css'
 
@@ -8,6 +11,10 @@ export default async function RootLayout({
 }>) {
   return (
     <PageLayout>
+      {/* Reader font size: applied server-side before paint, then kept in sync
+          on the client. Scoped to the reading views, as in the Pages Router. */}
+      <FontSizeStyle />
+      <FontSizeSync />
       <div
         className={css({
           color: 'text',

--- a/apps/www/src/app/(sanity)/components/article-actions/article-top-actions.tsx
+++ b/apps/www/src/app/(sanity)/components/article-actions/article-top-actions.tsx
@@ -65,7 +65,7 @@ export function ArticleTopActions({ article }: ArticleTopActionsProps) {
   const documentId = collectionsDocumentId(article)
   const path = article.slug
   const title = article.plainTitle
-  console.log('article', article)
+
   return (
     <div
       className={css({

--- a/apps/www/src/app/(sanity)/components/article-actions/article-top-actions.tsx
+++ b/apps/www/src/app/(sanity)/components/article-actions/article-top-actions.tsx
@@ -7,10 +7,12 @@ import { PdfDownloadAction } from './pdf-download-action'
 import { PlayAction } from './play-action'
 import { ShareAction } from './share-action'
 import type { ArticleDocumentType } from '@/app/(sanity)/groq/document-query'
+import { FontSizeDialog } from '@/app/components/ui/font-size-dialog'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { css } from '@republik/theme/css'
-import { EllipsisVertical } from 'lucide-react'
 import { DiscussionAction } from './discussion-action'
+import { AArrowUp, EllipsisVertical } from 'lucide-react'
+import { useState } from 'react'
 
 const menuTriggerStyle = css({
   cursor: 'pointer',
@@ -59,6 +61,7 @@ export type ArticleTopActionsProps = {
 }
 
 export function ArticleTopActions({ article }: ArticleTopActionsProps) {
+  const [fontSizeOpen, setFontSizeOpen] = useState(false)
   const documentId = collectionsDocumentId(article)
   const path = article.slug
   const title = article.plainTitle
@@ -108,9 +111,23 @@ export function ArticleTopActions({ article }: ArticleTopActionsProps) {
                 className={menuItemStyle}
               />
             </DropdownMenu.Item>
+            <DropdownMenu.Item
+              className={menuItemStyle}
+              onSelect={() => setFontSizeOpen(true)}
+            >
+              <AArrowUp size={ACTION_ICON_SIZE} />
+              Schriftgrösse
+            </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
+
+      {/*
+        Sibling of DropdownMenu.Root, never a child: opening a Radix Dialog
+        from inside a closing Dialog/DropdownMenu strands `pointer-events:
+        none` on <body>.
+      */}
+      <FontSizeDialog open={fontSizeOpen} onOpenChange={setFontSizeOpen} />
     </div>
   )
 }

--- a/apps/www/src/app/(sanity)/components/portable-text/block-quote.tsx
+++ b/apps/www/src/app/(sanity)/components/portable-text/block-quote.tsx
@@ -11,13 +11,15 @@ const containerStyle = css({
     px: '6',
   },
 
+  // Sizes follow the reader's font size setting — see `READER_FONT_SCALE` in the
+  // theme package.
   '& > *': {
     fontFamily: 'gtAmericaStandard',
-    fontSize: '0.9375rem',
+    fontSize: 'calc(0.9375rem * var(--article-font-scale, 1))',
     lineHeight: 1.4,
     pt: '3',
     md: {
-      fontSize: '1.125rem',
+      fontSize: 'calc(1.125rem * var(--article-font-scale, 1))',
       lineHeight: 1.5,
       pt: '4',
     },

--- a/apps/www/src/app/(sanity)/components/portable-text/caption.tsx
+++ b/apps/www/src/app/(sanity)/components/portable-text/caption.tsx
@@ -2,23 +2,25 @@ import { InlinePortableText } from '@/app/(sanity)/components/portable-text/rend
 import { type Caption } from '@/sanity.types'
 import { css, cx } from '@republik/theme/css'
 
+// Sizes follow the reader's font size setting — see `READER_FONT_SCALE` in the
+// theme package. Outside editorial content the `1` fallback applies.
 const legendStyle = css({
   fontFamily: 'gtAmericaStandard',
-  fontSize: '0.75rem',
+  fontSize: 'calc(0.75rem * var(--article-font-scale, 1))',
   lineHeight: '1.2',
   color: 'text',
   md: {
-    fontSize: '0.9375rem',
+    fontSize: 'calc(0.9375rem * var(--article-font-scale, 1))',
   },
 })
 
 const creditStyle = css({
-  fontSize: '0.625rem',
+  fontSize: 'calc(0.625rem * var(--article-font-scale, 1))',
   _before: {
     content: '" "',
   },
   md: {
-    fontSize: '0.75rem',
+    fontSize: 'calc(0.75rem * var(--article-font-scale, 1))',
   },
 })
 

--- a/apps/www/src/app/(sanity)/components/portable-text/note.tsx
+++ b/apps/www/src/app/(sanity)/components/portable-text/note.tsx
@@ -4,11 +4,13 @@ import { ReactNode } from 'react'
 export function Note({ children }: { children?: ReactNode }) {
   return (
     <p
+      // Sizes follow the reader's font size setting — see `READER_FONT_SCALE` in
+      // the theme package.
       className={css({
         textStyle: 'sans',
-        fontSize: 'xs',
+        fontSize: 'calc(token(fontSizes.xs) * var(--article-font-scale, 1))',
         md: {
-          fontSize: 's',
+          fontSize: 'calc(token(fontSizes.s) * var(--article-font-scale, 1))',
         },
       })}
     >

--- a/apps/www/src/app/(sanity)/components/portable-text/pull-quote.tsx
+++ b/apps/www/src/app/(sanity)/components/portable-text/pull-quote.tsx
@@ -2,14 +2,16 @@ import type { PullQuote } from '@/sanity.types'
 import { css, cx } from '@republik/theme/css'
 import { AsideImage } from './aside-image'
 
+// Sizes follow the reader's font size setting — see `READER_FONT_SCALE` in the
+// theme package.
 const quoteStyle = css({
   textStyle: 'serifBold',
-  fontSize: '3xl',
+  fontSize: 'calc(token(fontSizes.3xl) * var(--article-font-scale, 1))',
 })
 
 const sourceStyle = css({
   textStyle: 'sans',
-  fontSize: 's',
+  fontSize: 'calc(token(fontSizes.s) * var(--article-font-scale, 1))',
 })
 
 export function PullQuote({ value }: { value: PullQuote }) {

--- a/apps/www/src/app/components/font-size-style.tsx
+++ b/apps/www/src/app/components/font-size-style.tsx
@@ -1,0 +1,24 @@
+import { FONT_SIZE_COOKIE, isValidFontSize } from '@/app/lib/font-size'
+import { cookies } from 'next/headers'
+
+/**
+ * Applies the reader's font size before first paint, server-side.
+ *
+ * A `<style>` element rather than an inline script: the value is only ever a
+ * number, CSS can't execute, and it needs no `dangerouslySetInnerHTML`.
+ *
+ * Only render this from layouts that are already dynamic — `cookies()` opts a
+ * route out of static rendering, and several route groups depend on ISR
+ * (`revalidate = 60`). The articles layout already calls `draftMode()`, so it
+ * costs nothing there.
+ */
+export async function FontSizeStyle() {
+  const raw = (await cookies()).get(FONT_SIZE_COOKIE)?.value
+  const fontSize = Number(raw)
+
+  if (!isValidFontSize(fontSize)) {
+    return null
+  }
+
+  return <style>{`:root{font-size:${fontSize}px}`}</style>
+}

--- a/apps/www/src/app/components/font-size-style.tsx
+++ b/apps/www/src/app/components/font-size-style.tsx
@@ -1,16 +1,25 @@
-import { FONT_SIZE_COOKIE, isValidFontSize } from '@/app/lib/font-size'
+import {
+  FONT_SIZE_COOKIE,
+  fontSizeScale,
+  isValidFontSize,
+} from '@/app/lib/font-size'
 import { cookies } from 'next/headers'
 
 /**
- * Applies the reader's font size before first paint, server-side.
+ * Publishes the reader's font size before first paint, server-side.
+ *
+ * `--reader-font-scale` on `:root` is inert on its own — only the
+ * `editorialContent` recipe picks it up (as `--article-font-scale`), which is
+ * what confines the setting to article body text instead of scaling the whole
+ * rem-based app.
  *
  * A `<style>` element rather than an inline script: the value is only ever a
  * number, CSS can't execute, and it needs no `dangerouslySetInnerHTML`.
  *
  * Only render this from layouts that are already dynamic — `cookies()` opts a
  * route out of static rendering, and several route groups depend on ISR
- * (`revalidate = 60`). The articles layout already calls `draftMode()`, so it
- * costs nothing there.
+ * (`revalidate = 60`). The articles layout is already dynamic, so it costs
+ * nothing there.
  */
 export async function FontSizeStyle() {
   const raw = (await cookies()).get(FONT_SIZE_COOKIE)?.value
@@ -20,5 +29,7 @@ export async function FontSizeStyle() {
     return null
   }
 
-  return <style>{`:root{font-size:${fontSize}px}`}</style>
+  return (
+    <style>{`:root{--reader-font-scale:${fontSizeScale(fontSize)}}`}</style>
+  )
 }

--- a/apps/www/src/app/components/font-size-sync.tsx
+++ b/apps/www/src/app/components/font-size-sync.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { DEFAULT_FONT_SIZE, isValidFontSize } from '@/app/lib/font-size'
+import { useFontSize } from '@/lib/fontSize'
+import { writeFontSizeCookie } from '@/lib/fontSizeCookie'
+import { useEffect } from 'react'
+
+/**
+ * Keeps the document root in sync with the reader's font size.
+ *
+ * localStorage remains the source of truth — the Pages Router reads it directly
+ * and `usePersistedState` broadcasts changes across instances and tabs, so the
+ * font-size dialog reaches this component with no extra wiring.
+ *
+ * `useFontSize` mirrors the cookie on every write, so the reconcile below only
+ * matters for readers who set a size before that cookie existed: without it
+ * their stored size would never reach the server.
+ */
+export function FontSizeSync() {
+  const [fontSize] = useFontSize(DEFAULT_FONT_SIZE)
+
+  useEffect(() => {
+    if (!isValidFontSize(fontSize)) {
+      return
+    }
+
+    document.documentElement.style.fontSize = `${fontSize}px`
+    writeFontSizeCookie(fontSize)
+
+    return () => {
+      // Scoped to the reading views, like the Pages Router's FontSize/Sync —
+      // leaving the root scaled would follow the reader onto every other page.
+      document.documentElement.style.fontSize = ''
+    }
+  }, [fontSize])
+
+  return null
+}

--- a/apps/www/src/app/components/font-size-sync.tsx
+++ b/apps/www/src/app/components/font-size-sync.tsx
@@ -1,12 +1,19 @@
 'use client'
 
-import { DEFAULT_FONT_SIZE, isValidFontSize } from '@/app/lib/font-size'
+import {
+  DEFAULT_FONT_SIZE,
+  fontSizeScale,
+  isValidFontSize,
+} from '@/app/lib/font-size'
 import { useFontSize } from '@/lib/fontSize'
 import { writeFontSizeCookie } from '@/lib/fontSizeCookie'
 import { useEffect } from 'react'
 
 /**
- * Keeps the document root in sync with the reader's font size.
+ * Keeps `--reader-font-scale` on the document root in sync with the reader's
+ * font size — the client-side counterpart of `FontSizeStyle`. Only the
+ * `editorialContent` recipe consumes the property, so the setting scales
+ * article body text and nothing else.
  *
  * localStorage remains the source of truth — the Pages Router reads it directly
  * and `usePersistedState` broadcasts changes across instances and tabs, so the
@@ -24,13 +31,16 @@ export function FontSizeSync() {
       return
     }
 
-    document.documentElement.style.fontSize = `${fontSize}px`
+    document.documentElement.style.setProperty(
+      '--reader-font-scale',
+      `${fontSizeScale(fontSize)}`,
+    )
     writeFontSizeCookie(fontSize)
 
     return () => {
       // Scoped to the reading views, like the Pages Router's FontSize/Sync —
-      // leaving the root scaled would follow the reader onto every other page.
-      document.documentElement.style.fontSize = ''
+      // leaving the property set would follow the reader onto every other page.
+      document.documentElement.style.removeProperty('--reader-font-scale')
     }
   }, [fontSize])
 

--- a/apps/www/src/app/components/ui/font-size-dialog.tsx
+++ b/apps/www/src/app/components/ui/font-size-dialog.tsx
@@ -9,16 +9,18 @@ import {
 } from '@/app/lib/font-size'
 import { useFontSize } from '@/lib/fontSize'
 import * as Dialog from '@radix-ui/react-dialog'
-import { IconAdd, IconClose, IconRemove } from '@republik/icons'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+import { IconAdd, IconRemove } from '@republik/icons'
 import { css } from '@republik/theme/css'
 import { useEffect } from 'react'
 
 const stepButtonStyle = css({
   alignItems: 'center',
+  borderRadius: 'sm',
   cursor: 'pointer',
   display: 'inline-flex',
   justifyContent: 'center',
-  padding: '3',
+  padding: '2',
   _hover: { backgroundColor: 'hover' },
   '&:disabled': { color: 'disabled', cursor: 'default' },
 })
@@ -57,6 +59,7 @@ export function FontSizeDialog({
             // by the campaign paynote, which is fixed to the bottom at 9998.
             zIndex: 99998,
             _stateOpen: { animation: 'fadeIn' },
+            _stateClosed: { animation: 'fadeOut' },
           })}
         >
           <Dialog.Content
@@ -65,87 +68,82 @@ export function FontSizeDialog({
               backgroundColor: 'background.overlay',
               boxShadow: 'md',
               color: 'text',
-              margin: '8',
-              maxWidth: 375,
-              width: 'full',
+              // Hugs its content — the panel holds a stepper, not a form.
+              margin: '4',
+              padding: '4',
+              textAlign: 'center',
+              width: 'fit-content',
               zIndex: 99999,
             })}
           >
+            {/* Radix requires a title; the panel is small enough to speak for
+                itself, so it is only exposed to assistive technology. */}
+            <VisuallyHidden asChild>
+              <Dialog.Title>Schriftgrösse</Dialog.Title>
+            </VisuallyHidden>
+
             <div
               className={css({
                 alignItems: 'center',
-                borderBottom: '1px solid',
-                borderColor: 'divider',
                 display: 'flex',
-                justifyContent: 'space-between',
-                padding: '4',
+                gap: '2',
+                justifyContent: 'center',
               })}
             >
-              <Dialog.Title className={css({ fontWeight: 'medium' })}>
-                Schriftgrösse
-              </Dialog.Title>
-              <Dialog.Close
-                aria-label='Schliessen'
-                className={css({ cursor: 'pointer' })}
-              >
-                <IconClose size={24} />
-              </Dialog.Close>
-            </div>
-
-            <div className={css({ padding: '6', textAlign: 'center' })}>
-              <div
-                className={css({
-                  alignItems: 'center',
-                  display: 'flex',
-                  gap: '4',
-                  justifyContent: 'center',
-                })}
-              >
-                <button
-                  className={stepButtonStyle}
-                  disabled={fontSize <= MIN_FONT_SIZE}
-                  onClick={() =>
-                    setFontSize(
-                      Math.max(MIN_FONT_SIZE, fontSize - FONT_SIZE_STEP),
-                    )
-                  }
-                  title='Schrift verkleinern'
-                  type='button'
-                >
-                  <IconRemove size={24} />
-                </button>
-                <span className={css({ minWidth: '4rem', textStyle: 'sans' })}>
-                  {percentage}
-                </span>
-                <button
-                  className={stepButtonStyle}
-                  disabled={fontSize >= MAX_FONT_SIZE}
-                  onClick={() =>
-                    setFontSize(
-                      Math.min(MAX_FONT_SIZE, fontSize + FONT_SIZE_STEP),
-                    )
-                  }
-                  title='Schrift vergrössern'
-                  type='button'
-                >
-                  <IconAdd size={24} />
-                </button>
-              </div>
-
               <button
-                className={css({
-                  cursor: 'pointer',
-                  color: 'textSoft',
-                  fontSize: 's',
-                  marginTop: '2',
-                  textDecoration: 'underline',
-                })}
-                onClick={() => setFontSize(DEFAULT_FONT_SIZE)}
+                className={stepButtonStyle}
+                disabled={fontSize <= MIN_FONT_SIZE}
+                onClick={() =>
+                  setFontSize(
+                    Math.max(MIN_FONT_SIZE, fontSize - FONT_SIZE_STEP),
+                  )
+                }
+                title='Schrift verkleinern'
                 type='button'
               >
-                Zurücksetzen
+                <IconRemove size={24} />
+              </button>
+              <span
+                className={css({
+                  textStyle: 'sans',
+                  fontSize: 's',
+                  // Keeps the panel from twitching between 80 % and 100 %.
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: '3.5rem',
+                })}
+              >
+                {percentage}
+              </span>
+              <button
+                className={stepButtonStyle}
+                disabled={fontSize >= MAX_FONT_SIZE}
+                onClick={() =>
+                  setFontSize(
+                    Math.min(MAX_FONT_SIZE, fontSize + FONT_SIZE_STEP),
+                  )
+                }
+                title='Schrift vergrössern'
+                type='button'
+              >
+                <IconAdd size={24} />
               </button>
             </div>
+
+            <button
+              className={css({
+                textStyle: 'sans',
+                cursor: 'pointer',
+                color: 'textSoft',
+                fontSize: 'xs',
+                marginTop: '1',
+                textDecoration: 'underline',
+                _hover: { color: 'text' },
+              })}
+              onClick={() => setFontSize(DEFAULT_FONT_SIZE)}
+              type='button'
+            >
+              Zurücksetzen
+            </button>
           </Dialog.Content>
         </Dialog.Overlay>
       </Dialog.Portal>

--- a/apps/www/src/app/components/ui/font-size-dialog.tsx
+++ b/apps/www/src/app/components/ui/font-size-dialog.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useTrackEvent } from '@/app/lib/analytics/event-tracking'
+import {
+  DEFAULT_FONT_SIZE,
+  FONT_SIZE_STEP,
+  MAX_FONT_SIZE,
+  MIN_FONT_SIZE,
+} from '@/app/lib/font-size'
+import { useFontSize } from '@/lib/fontSize'
+import * as Dialog from '@radix-ui/react-dialog'
+import { IconAdd, IconClose, IconRemove } from '@republik/icons'
+import { css } from '@republik/theme/css'
+import { useEffect } from 'react'
+
+const stepButtonStyle = css({
+  alignItems: 'center',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  justifyContent: 'center',
+  padding: '3',
+  _hover: { backgroundColor: 'hover' },
+  '&:disabled': { color: 'disabled', cursor: 'default' },
+})
+
+export function FontSizeDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [fontSize, setFontSize] = useFontSize(DEFAULT_FONT_SIZE)
+  const trackEvent = useTrackEvent()
+  const percentage = `${Math.round((100 * fontSize) / DEFAULT_FONT_SIZE)}%`
+
+  useEffect(() => {
+    if (!open) return
+    trackEvent({ action: 'openOverlay', name: percentage })
+    return () => trackEvent({ action: 'closeOverlay', name: percentage })
+    // Only the open/close transition is tracked, not every size change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={css({
+            backgroundColor: 'overlay',
+            display: 'grid',
+            inset: 0,
+            overflowY: 'auto',
+            placeItems: 'center',
+            position: 'fixed',
+            // Same stacking plane as `ui/overlay.tsx`. Anything lower is covered
+            // by the campaign paynote, which is fixed to the bottom at 9998.
+            zIndex: 99998,
+            _stateOpen: { animation: 'fadeIn' },
+          })}
+        >
+          <Dialog.Content
+            aria-describedby={undefined}
+            className={css({
+              backgroundColor: 'background.overlay',
+              boxShadow: 'md',
+              color: 'text',
+              margin: '8',
+              maxWidth: 375,
+              width: 'full',
+              zIndex: 99999,
+            })}
+          >
+            <div
+              className={css({
+                alignItems: 'center',
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '4',
+              })}
+            >
+              <Dialog.Title className={css({ fontWeight: 'medium' })}>
+                Schriftgrösse
+              </Dialog.Title>
+              <Dialog.Close
+                aria-label='Schliessen'
+                className={css({ cursor: 'pointer' })}
+              >
+                <IconClose size={24} />
+              </Dialog.Close>
+            </div>
+
+            <div className={css({ padding: '6', textAlign: 'center' })}>
+              <div
+                className={css({
+                  alignItems: 'center',
+                  display: 'flex',
+                  gap: '4',
+                  justifyContent: 'center',
+                })}
+              >
+                <button
+                  className={stepButtonStyle}
+                  disabled={fontSize <= MIN_FONT_SIZE}
+                  onClick={() =>
+                    setFontSize(
+                      Math.max(MIN_FONT_SIZE, fontSize - FONT_SIZE_STEP),
+                    )
+                  }
+                  title='Schrift verkleinern'
+                  type='button'
+                >
+                  <IconRemove size={24} />
+                </button>
+                <span className={css({ minWidth: '4rem', textStyle: 'sans' })}>
+                  {percentage}
+                </span>
+                <button
+                  className={stepButtonStyle}
+                  disabled={fontSize >= MAX_FONT_SIZE}
+                  onClick={() =>
+                    setFontSize(
+                      Math.min(MAX_FONT_SIZE, fontSize + FONT_SIZE_STEP),
+                    )
+                  }
+                  title='Schrift vergrössern'
+                  type='button'
+                >
+                  <IconAdd size={24} />
+                </button>
+              </div>
+
+              <button
+                className={css({
+                  cursor: 'pointer',
+                  color: 'textSoft',
+                  fontSize: 's',
+                  marginTop: '2',
+                  textDecoration: 'underline',
+                })}
+                onClick={() => setFontSize(DEFAULT_FONT_SIZE)}
+                type='button'
+              >
+                Zurücksetzen
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/www/src/app/lib/font-size.ts
+++ b/apps/www/src/app/lib/font-size.ts
@@ -1,0 +1,24 @@
+/** Carried over verbatim from the legacy FontSize/Overlay.js. */
+export const DEFAULT_FONT_SIZE = 16
+export const FONT_SIZE_STEP = 3.2
+export const MIN_FONT_SIZE = 8
+export const MAX_FONT_SIZE = 48
+
+/**
+ * Mirror of the `republik-font-size` localStorage value, so the server can
+ * apply the size before first paint. localStorage stays the source of truth —
+ * the Pages Router reads it directly and `usePersistedState` syncs instances
+ * off it — this cookie only exists to make SSR aware of it.
+ *
+ * Same name as the storage key by design, so it is imported rather than
+ * re-declared. Imported from `fontSizeCookie`, not `fontSize` — the latter
+ * exports a hook, and this module is read by a server component.
+ */
+export { FONT_SIZE_KEY as FONT_SIZE_COOKIE } from '@/lib/fontSizeCookie'
+
+/** Guards against a hand-edited cookie reaching the rendered stylesheet. */
+export function isValidFontSize(value: number): boolean {
+  return (
+    Number.isFinite(value) && value >= MIN_FONT_SIZE && value <= MAX_FONT_SIZE
+  )
+}

--- a/apps/www/src/app/lib/font-size.ts
+++ b/apps/www/src/app/lib/font-size.ts
@@ -22,3 +22,15 @@ export function isValidFontSize(value: number): boolean {
     Number.isFinite(value) && value >= MIN_FONT_SIZE && value <= MAX_FONT_SIZE
   )
 }
+
+/**
+ * The stored size as a unitless factor — what `--reader-font-scale` carries.
+ *
+ * The setting is stored in pixels (the Pages Router applies it as a root font
+ * size and reads the same key), but the App Router multiplies the editorial
+ * sizes with it, which keeps them in `rem` and so keeps the browser's own font
+ * size setting intact.
+ */
+export function fontSizeScale(fontSize: number): number {
+  return Math.round((fontSize / DEFAULT_FONT_SIZE) * 1e4) / 1e4
+}

--- a/apps/www/src/lib/fontSize.js
+++ b/apps/www/src/lib/fontSize.js
@@ -1,4 +1,28 @@
+import { useCallback } from 'react'
+import { FONT_SIZE_KEY, writeFontSizeCookie } from './fontSizeCookie'
 import createPersistedState from './hooks/use-persisted-state'
 
-export const FONT_SIZE_KEY = 'republik-font-size'
-export const useFontSize = createPersistedState(FONT_SIZE_KEY)
+// Re-exported for the Pages-Router callers that import it from here.
+export { FONT_SIZE_KEY }
+
+const usePersistedFontSize = createPersistedState(FONT_SIZE_KEY)
+
+/**
+ * Both routers write the font size through this hook — the Pages-Router overlay
+ * and the App-Router dialog — so mirroring the cookie in the setter is what
+ * keeps the two in step. Without it, a size changed on a legacy page left the
+ * cookie stale and the next Sanity article server-rendered the wrong size.
+ */
+export const useFontSize = (initialState) => {
+  const [fontSize, setFontSize] = usePersistedFontSize(initialState)
+
+  const setFontSizeAndMirror = useCallback(
+    (next) => {
+      setFontSize(next)
+      writeFontSizeCookie(next)
+    },
+    [setFontSize],
+  )
+
+  return [fontSize, setFontSizeAndMirror]
+}

--- a/apps/www/src/lib/fontSizeCookie.ts
+++ b/apps/www/src/lib/fontSizeCookie.ts
@@ -1,0 +1,25 @@
+/**
+ * The reader's font size, as a cookie.
+ *
+ * Deliberately free of React imports: `app/components/font-size-style.tsx` is a
+ * server component and reads the cookie name from here. Importing it from
+ * `@/lib/fontSize` instead would pull `usePersistedState` — and with it
+ * `useState`/`useRef` — into a Server Component module.
+ */
+
+/** Storage key and cookie name — the same value on purpose. */
+export const FONT_SIZE_KEY = 'republik-font-size'
+
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365
+
+/**
+ * Mirrors the size into a cookie so the server can apply it before first paint.
+ * localStorage stays the source of truth; this is only its readable projection.
+ */
+export function writeFontSizeCookie(fontSize: number): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  const secure = window.location.protocol === 'https:' ? ';Secure' : ''
+  document.cookie = `${FONT_SIZE_KEY}=${fontSize};path=/;max-age=${ONE_YEAR_SECONDS};SameSite=Lax${secure}`
+}

--- a/packages/theme/presets/preset-republik.ts
+++ b/packages/theme/presets/preset-republik.ts
@@ -1,6 +1,7 @@
 import { definePreset } from '@pandacss/dev'
 import { buttonRecipe } from '../src/recipes/button'
 import { editorialContentRecipe } from '../src/recipes/editorial-content'
+import { editorialFontSizes } from '../src/typography'
 
 export const presetRepublik = definePreset({
   name: 'republik',
@@ -353,7 +354,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'republikSerif',
             fontWeight: 'black',
             fontStyle: 'normal',
-            fontSize: { base: '1.875rem', md: '3.625rem' },
+            fontSize: editorialFontSizes.editorialTitle,
             lineHeight: 1.1333,
           },
         },
@@ -362,7 +363,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'rubis',
             fontWeight: '400',
             fontStyle: 'normal',
-            fontSize: { base: '1.1875rem', md: '1.4375rem' },
+            fontSize: editorialFontSizes.editorialLead,
             lineHeight: 1.5,
           },
         },
@@ -371,7 +372,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'gtAmericaStandard',
             fontWeight: '400',
             fontStyle: 'normal',
-            fontSize: { base: '0.875rem', md: '0.9375rem' },
+            fontSize: editorialFontSizes.editorialByline,
             lineHeight: 1.25,
           },
         },
@@ -380,7 +381,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'gtAmericaStandard',
             fontWeight: '500',
             fontStyle: 'normal',
-            fontSize: { base: '1rem', md: '1.25rem' },
+            fontSize: editorialFontSizes.editorialHeading,
           },
         },
         editorialParagraph: {
@@ -388,7 +389,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'rubis',
             fontWeight: 400,
             fontStyle: 'normal',
-            fontSize: { base: '1.0625rem', md: '1.1875rem' },
+            fontSize: editorialFontSizes.editorialParagraph,
             lineHeight: 1.6,
           },
         },
@@ -397,7 +398,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'rubis',
             fontWeight: 700,
             fontStyle: 'normal',
-            fontSize: { base: '1.1875rem', md: '1.5rem' },
+            fontSize: editorialFontSizes.editorialSubheading,
             lineHeight: 1.5,
           },
         },
@@ -406,7 +407,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'gtAmericaStandard',
             fontWeight: 'medium',
             fontStyle: 'normal',
-            fontSize: { base: '1.875rem', md: '3.625rem' },
+            fontSize: editorialFontSizes.metaTitle,
             lineHeight: 1.1333,
           },
         },
@@ -415,7 +416,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'gtAmericaStandard',
             fontWeight: 'medium',
             fontStyle: 'normal',
-            fontSize: { base: '1.1875rem', md: '1.5rem' },
+            fontSize: editorialFontSizes.metaSubheading,
             lineHeight: 1.5,
           },
         },
@@ -424,7 +425,7 @@ export const presetRepublik = definePreset({
             fontFamily: 'gtAmericaStandard',
             fontWeight: 400,
             fontStyle: 'normal',
-            fontSize: { base: '1.0625rem', md: '1.1875rem' },
+            fontSize: editorialFontSizes.metaParagraph,
             lineHeight: 1.6,
           },
         },

--- a/packages/theme/src/recipes/editorial-content.ts
+++ b/packages/theme/src/recipes/editorial-content.ts
@@ -1,4 +1,5 @@
 import { defineParts, defineRecipe } from '@pandacss/dev'
+import { editorialFontSizes, readerScaledFontSize } from '../typography'
 
 const contentParts = defineParts({
   root: { selector: '&' },
@@ -23,12 +24,25 @@ const contentParts = defineParts({
   orderedListItems: { selector: '& > ol li' },
 })
 
+/**
+ * An editorial text style whose size follows the reader's font size setting.
+ * Size and text style come from the same key, so the two can't drift — see
+ * `editorialFontSizes`, which the preset's `textStyles` use as well.
+ */
+const readerScaledText = (textStyle: keyof typeof editorialFontSizes) => ({
+  textStyle,
+  ...readerScaledFontSize(editorialFontSizes[textStyle]),
+})
+
 export const editorialContentRecipe = defineRecipe({
   className: 'editorial-content',
   description: 'Styles for editorial content (like articles)',
 
   base: contentParts({
     root: {
+      // Confines the reader's font size setting to editorial content — see
+      // `READER_FONT_SCALE`.
+      '--article-font-scale': 'var(--reader-font-scale, 1)',
       display: 'grid',
       gridTemplateColumns: `
         [full-start]
@@ -114,30 +128,22 @@ export const editorialContentRecipe = defineRecipe({
       EDITORIAL: contentParts({
         heading: { textStyle: 'editorialHeading' },
         title: { textStyle: 'editorialTitle' },
-        lead: { textStyle: 'editorialLead' },
+        lead: readerScaledText('editorialLead'),
         byline: { textStyle: 'editorialByline' },
-        paragraphs: { textStyle: 'editorialParagraph' },
-        subheadings: { textStyle: 'editorialSubheading' },
-        unorderedListItems: {
-          textStyle: 'editorialParagraph',
-        },
-        orderedListItems: {
-          textStyle: 'editorialParagraph',
-        },
+        paragraphs: readerScaledText('editorialParagraph'),
+        subheadings: readerScaledText('editorialSubheading'),
+        unorderedListItems: readerScaledText('editorialParagraph'),
+        orderedListItems: readerScaledText('editorialParagraph'),
       }),
       META: contentParts({
         heading: { textStyle: 'editorialHeading' },
         title: { textStyle: 'metaTitle' },
-        lead: { textStyle: 'editorialLead' },
+        lead: readerScaledText('editorialLead'),
         byline: { textStyle: 'editorialByline' },
-        paragraphs: { textStyle: 'editorialParagraph' },
-        subheadings: { textStyle: 'editorialSubheading' },
-        unorderedListItems: {
-          textStyle: 'editorialParagraph',
-        },
-        orderedListItems: {
-          textStyle: 'editorialParagraph',
-        },
+        paragraphs: readerScaledText('editorialParagraph'),
+        subheadings: readerScaledText('editorialSubheading'),
+        unorderedListItems: readerScaledText('editorialParagraph'),
+        orderedListItems: readerScaledText('editorialParagraph'),
       }),
       PAGE: contentParts({
         heading: {
@@ -151,18 +157,14 @@ export const editorialContentRecipe = defineRecipe({
           gridColumn: 'breakout',
         },
         lead: {
-          textStyle: 'editorialLead',
+          ...readerScaledText('editorialLead'),
           textAlign: 'center',
           gridColumn: 'breakout',
         },
-        paragraphs: { textStyle: 'metaParagraph' },
-        subheadings: { textStyle: 'metaSubheading' },
-        unorderedListItems: {
-          textStyle: 'metaParagraph',
-        },
-        orderedListItems: {
-          textStyle: 'metaParagraph',
-        },
+        paragraphs: readerScaledText('metaParagraph'),
+        subheadings: readerScaledText('metaSubheading'),
+        unorderedListItems: readerScaledText('metaParagraph'),
+        orderedListItems: readerScaledText('metaParagraph'),
       }),
     },
   },

--- a/packages/theme/src/typography.ts
+++ b/packages/theme/src/typography.ts
@@ -1,0 +1,48 @@
+/**
+ * The reader's font size setting, as a unitless factor.
+ *
+ * `--reader-font-scale` is written to `:root` from the cookie (server) and
+ * localStorage (client); the `editorialContent` recipe re-publishes it on its
+ * root as `--article-font-scale`. Only declarations inside an editorial-content
+ * root see it — everywhere else the `1` fallback applies, which is what keeps
+ * the front-page teasers fixed even though they share the `editorial*` /
+ * `meta*` text styles.
+ *
+ * A factor rather than an absolute size: `calc(1.0625rem * 1.2)` still respects
+ * the browser's own font size setting, which overriding the root font size did
+ * not.
+ */
+export const READER_FONT_SCALE = 'var(--article-font-scale, 1)'
+
+type FontSize = { base: string; md: string }
+
+/**
+ * Font sizes of the editorial text styles — the single source shared by the
+ * `textStyles` in `preset-republik.ts` (fixed, for anything outside an article)
+ * and by the `editorialContent` recipe, which scales the same values with the
+ * reader's font size setting. Keys are the text style names.
+ */
+export const editorialFontSizes = {
+  editorialTitle: { base: '1.875rem', md: '3.625rem' },
+  editorialLead: { base: '1.1875rem', md: '1.4375rem' },
+  editorialByline: { base: '0.875rem', md: '0.9375rem' },
+  editorialHeading: { base: '1rem', md: '1.25rem' },
+  editorialParagraph: { base: '1.0625rem', md: '1.1875rem' },
+  editorialSubheading: { base: '1.1875rem', md: '1.5rem' },
+  metaTitle: { base: '1.875rem', md: '3.625rem' },
+  metaSubheading: { base: '1.1875rem', md: '1.5rem' },
+  metaParagraph: { base: '1.0625rem', md: '1.1875rem' },
+} satisfies Record<string, FontSize>
+
+/** Scales a font size with the reader's setting. */
+export const readerScaled = (fontSize: string) =>
+  `calc(${fontSize} * ${READER_FONT_SCALE})`
+
+/**
+ * A font size that follows the reader's setting at both breakpoints. Returns the
+ * `md` condition too, so spread it into a style object.
+ */
+export const readerScaledFontSize = ({ base, md }: FontSize) => ({
+  fontSize: readerScaled(base),
+  md: { fontSize: readerScaled(md) },
+})


### PR DESCRIPTION
**TLDR**; Brings the font size control to the Sanity article page's new action bar (⋮ → Schriftgrösse), and — unlike the Pages Router original — scales only the article's body text instead of the whole app.

**How it works**. The setting is carried as a unitless factor. --reader-font-scale goes on :root — server-side from the cookie before first paint, client-side from localStorage — and does nothing on its own. The editorialContent recipe re-publishes it on its own root as --article-font-scale; that indirection is the scoping. Only declarations referencing the property scale, and only inside editorial content.

**Scales**: paragraphs, list items, subheadings, lead, block quotes, pull quotes, captions, notes. Does not: title, kicker, byline, action bar, site chrome, and the front-page teasers — even though the teasers share the editorial*/meta* text styles, which is what the two-level property protects. A factor rather than an absolute size also keeps sizes in rem, so the reader's own browser font size setting still applies.

**One source of truth.** The editorial font sizes live in packages/theme/src/typography.ts, keyed by text style name, consumed by preset-republik.ts (fixed) and editorial-content.ts (scaled) — one key selects both the text style and its size, so they can't drift.