### PR TITLE
feat: preview article/page docs by id instead of slug

### DIFF
--- a/apps/www/src/app/(sanity)/[...path]/page.tsx
+++ b/apps/www/src/app/(sanity)/[...path]/page.tsx
@@ -1,6 +1,6 @@
 import ArticleDocument from '@/app/(sanity)/[...path]/components/article-document'
 import PageDocument from '@/app/(sanity)/[...path]/components/page-document'
-import { DOCUMENT_QUERY } from '@/app/(sanity)/groq/document-query'
+import { DOCUMENT_BY_SLUG_QUERY } from '@/app/(sanity)/groq/document-query'
 import { SEO_QUERY } from '@/app/(sanity)/groq/seo-query'
 import { getArticleJsonLd } from '@/app/(sanity)/lib/json-ld'
 import { sanityFetch } from '@/app/(sanity)/lib/live'
@@ -44,7 +44,7 @@ export default async function DocumentPage({
   const slug = `/${path.join('/')}`
 
   const { data } = await sanityFetch({
-    query: DOCUMENT_QUERY,
+    query: DOCUMENT_BY_SLUG_QUERY,
     params: { slug },
   })
 

--- a/apps/www/src/app/(sanity)/groq/document-query.ts
+++ b/apps/www/src/app/(sanity)/groq/document-query.ts
@@ -8,15 +8,29 @@ import {
 } from '@/app/(sanity)/groq/teaser-large-fragment'
 import { TEASER_LIST_BLOCK_FRAGMENT } from '@/app/(sanity)/groq/teaser-list-block-fragment'
 import { TEASER_SMALL_FRAGMENT } from '@/app/(sanity)/groq/teaser-small-fragment'
-import type { DOCUMENT_QUERY_RESULT } from '@/sanity.types'
+import type {
+  DOCUMENT_BY_ID_QUERY_RESULT,
+  DOCUMENT_BY_SLUG_QUERY_RESULT,
+} from '@/sanity.types'
 import { defineQuery } from 'next-sanity'
 
-export type ArticleDocumentType = Extract<
-  DOCUMENT_QUERY_RESULT,
-  { _type: 'article' }
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+
+type Assert<T extends true> = T
+
+// DOCUMENT_BY_SLUG_QUERY and DOCUMENT_BY_ID_QUERY select the same DOCUMENT_FIELDS,
+// so typegen emits two structurally identical result types. Fail the build if they
+// ever drift, which is what makes the DocumentType alias below safe.
+type _ResultsMatch = Assert<
+  Equals<DOCUMENT_BY_SLUG_QUERY_RESULT, DOCUMENT_BY_ID_QUERY_RESULT>
 >
 
-export type PageDocumentType = Extract<DOCUMENT_QUERY_RESULT, { _type: 'page' }>
+export type DocumentType = DOCUMENT_BY_SLUG_QUERY_RESULT
+
+export type ArticleDocumentType = Extract<DocumentType, { _type: 'article' }>
+
+export type PageDocumentType = Extract<DocumentType, { _type: 'page' }>
 
 export type PageBuilderBlock =
   | NonNullable<NonNullable<PageDocumentType>['pageBuilder']>[number]
@@ -27,8 +41,7 @@ export type PageBuilderBlock =
       reference: TeaserLargeFragmentType
     }
 
-export const DOCUMENT_QUERY = defineQuery(
-  `*[_type in ["article", "page"] && slug.current == $slug][0]{
+const DOCUMENT_FIELDS = /* groq */ `{
     _id,
     _type,
     title,
@@ -121,5 +134,13 @@ export const DOCUMENT_QUERY = defineQuery(
         },
       }
     }
-  }`,
+  }
+  `
+
+export const DOCUMENT_BY_SLUG_QUERY = defineQuery(
+  `*[_type in ["article", "page"] && slug.current == $slug][0]${DOCUMENT_FIELDS}`,
+)
+
+export const DOCUMENT_BY_ID_QUERY = defineQuery(
+  `*[_type in ["article", "page"] && _id == $id][0]${DOCUMENT_FIELDS}`,
 )

--- a/apps/www/src/app/(sanity)/preview/[id]/page.tsx
+++ b/apps/www/src/app/(sanity)/preview/[id]/page.tsx
@@ -1,18 +1,17 @@
 import ArticleDocument from '@/app/(sanity)/[...path]/components/article-document'
 import PageDocument from '@/app/(sanity)/[...path]/components/page-document'
-import { DOCUMENT_QUERY } from '@/app/(sanity)/groq/document-query'
+import { DOCUMENT_BY_ID_QUERY } from '@/app/(sanity)/groq/document-query'
 import { sanityFetch } from '@/app/(sanity)/lib/live'
 import { notFound } from 'next/navigation'
 
 export default async function DocumentPreviewPage({
   params,
-}: PageProps<'/preview/[...path]'>) {
-  const { path } = await params
-  const slug = `/${path.join('/')}`
+}: PageProps<'/preview/[id]'>) {
+  const { id } = await params
 
   const { data } = await sanityFetch({
-    query: DOCUMENT_QUERY,
-    params: { slug },
+    query: DOCUMENT_BY_ID_QUERY,
+    params: { id },
   })
 
   if (!data) {

--- a/apps/www/src/sanity.types.ts
+++ b/apps/www/src/sanity.types.ts
@@ -1699,9 +1699,9 @@ export type CTA_BLOCK_FRAGMENT_QUERY_RESULT = {
 } | null
 
 // Source: src/app/(sanity)/groq/document-query.ts
-// Variable: DOCUMENT_QUERY
+// Variable: DOCUMENT_BY_SLUG_QUERY
 // Query: *[_type in ["article", "page"] && slug.current == $slug][0]{    _id,    _type,    title,    description,    "slug": slug.current,    _updatedAt,    cover {      ...    },    heading->{      _id,      title,      "slug": slug.current    },    theme {      name,      accentColor,      darkMode    },    _type == "article" => {      repoId,      "plainTitle": pt::text(title),      audioSourceMp3,      audioDurationMs,      _updatedAt,      publishDate,      // Plain text and SEO overrides, used for the JSON-LD linked data      "plainTitle": pt::text(title),      "plainDescription": pt::text(description),      seo {        title,        description,        image,        useImageBuilder      },      discussion->{        backendDiscussionId,      },      inlineDiscussion,      readingAccess,        byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  },      newsletter->{        title,        description,        frequency,        image,        name,      },        content[]{    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    },    body[] {      ...,      markDefs[]{        ...,        _type == "internalLink" => {          "slug": select(            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),            reference->slug.current          )        }      }    }  },      contributors[]{        _id,        kind,        // Same profile slug as the byline links        "slug": coalesce(contributor->slug.current, contributor->userId),        "name": contributor->title,        "description": contributor->description,        "portrait": contributor->portrait      },      "articleCollection": articleCollections[featured == true][0].collection->{        _id,        title,        description,        image,        series      },      articleRecommendations[]->{          _id,  _type,  "title": coalesce(teaserSmall.title, title),  "description": coalesce(teaserSmall.description, description),  "byline": teaserSmall.  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  },  "slug": slug.current,  "image": teaserSmall.image,  publishDate,  "heading": select(    defined(teaserSmall.heading) || defined(heading) => {      "_id": heading->_id,      "title": coalesce(teaserSmall.heading, pt::text(heading->title)),      "slug": heading->slug.current,    }  ),  theme {    name,    accentColor,  },  "color": teaserSmall.color,  "backgroundColor": teaserSmall.backgroundColor,  "headingColor": teaserSmall.headingColor,      }    },    _type == "page" => {      pageBuilder[]{        _key,        _type,        _type == "menu" => {            hasSeparator,  heading {    title,    page->{      _id,      "title": pt::text(title),      "slug": slug.current    }  },  pages[]{    _key,    _type,    _type == "link" => {      href,      title    },    _type == "reference" => {      "page": @->{        _id,        "title": pt::text(title),        "slug": slug.current      }    }  }        },        _type == "callToAction" => {            target->{    _id,    _type,    _type == "newsletter" => {      name,      title    },    _type == "podcast" => {      podigeeSlug,      spotifyUrl,      appleUrl    },    _type == "articleCollection" => {      title,      description    }  }        },        _type == "editorBlock" => {            content[]{    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    },    body[] {      ...,      markDefs[]{        ...,        _type == "internalLink" => {          "slug": select(            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),            reference->slug.current          )        }      }    }  }        },        _type == "teaserList" => {            appearance,  color,  backgroundColor,  imageStyle,  skipDescription,  maxItems,  title,  "total": select(    source.sourceType == "MANUAL" => count(source.items),    source.sourceType == "COLLECTION" => count(*[      (        _type == "article" &&        ^.source.collection._ref in articleCollections[].collection._ref      ) || (        _type == "teaserSmall" &&        collection._ref == ^.source.collection._ref      )    ]),    0  ),  "series": source.sourceType == "COLLECTION" &&    source.collection->series == true,  "collectionId": source.collection._ref        },        _type == "teaserLarge" => {          "reference": @->{  _id,  _type,  "targetType": target[0]->_type,  // link can either be a plain link OR a referenced doc  "target": coalesce(target[0]->slug.current, target[0].href),  "targetId": target[0]->_id,  "publishDate": target[0]->publishDate,  "theme": {    "name": target[0]->theme.name,    "accentColor": target[0]->theme.accentColor,  },  // heading: own string override, else the referenced doc's format title  "heading": select(    defined(heading) => { "title": heading },    defined(target[0]->heading) => {      "title": pt::text(target[0]->heading->title)    }  ),  "teaser": {    layout,    "title": coalesce(title, target[0]->title),    "description": coalesce(description, target[0]->description),    "byline": coalesce(  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  }, target[0]->  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  }),    "image": coalesce(image, target[0]->image),    imageCredits,    imagePosition,    imagePadding,    textPosition,    textAlignment,    textSize,    color,    backgroundColor,    // Audio always comes from the target article itself — a teaserLarge    // override doc has no audio of its own.    "audioTitle": pt::text(target[0]->title),    "audioSourceMp3": target[0]->audioSourceMp3,    "audioDurationMs": target[0]->audioDurationMs,  }}        },      }    }  }
-export type DOCUMENT_QUERY_RESULT =
+export type DOCUMENT_BY_SLUG_QUERY_RESULT =
   | {
       _id: string
       _type: 'article'
@@ -1831,17 +1831,13 @@ export type DOCUMENT_QUERY_RESULT =
                   content?: InlineEditor
                   href?: string
                   reference?:
-                    | ArticleReference
-                    | ContributorReference
-                    | PageReference
+                    ArticleReference | ContributorReference | PageReference
                 }
               | {
                   _key: string
                   _type: 'internalLink'
                   reference:
-                    | ArticleReference
-                    | ContributorReference
-                    | PageReference
+                    ArticleReference | ContributorReference | PageReference
                   slug: string | null
                 }
               | {
@@ -2497,9 +2493,7 @@ export type DOCUMENT_QUERY_RESULT =
                     _key: string
                     _type: 'internalLink'
                     reference:
-                      | ArticleReference
-                      | ContributorReference
-                      | PageReference
+                      ArticleReference | ContributorReference | PageReference
                     slug: string | null
                   }
                 | {
@@ -2555,9 +2549,1382 @@ export type DOCUMENT_QUERY_RESULT =
                     _key: string
                     _type: 'internalLink'
                     reference:
-                      | ArticleReference
-                      | ContributorReference
-                      | PageReference
+                      ArticleReference | ContributorReference | PageReference
+                    slug: string | null
+                  }
+                | {
+                    _key: string
+                    _type: 'link'
+                    href?: string
+                    title?: string
+                  }
+              > | null
+              level?: number
+              _type: 'block'
+              _key: string
+            }> | null
+            slug: string
+            image: {
+              asset?: SanityImageAssetReference
+              media?: unknown
+              hotspot?: SanityImageHotspot
+              crop?: SanityImageCrop
+              imageDark?: ImageDark
+              _type: 'image'
+            } | null
+            publishDate: string | null
+            heading: {
+              _id: string | null
+              title: string
+              slug: string | null
+            }
+            theme: {
+              name: 'EDITORIAL' | 'META' | 'PAGE' | null
+              accentColor: Color | null
+            } | null
+            color: Color | null
+            backgroundColor: Color | null
+            headingColor: Color | null
+          }
+      > | null
+    }
+  | {
+      _id: string
+      _type: 'page'
+      title: InlineEditor
+      description: InlineEditor | null
+      slug: string
+      _updatedAt: string
+      cover: {
+        _type: 'editorialImage'
+        asset?: SanityImageAssetReference
+        media?: unknown
+        hotspot?: SanityImageHotspot
+        crop?: SanityImageCrop
+        imageDark?: {
+          asset?: SanityImageAssetReference
+          media?: unknown
+          hotspot?: SanityImageHotspot
+          crop?: SanityImageCrop
+          _type: 'image'
+        }
+        alt?: string
+        caption?: Caption
+        size?: 'BREAKOUT' | 'FULL' | 'NORMAL' | 'TINY'
+      } | null
+      heading: {
+        _id: string
+        title: InlineEditor
+        slug: string
+      } | null
+      theme: {
+        name: 'EDITORIAL' | 'META' | 'PAGE' | null
+        accentColor: Color | null
+        darkMode: boolean | null
+      } | null
+      pageBuilder: Array<
+        | {
+            _key: string
+            _type: 'callToAction'
+            target:
+              | {
+                  _id: string
+                  _type: 'articleCollection'
+                  title: string
+                  description: string | null
+                }
+              | {
+                  _id: string
+                  _type: 'newsletter'
+                  name: string
+                  title: string
+                }
+              | {
+                  _id: string
+                  _type: 'podcast'
+                  podigeeSlug: string | null
+                  spotifyUrl: string | null
+                  appleUrl: string | null
+                }
+          }
+        | {
+            _key: string
+            _type: 'editorBlock'
+            content: Array<
+              | {
+                  children?: Array<{
+                    marks?: Array<string>
+                    text?: string
+                    _type: 'span'
+                    _key: string
+                  }>
+                  style?: 'heading' | 'normal' | 'note'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'expandableLink'
+                        content?: InlineEditor
+                        href?: string
+                        reference?:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                      }
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'blockQuote'
+                  body: Array<
+                    | {
+                        children?: Array<
+                          | ({
+                              _key: string
+                            } & Variable)
+                          | ({
+                              _key: string
+                            } & VoiceTag)
+                          | {
+                              marks?: Array<string>
+                              text?: string
+                              _type: 'span'
+                              _key: string
+                            }
+                        >
+                        style?: 'heading' | 'normal'
+                        listItem?: 'bullet' | 'number'
+                        markDefs: Array<
+                          | {
+                              _key: string
+                              _type: 'internalLink'
+                              reference:
+                                | ArticleReference
+                                | ContributorReference
+                                | PageReference
+                              slug: string | null
+                            }
+                          | {
+                              _key: string
+                              _type: 'link'
+                              href?: string
+                              title?: string
+                            }
+                        > | null
+                        level?: number
+                        _type: 'block'
+                        _key: string
+                      }
+                    | {
+                        _key: string
+                        _type: 'button'
+                        text?: string
+                        url?: string
+                        markDefs: null
+                      }
+                    | {
+                        _key: string
+                        _type: 'divider'
+                        style?: string
+                        markDefs: null
+                      }
+                    | {
+                        _key: string
+                        _type: 'dividerStars'
+                        style?: string
+                        markDefs: null
+                      }
+                  > | null
+                  caption?: Caption
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'chart'
+                  title?: InlineEditor
+                  description?: InlineEditor
+                  chartConfig?: ChartConfig
+                  source?: InlineEditor
+                  size?: 'BREAKOUT' | 'FLOAT_TINY' | 'NARROW' | 'NORMAL'
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'dynamicComponent'
+                  size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+                  src?: string
+                  identifier?:
+                    | 'CHALLENGE_ACCEPTED_INLINE_TEASER'
+                    | 'CLIMATE_LAB_COUNTER'
+                    | 'CLIMATE_LAB_INLINE_TEASER'
+                    | 'COMPACT_DETAILS_FORM'
+                    | 'EDGE_QUESTION'
+                    | 'ELECTION_CANDIDACY'
+                    | 'ELECTION_RESULT_DIVERSITY'
+                    | 'ELECTION_RESULT'
+                    | 'ELECTION'
+                    | 'INSTANT_SURVEY'
+                    | 'MANIFEST'
+                    | 'NEWSLETTER_SIGNUP'
+                    | 'POSTCARD_GALLERY'
+                    | 'POSTCARD'
+                    | 'QUESTIONNAIRE_OVERVIEW'
+                    | 'QUESTIONNAIRE_SUBMISSIONS'
+                    | 'QUESTIONNAIRE'
+                    | 'REASONS_VIDEO'
+                    | 'TEAM_TEASER'
+                    | 'TESTIMONIAL_LIST'
+                    | 'TRIAL_FORM'
+                    | 'VOTE_COUNTER'
+                    | 'VOTE_RESULT'
+                    | 'VOTEBOX'
+                  props?: Code
+                  autoHtml?: boolean
+                  html?: Code
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'editorialImage'
+                  asset?: SanityImageAssetReference
+                  media?: unknown
+                  hotspot?: SanityImageHotspot
+                  crop?: SanityImageCrop
+                  imageDark?: {
+                    asset?: SanityImageAssetReference
+                    media?: unknown
+                    hotspot?: SanityImageHotspot
+                    crop?: SanityImageCrop
+                    _type: 'image'
+                  }
+                  alt?: string
+                  caption?: Caption
+                  size?: 'BREAKOUT' | 'FULL' | 'NORMAL' | 'TINY'
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'embedComment'
+                  id?: string
+                  content?: string
+                  tags?: Array<string>
+                  createdAt?: string
+                  updatedAt?: string
+                  parentIds?: Array<string>
+                  discussion?: EmbedCommentDiscussion
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'embedDataWrapper'
+                  datawrapperId?: string
+                  forceDark?: boolean
+                  plain?: boolean
+                  size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'embedTwitter'
+                  url?: string
+                  id?: string
+                  createdAt?: string
+                  retrievedAt?: string
+                  text?: string
+                  html?: string
+                  userId?: string
+                  userName?: string
+                  userScreenName?: string
+                  userProfileImageUrl?: string
+                  image?: string
+                  more?: string
+                  playable?: boolean
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'embedVideo'
+                  size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+                  platform?: 'vimeo' | 'youtube'
+                  url?: string
+                  id?: string
+                  title?: string
+                  createdAt?: string
+                  retrievedAt?: string
+                  userName?: string
+                  userUrl?: string
+                  userProfileImageUrl?: string
+                  thumbnail?: string
+                  aspectRatio?: number
+                  durationMs?: number
+                  mediaId?: string
+                  src?: Src
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'html'
+                  html?: string
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'imageGroup'
+                  images?: Array<
+                    {
+                      _key: string
+                    } & GroupedEditorialImage
+                  >
+                  caption?: Caption
+                  size?: 'BREAKOUT' | 'NARROW' | 'NORMAL'
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'infoBox'
+                  title?: string
+                  body: Array<
+                    | {
+                        children?: Array<
+                          | ({
+                              _key: string
+                            } & Variable)
+                          | ({
+                              _key: string
+                            } & VoiceTag)
+                          | {
+                              marks?: Array<string>
+                              text?: string
+                              _type: 'span'
+                              _key: string
+                            }
+                        >
+                        style?: 'heading' | 'normal'
+                        listItem?: 'bullet' | 'number'
+                        markDefs: Array<
+                          | {
+                              _key: string
+                              _type: 'internalLink'
+                              reference:
+                                | ArticleReference
+                                | ContributorReference
+                                | PageReference
+                              slug: string | null
+                            }
+                          | {
+                              _key: string
+                              _type: 'link'
+                              href?: string
+                              title?: string
+                            }
+                        > | null
+                        level?: number
+                        _type: 'block'
+                        _key: string
+                      }
+                    | {
+                        _key: string
+                        _type: 'button'
+                        text?: string
+                        url?: string
+                        markDefs: null
+                      }
+                    | {
+                        _key: string
+                        _type: 'divider'
+                        style?: string
+                        markDefs: null
+                      }
+                    | {
+                        _key: string
+                        _type: 'dividerStars'
+                        style?: string
+                        markDefs: null
+                      }
+                  > | null
+                  image?: AsideImage
+                  size?: 'breakout' | 'float'
+                  figureSize?: 'L' | 'M' | 'S'
+                  figureFloat?: boolean
+                  collapsible?: boolean
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'pullQuote'
+                  text?: string
+                  source?: string
+                  image?: AsideImage
+                  size?: 'breakout' | 'float' | 'narrow'
+                  markDefs: null
+                  body: null
+                }
+              | {
+                  _key: string
+                  _type: 'storyComponent'
+                  url?: string
+                  tagname?: string
+                  componentData?: Code
+                  size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+                  markDefs: null
+                  body: null
+                }
+            > | null
+          }
+        | {
+            _key: string
+            _type: 'menu'
+            hasSeparator: boolean | null
+            heading: {
+              title: string | null
+              page: {
+                _id: string
+                title: string
+                slug: string
+              } | null
+            } | null
+            pages: Array<
+              | {
+                  _key: string
+                  _type: 'link'
+                  href: string | null
+                  title: string | null
+                }
+              | {
+                  _key: string
+                  _type: 'reference'
+                  page: {
+                    _id: string
+                    title: string
+                    slug: string
+                  }
+                }
+            > | null
+          }
+        | {
+            _key: string
+            _type: 'reference'
+          }
+        | {
+            _key: string
+            _type: 'teaserList'
+            appearance: 'CAROUSEL' | 'FEED' | 'GRID' | null
+            color: Color | null
+            backgroundColor: Color | null
+            imageStyle: 'NONE' | 'NORMAL' | 'SMALL' | null
+            skipDescription: boolean | null
+            maxItems: number | null
+            title: string | null
+            total: number | 0 | null
+            series: boolean | false
+            collectionId: string | null
+          }
+      > | null
+    }
+  | null
+
+// Source: src/app/(sanity)/groq/document-query.ts
+// Variable: DOCUMENT_BY_ID_QUERY
+// Query: *[_type in ["article", "page"] && _id == $id][0]{    _id,    _type,    title,    description,    "slug": slug.current,    _updatedAt,    cover {      ...    },    heading->{      _id,      title,      "slug": slug.current    },    theme {      name,      accentColor,      darkMode    },    _type == "article" => {      repoId,      "plainTitle": pt::text(title),      audioSourceMp3,      audioDurationMs,      _updatedAt,      publishDate,      // Plain text and SEO overrides, used for the JSON-LD linked data      "plainTitle": pt::text(title),      "plainDescription": pt::text(description),      seo {        title,        description,        image,        useImageBuilder      },      discussion->{        backendDiscussionId,      },      inlineDiscussion,      readingAccess,        byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  },      newsletter->{        title,        description,        frequency,        image,        name,      },        content[]{    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    },    body[] {      ...,      markDefs[]{        ...,        _type == "internalLink" => {          "slug": select(            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),            reference->slug.current          )        }      }    }  },      contributors[]{        _id,        kind,        // Same profile slug as the byline links        "slug": coalesce(contributor->slug.current, contributor->userId),        "name": contributor->title,        "description": contributor->description,        "portrait": contributor->portrait      },      "articleCollection": articleCollections[featured == true][0].collection->{        _id,        title,        description,        image,        series      },      articleRecommendations[]->{          _id,  _type,  "title": coalesce(teaserSmall.title, title),  "description": coalesce(teaserSmall.description, description),  "byline": teaserSmall.  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  },  "slug": slug.current,  "image": teaserSmall.image,  publishDate,  "heading": select(    defined(teaserSmall.heading) || defined(heading) => {      "_id": heading->_id,      "title": coalesce(teaserSmall.heading, pt::text(heading->title)),      "slug": heading->slug.current,    }  ),  theme {    name,    accentColor,  },  "color": teaserSmall.color,  "backgroundColor": teaserSmall.backgroundColor,  "headingColor": teaserSmall.headingColor,      }    },    _type == "page" => {      pageBuilder[]{        _key,        _type,        _type == "menu" => {            hasSeparator,  heading {    title,    page->{      _id,      "title": pt::text(title),      "slug": slug.current    }  },  pages[]{    _key,    _type,    _type == "link" => {      href,      title    },    _type == "reference" => {      "page": @->{        _id,        "title": pt::text(title),        "slug": slug.current      }    }  }        },        _type == "callToAction" => {            target->{    _id,    _type,    _type == "newsletter" => {      name,      title    },    _type == "podcast" => {      podigeeSlug,      spotifyUrl,      appleUrl    },    _type == "articleCollection" => {      title,      description    }  }        },        _type == "editorBlock" => {            content[]{    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    },    body[] {      ...,      markDefs[]{        ...,        _type == "internalLink" => {          "slug": select(            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),            reference->slug.current          )        }      }    }  }        },        _type == "teaserList" => {            appearance,  color,  backgroundColor,  imageStyle,  skipDescription,  maxItems,  title,  "total": select(    source.sourceType == "MANUAL" => count(source.items),    source.sourceType == "COLLECTION" => count(*[      (        _type == "article" &&        ^.source.collection._ref in articleCollections[].collection._ref      ) || (        _type == "teaserSmall" &&        collection._ref == ^.source.collection._ref      )    ]),    0  ),  "series": source.sourceType == "COLLECTION" &&    source.collection->series == true,  "collectionId": source.collection._ref        },        _type == "teaserLarge" => {          "reference": @->{  _id,  _type,  "targetType": target[0]->_type,  // link can either be a plain link OR a referenced doc  "target": coalesce(target[0]->slug.current, target[0].href),  "targetId": target[0]->_id,  "publishDate": target[0]->publishDate,  "theme": {    "name": target[0]->theme.name,    "accentColor": target[0]->theme.accentColor,  },  // heading: own string override, else the referenced doc's format title  "heading": select(    defined(heading) => { "title": heading },    defined(target[0]->heading) => {      "title": pt::text(target[0]->heading->title)    }  ),  "teaser": {    layout,    "title": coalesce(title, target[0]->title),    "description": coalesce(description, target[0]->description),    "byline": coalesce(  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  }, target[0]->  byline[] {    ...,    markDefs[]{      ...,      _type == "internalLink" => {        "slug": select(          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),          reference->slug.current        )      }    }  }),    "image": coalesce(image, target[0]->image),    imageCredits,    imagePosition,    imagePadding,    textPosition,    textAlignment,    textSize,    color,    backgroundColor,    // Audio always comes from the target article itself — a teaserLarge    // override doc has no audio of its own.    "audioTitle": pt::text(target[0]->title),    "audioSourceMp3": target[0]->audioSourceMp3,    "audioDurationMs": target[0]->audioDurationMs,  }}        },      }    }  }
+export type DOCUMENT_BY_ID_QUERY_RESULT =
+  | {
+      _id: string
+      _type: 'article'
+      title: InlineEditor
+      description: InlineEditor | null
+      slug: string
+      _updatedAt: string
+      cover: {
+        _type: 'editorialImage'
+        asset?: SanityImageAssetReference
+        media?: unknown
+        hotspot?: SanityImageHotspot
+        crop?: SanityImageCrop
+        imageDark?: {
+          asset?: SanityImageAssetReference
+          media?: unknown
+          hotspot?: SanityImageHotspot
+          crop?: SanityImageCrop
+          _type: 'image'
+        }
+        alt?: string
+        caption?: Caption
+        size?: 'BREAKOUT' | 'FULL' | 'NORMAL' | 'TINY'
+      } | null
+      heading: {
+        _id: string
+        title: InlineEditor
+        slug: string
+      } | null
+      theme: {
+        name: 'EDITORIAL' | 'META' | 'PAGE' | null
+        accentColor: Color | null
+        darkMode: boolean | null
+      } | null
+      repoId: string | null
+      plainTitle: string
+      audioSourceMp3: string | null
+      audioDurationMs: number | null
+      publishDate: string | null
+      plainDescription: string
+      seo: {
+        title: string | null
+        description: string | null
+        image: {
+          asset?: SanityImageAssetReference
+          media?: unknown
+          hotspot?: SanityImageHotspot
+          crop?: SanityImageCrop
+          _type: 'image'
+        } | null
+        useImageBuilder: boolean | null
+      } | null
+      discussion: {
+        backendDiscussionId: string | null
+      } | null
+      inlineDiscussion: boolean | null
+      readingAccess: 'OPEN' | 'PAYNOTE' | 'REGWALL' | null
+      byline: Array<{
+        children?: Array<{
+          marks?: Array<string>
+          text?: string
+          _type: 'span'
+          _key: string
+        }>
+        style?: 'normal'
+        listItem?: never
+        markDefs: Array<
+          | {
+              _key: string
+              _type: 'internalLink'
+              reference: ArticleReference | ContributorReference | PageReference
+              slug: string | null
+            }
+          | {
+              _key: string
+              _type: 'link'
+              href?: string
+              title?: string
+            }
+        > | null
+        level?: number
+        _type: 'block'
+        _key: string
+      }> | null
+      newsletter: {
+        title: string
+        description: string | null
+        frequency: string | null
+        image: {
+          asset?: SanityImageAssetReference
+          media?: unknown
+          hotspot?: SanityImageHotspot
+          crop?: SanityImageCrop
+          imageDark?: {
+            asset?: SanityImageAssetReference
+            media?: unknown
+            hotspot?: SanityImageHotspot
+            crop?: SanityImageCrop
+            _type: 'image'
+          }
+          _type: 'image'
+        } | null
+        name: string
+      } | null
+      content: Array<
+        | {
+            children?: Array<
+              | ({
+                  _key: string
+                } & Variable)
+              | ({
+                  _key: string
+                } & VoiceTag)
+              | {
+                  marks?: Array<string>
+                  text?: string
+                  _type: 'span'
+                  _key: string
+                }
+            >
+            style?: 'heading' | 'normal' | 'note'
+            listItem?: 'bullet' | 'number'
+            markDefs: Array<
+              | {
+                  _key: string
+                  _type: 'expandableLink'
+                  content?: InlineEditor
+                  href?: string
+                  reference?:
+                    ArticleReference | ContributorReference | PageReference
+                }
+              | {
+                  _key: string
+                  _type: 'internalLink'
+                  reference:
+                    ArticleReference | ContributorReference | PageReference
+                  slug: string | null
+                }
+              | {
+                  _key: string
+                  _type: 'link'
+                  href?: string
+                  title?: string
+                }
+            > | null
+            level?: number
+            _type: 'block'
+            _key: string
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'blockQuote'
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            caption?: Caption
+            markDefs: null
+          }
+        | {
+            _key: string
+            _type: 'button'
+            text?: string
+            url?: string
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'chart'
+            title?: InlineEditor
+            description?: InlineEditor
+            chartConfig?: ChartConfig
+            source?: InlineEditor
+            size?: 'BREAKOUT' | 'FLOAT_TINY' | 'NARROW' | 'NORMAL'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'divider'
+            style?: string
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'dividerStars'
+            style?: string
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'dynamicComponent'
+            size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+            src?: string
+            identifier?:
+              | 'CHALLENGE_ACCEPTED_INLINE_TEASER'
+              | 'CLIMATE_LAB_COUNTER'
+              | 'CLIMATE_LAB_INLINE_TEASER'
+              | 'COMPACT_DETAILS_FORM'
+              | 'EDGE_QUESTION'
+              | 'ELECTION_CANDIDACY'
+              | 'ELECTION_RESULT_DIVERSITY'
+              | 'ELECTION_RESULT'
+              | 'ELECTION'
+              | 'INSTANT_SURVEY'
+              | 'MANIFEST'
+              | 'NEWSLETTER_SIGNUP'
+              | 'POSTCARD_GALLERY'
+              | 'POSTCARD'
+              | 'QUESTIONNAIRE_OVERVIEW'
+              | 'QUESTIONNAIRE_SUBMISSIONS'
+              | 'QUESTIONNAIRE'
+              | 'REASONS_VIDEO'
+              | 'TEAM_TEASER'
+              | 'TESTIMONIAL_LIST'
+              | 'TRIAL_FORM'
+              | 'VOTE_COUNTER'
+              | 'VOTE_RESULT'
+              | 'VOTEBOX'
+            props?: Code
+            autoHtml?: boolean
+            html?: Code
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'editorialImage'
+            asset?: SanityImageAssetReference
+            media?: unknown
+            hotspot?: SanityImageHotspot
+            crop?: SanityImageCrop
+            imageDark?: {
+              asset?: SanityImageAssetReference
+              media?: unknown
+              hotspot?: SanityImageHotspot
+              crop?: SanityImageCrop
+              _type: 'image'
+            }
+            alt?: string
+            caption?: Caption
+            size?: 'BREAKOUT' | 'FULL' | 'NORMAL' | 'TINY'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'emailOnly'
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            markDefs: null
+          }
+        | {
+            _key: string
+            _type: 'embedComment'
+            id?: string
+            content?: string
+            tags?: Array<string>
+            createdAt?: string
+            updatedAt?: string
+            parentIds?: Array<string>
+            discussion?: EmbedCommentDiscussion
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'embedDataWrapper'
+            datawrapperId?: string
+            forceDark?: boolean
+            plain?: boolean
+            size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'embedTwitter'
+            url?: string
+            id?: string
+            createdAt?: string
+            retrievedAt?: string
+            text?: string
+            html?: string
+            userId?: string
+            userName?: string
+            userScreenName?: string
+            userProfileImageUrl?: string
+            image?: string
+            more?: string
+            playable?: boolean
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'embedVideo'
+            size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+            platform?: 'vimeo' | 'youtube'
+            url?: string
+            id?: string
+            title?: string
+            createdAt?: string
+            retrievedAt?: string
+            userName?: string
+            userUrl?: string
+            userProfileImageUrl?: string
+            thumbnail?: string
+            aspectRatio?: number
+            durationMs?: number
+            mediaId?: string
+            src?: Src
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'html'
+            html?: string
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'if'
+            present: 'hasAccess' | 'lastName'
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            markDefs: null
+          }
+        | {
+            _key: string
+            _type: 'ifNot'
+            present: 'hasAccess' | 'lastName'
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            markDefs: null
+          }
+        | {
+            _key: string
+            _type: 'imageGroup'
+            images?: Array<
+              {
+                _key: string
+              } & GroupedEditorialImage
+            >
+            caption?: Caption
+            size?: 'BREAKOUT' | 'NARROW' | 'NORMAL'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'infoBox'
+            title?: string
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            image?: AsideImage
+            size?: 'breakout' | 'float'
+            figureSize?: 'L' | 'M' | 'S'
+            figureFloat?: boolean
+            collapsible?: boolean
+            markDefs: null
+          }
+        | {
+            _key: string
+            _type: 'pullQuote'
+            text?: string
+            source?: string
+            image?: AsideImage
+            size?: 'breakout' | 'float' | 'narrow'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'seriesNav'
+            series: ArticleCollectionReference
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'storyComponent'
+            url?: string
+            tagname?: string
+            componentData?: Code
+            size?: 'BREAKOUT' | 'FULL' | 'NORMAL'
+            markDefs: null
+            body: null
+          }
+        | {
+            _key: string
+            _type: 'webOnly'
+            body: Array<
+              | {
+                  children?: Array<
+                    | ({
+                        _key: string
+                      } & Variable)
+                    | ({
+                        _key: string
+                      } & VoiceTag)
+                    | {
+                        marks?: Array<string>
+                        text?: string
+                        _type: 'span'
+                        _key: string
+                      }
+                  >
+                  style?: 'heading' | 'normal'
+                  listItem?: 'bullet' | 'number'
+                  markDefs: Array<
+                    | {
+                        _key: string
+                        _type: 'internalLink'
+                        reference:
+                          | ArticleReference
+                          | ContributorReference
+                          | PageReference
+                        slug: string | null
+                      }
+                    | {
+                        _key: string
+                        _type: 'link'
+                        href?: string
+                        title?: string
+                      }
+                  > | null
+                  level?: number
+                  _type: 'block'
+                  _key: string
+                }
+              | {
+                  _key: string
+                  _type: 'button'
+                  text?: string
+                  url?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'divider'
+                  style?: string
+                  markDefs: null
+                }
+              | {
+                  _key: string
+                  _type: 'dividerStars'
+                  style?: string
+                  markDefs: null
+                }
+            > | null
+            markDefs: null
+          }
+      > | null
+      contributors: Array<{
+        _id: null
+        kind: string | null
+        slug: string | null
+        name: string | null
+        description: null
+        portrait: null
+      }> | null
+      articleCollection: {
+        _id: string
+        title: string
+        description: string | null
+        image: {
+          asset?: SanityImageAssetReference
+          media?: unknown
+          hotspot?: SanityImageHotspot
+          crop?: SanityImageCrop
+          imageDark?: {
+            asset?: SanityImageAssetReference
+            media?: unknown
+            hotspot?: SanityImageHotspot
+            crop?: SanityImageCrop
+            _type: 'image'
+          }
+          _type: 'image'
+        } | null
+        series: boolean | null
+      } | null
+      articleRecommendations: Array<
+        | {
+            _id: string
+            _type: 'article'
+            title: InlineEditor
+            description: InlineEditor | null
+            byline: Array<{
+              children?: Array<{
+                marks?: Array<string>
+                text?: string
+                _type: 'span'
+                _key: string
+              }>
+              style?: 'normal'
+              listItem?: never
+              markDefs: Array<
+                | {
+                    _key: string
+                    _type: 'internalLink'
+                    reference:
+                      ArticleReference | ContributorReference | PageReference
+                    slug: string | null
+                  }
+                | {
+                    _key: string
+                    _type: 'link'
+                    href?: string
+                    title?: string
+                  }
+              > | null
+              level?: number
+              _type: 'block'
+              _key: string
+            }> | null
+            slug: string
+            image: {
+              asset?: SanityImageAssetReference
+              media?: unknown
+              hotspot?: SanityImageHotspot
+              crop?: SanityImageCrop
+              imageDark?: ImageDark
+              _type: 'image'
+            } | null
+            publishDate: string | null
+            heading: {
+              _id: string | null
+              title: string
+              slug: string | null
+            }
+            theme: {
+              name: 'EDITORIAL' | 'META' | 'PAGE' | null
+              accentColor: Color | null
+            } | null
+            color: Color | null
+            backgroundColor: Color | null
+            headingColor: Color | null
+          }
+        | {
+            _id: string
+            _type: 'page'
+            title: InlineEditor
+            description: InlineEditor | null
+            byline: Array<{
+              children?: Array<{
+                marks?: Array<string>
+                text?: string
+                _type: 'span'
+                _key: string
+              }>
+              style?: 'normal'
+              listItem?: never
+              markDefs: Array<
+                | {
+                    _key: string
+                    _type: 'internalLink'
+                    reference:
+                      ArticleReference | ContributorReference | PageReference
                     slug: string | null
                   }
                 | {
@@ -3298,17 +4665,13 @@ export type PORTABLE_TEXT_CONTENT_FRAGMENT_QUERY_RESULT = {
                 content?: InlineEditor
                 href?: string
                 reference?:
-                  | ArticleReference
-                  | ContributorReference
-                  | PageReference
+                  ArticleReference | ContributorReference | PageReference
               }
             | {
                 _key: string
                 _type: 'internalLink'
                 reference:
-                  | ArticleReference
-                  | ContributorReference
-                  | PageReference
+                  ArticleReference | ContributorReference | PageReference
                 slug: string | null
               }
             | {
@@ -3349,9 +4712,7 @@ export type PORTABLE_TEXT_CONTENT_FRAGMENT_QUERY_RESULT = {
                       _key: string
                       _type: 'internalLink'
                       reference:
-                        | ArticleReference
-                        | ContributorReference
-                        | PageReference
+                        ArticleReference | ContributorReference | PageReference
                       slug: string | null
                     }
                   | {
@@ -3587,9 +4948,7 @@ export type PORTABLE_TEXT_CONTENT_FRAGMENT_QUERY_RESULT = {
                       _key: string
                       _type: 'internalLink'
                       reference:
-                        | ArticleReference
-                        | ContributorReference
-                        | PageReference
+                        ArticleReference | ContributorReference | PageReference
                       slug: string | null
                     }
                   | {
@@ -3769,9 +5128,7 @@ export type SERIES_MENU_QUERY_RESULT = {
                   _key: string
                   _type: 'internalLink'
                   reference:
-                    | ArticleReference
-                    | ContributorReference
-                    | PageReference
+                    ArticleReference | ContributorReference | PageReference
                   slug: string | null
                 }
               | {
@@ -3827,9 +5184,7 @@ export type SERIES_MENU_QUERY_RESULT = {
                   _key: string
                   _type: 'internalLink'
                   reference:
-                    | ArticleReference
-                    | ContributorReference
-                    | PageReference
+                    ArticleReference | ContributorReference | PageReference
                   slug: string | null
                 }
               | {
@@ -3911,9 +5266,7 @@ export type SERIES_NAV_QUERY_RESULT = {
                 _key: string
                 _type: 'internalLink'
                 reference:
-                  | ArticleReference
-                  | ContributorReference
-                  | PageReference
+                  ArticleReference | ContributorReference | PageReference
                 slug: string | null
               }
             | {
@@ -3969,9 +5322,7 @@ export type SERIES_NAV_QUERY_RESULT = {
                 _key: string
                 _type: 'internalLink'
                 reference:
-                  | ArticleReference
-                  | ContributorReference
-                  | PageReference
+                  ArticleReference | ContributorReference | PageReference
                 slug: string | null
               }
             | {
@@ -4880,7 +6231,8 @@ declare module '@sanity/client' {
     '\n  *[_type == "article" && _id in $ids]{\n    _id,\n    "title": pt::text(title),\n    "path": slug.current,\n    publishDate,\n    audioSourceMp3,\n    audioDurationMs,\n  }\n': AUDIO_QUEUE_ITEMS_QUERY_RESULT
     '*[_type == "article"][0]{\n    \n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n\n  }': BYLINE_FRAGMENT_QUERY_RESULT
     '*[_type == "page"][0]{\n    "block": pageBuilder[_type == "callToAction"][0]{\n      \n  target->{\n    _id,\n    _type,\n    _type == "newsletter" => {\n      name,\n      title\n    },\n    _type == "podcast" => {\n      podigeeSlug,\n      spotifyUrl,\n      appleUrl\n    },\n    _type == "articleCollection" => {\n      title,\n      description\n    }\n  }\n\n    }\n  }': CTA_BLOCK_FRAGMENT_QUERY_RESULT
-    '*[_type in ["article", "page"] && slug.current == $slug][0]{\n    _id,\n    _type,\n    title,\n    description,\n    "slug": slug.current,\n    _updatedAt,\n    cover {\n      ...\n    },\n    heading->{\n      _id,\n      title,\n      "slug": slug.current\n    },\n    theme {\n      name,\n      accentColor,\n      darkMode\n    },\n\n    _type == "article" => {\n      repoId,\n      "plainTitle": pt::text(title),\n      audioSourceMp3,\n      audioDurationMs,\n      _updatedAt,\n      publishDate,\n      // Plain text and SEO overrides, used for the JSON-LD linked data\n      "plainTitle": pt::text(title),\n      "plainDescription": pt::text(description),\n      seo {\n        title,\n        description,\n        image,\n        useImageBuilder\n      },\n      discussion->{\n        backendDiscussionId,\n      },\n      inlineDiscussion,\n      readingAccess,\n      \n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n      newsletter->{\n        title,\n        description,\n        frequency,\n        image,\n        name,\n      },\n      \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n,\n      contributors[]{\n        _id,\n        kind,\n        // Same profile slug as the byline links\n        "slug": coalesce(contributor->slug.current, contributor->userId),\n        "name": contributor->title,\n        "description": contributor->description,\n        "portrait": contributor->portrait\n      },\n      "articleCollection": articleCollections[featured == true][0].collection->{\n        _id,\n        title,\n        description,\n        image,\n        series\n      },\n      articleRecommendations[]->{\n        \n  _id,\n  _type,\n  "title": coalesce(teaserSmall.title, title),\n  "description": coalesce(teaserSmall.description, description),\n  "byline": teaserSmall.\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n  "slug": slug.current,\n  "image": teaserSmall.image,\n  publishDate,\n  "heading": select(\n    defined(teaserSmall.heading) || defined(heading) => {\n      "_id": heading->_id,\n      "title": coalesce(teaserSmall.heading, pt::text(heading->title)),\n      "slug": heading->slug.current,\n    }\n  ),\n  theme {\n    name,\n    accentColor,\n  },\n  "color": teaserSmall.color,\n  "backgroundColor": teaserSmall.backgroundColor,\n  "headingColor": teaserSmall.headingColor,\n\n      }\n    },\n\n    _type == "page" => {\n      pageBuilder[]{\n        _key,\n        _type,\n        _type == "menu" => {\n          \n  hasSeparator,\n  heading {\n    title,\n    page->{\n      _id,\n      "title": pt::text(title),\n      "slug": slug.current\n    }\n  },\n  pages[]{\n    _key,\n    _type,\n    _type == "link" => {\n      href,\n      title\n    },\n    _type == "reference" => {\n      "page": @->{\n        _id,\n        "title": pt::text(title),\n        "slug": slug.current\n      }\n    }\n  }\n\n        },\n        _type == "callToAction" => {\n          \n  target->{\n    _id,\n    _type,\n    _type == "newsletter" => {\n      name,\n      title\n    },\n    _type == "podcast" => {\n      podigeeSlug,\n      spotifyUrl,\n      appleUrl\n    },\n    _type == "articleCollection" => {\n      title,\n      description\n    }\n  }\n\n        },\n        _type == "editorBlock" => {\n          \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n\n        },\n        _type == "teaserList" => {\n          \n  appearance,\n  color,\n  backgroundColor,\n  imageStyle,\n  skipDescription,\n  maxItems,\n  title,\n  "total": select(\n    source.sourceType == "MANUAL" => count(source.items),\n    source.sourceType == "COLLECTION" => count(*[\n      (\n        _type == "article" &&\n        ^.source.collection._ref in articleCollections[].collection._ref\n      ) || (\n        _type == "teaserSmall" &&\n        collection._ref == ^.source.collection._ref\n      )\n    ]),\n    0\n  ),\n  "series": source.sourceType == "COLLECTION" &&\n    source.collection->series == true,\n  "collectionId": source.collection._ref\n\n        },\n        _type == "teaserLarge" => {\n          "reference": @->{\n  _id,\n  _type,\n  "targetType": target[0]->_type,\n  // link can either be a plain link OR a referenced doc\n  "target": coalesce(target[0]->slug.current, target[0].href),\n  "targetId": target[0]->_id,\n  "publishDate": target[0]->publishDate,\n  "theme": {\n    "name": target[0]->theme.name,\n    "accentColor": target[0]->theme.accentColor,\n  },\n  // heading: own string override, else the referenced doc\'s format title\n  "heading": select(\n    defined(heading) => { "title": heading },\n    defined(target[0]->heading) => {\n      "title": pt::text(target[0]->heading->title)\n    }\n  ),\n  "teaser": {\n    layout,\n    "title": coalesce(title, target[0]->title),\n    "description": coalesce(description, target[0]->description),\n    "byline": coalesce(\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n, target[0]->\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n),\n    "image": coalesce(image, target[0]->image),\n    imageCredits,\n    imagePosition,\n    imagePadding,\n    textPosition,\n    textAlignment,\n    textSize,\n    color,\n    backgroundColor,\n    // Audio always comes from the target article itself \u2014 a teaserLarge\n    // override doc has no audio of its own.\n    "audioTitle": pt::text(target[0]->title),\n    "audioSourceMp3": target[0]->audioSourceMp3,\n    "audioDurationMs": target[0]->audioDurationMs,\n  }\n}\n        },\n      }\n    }\n  }': DOCUMENT_QUERY_RESULT
+    '*[_type in ["article", "page"] && slug.current == $slug][0]{\n    _id,\n    _type,\n    title,\n    description,\n    "slug": slug.current,\n    _updatedAt,\n    cover {\n      ...\n    },\n    heading->{\n      _id,\n      title,\n      "slug": slug.current\n    },\n    theme {\n      name,\n      accentColor,\n      darkMode\n    },\n\n    _type == "article" => {\n      repoId,\n      "plainTitle": pt::text(title),\n      audioSourceMp3,\n      audioDurationMs,\n      _updatedAt,\n      publishDate,\n      // Plain text and SEO overrides, used for the JSON-LD linked data\n      "plainTitle": pt::text(title),\n      "plainDescription": pt::text(description),\n      seo {\n        title,\n        description,\n        image,\n        useImageBuilder\n      },\n      discussion->{\n        backendDiscussionId,\n      },\n      inlineDiscussion,\n      readingAccess,\n      \n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n      newsletter->{\n        title,\n        description,\n        frequency,\n        image,\n        name,\n      },\n      \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n,\n      contributors[]{\n        _id,\n        kind,\n        // Same profile slug as the byline links\n        "slug": coalesce(contributor->slug.current, contributor->userId),\n        "name": contributor->title,\n        "description": contributor->description,\n        "portrait": contributor->portrait\n      },\n      "articleCollection": articleCollections[featured == true][0].collection->{\n        _id,\n        title,\n        description,\n        image,\n        series\n      },\n      articleRecommendations[]->{\n        \n  _id,\n  _type,\n  "title": coalesce(teaserSmall.title, title),\n  "description": coalesce(teaserSmall.description, description),\n  "byline": teaserSmall.\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n  "slug": slug.current,\n  "image": teaserSmall.image,\n  publishDate,\n  "heading": select(\n    defined(teaserSmall.heading) || defined(heading) => {\n      "_id": heading->_id,\n      "title": coalesce(teaserSmall.heading, pt::text(heading->title)),\n      "slug": heading->slug.current,\n    }\n  ),\n  theme {\n    name,\n    accentColor,\n  },\n  "color": teaserSmall.color,\n  "backgroundColor": teaserSmall.backgroundColor,\n  "headingColor": teaserSmall.headingColor,\n\n      }\n    },\n\n    _type == "page" => {\n      pageBuilder[]{\n        _key,\n        _type,\n        _type == "menu" => {\n          \n  hasSeparator,\n  heading {\n    title,\n    page->{\n      _id,\n      "title": pt::text(title),\n      "slug": slug.current\n    }\n  },\n  pages[]{\n    _key,\n    _type,\n    _type == "link" => {\n      href,\n      title\n    },\n    _type == "reference" => {\n      "page": @->{\n        _id,\n        "title": pt::text(title),\n        "slug": slug.current\n      }\n    }\n  }\n\n        },\n        _type == "callToAction" => {\n          \n  target->{\n    _id,\n    _type,\n    _type == "newsletter" => {\n      name,\n      title\n    },\n    _type == "podcast" => {\n      podigeeSlug,\n      spotifyUrl,\n      appleUrl\n    },\n    _type == "articleCollection" => {\n      title,\n      description\n    }\n  }\n\n        },\n        _type == "editorBlock" => {\n          \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n\n        },\n        _type == "teaserList" => {\n          \n  appearance,\n  color,\n  backgroundColor,\n  imageStyle,\n  skipDescription,\n  maxItems,\n  title,\n  "total": select(\n    source.sourceType == "MANUAL" => count(source.items),\n    source.sourceType == "COLLECTION" => count(*[\n      (\n        _type == "article" &&\n        ^.source.collection._ref in articleCollections[].collection._ref\n      ) || (\n        _type == "teaserSmall" &&\n        collection._ref == ^.source.collection._ref\n      )\n    ]),\n    0\n  ),\n  "series": source.sourceType == "COLLECTION" &&\n    source.collection->series == true,\n  "collectionId": source.collection._ref\n\n        },\n        _type == "teaserLarge" => {\n          "reference": @->{\n  _id,\n  _type,\n  "targetType": target[0]->_type,\n  // link can either be a plain link OR a referenced doc\n  "target": coalesce(target[0]->slug.current, target[0].href),\n  "targetId": target[0]->_id,\n  "publishDate": target[0]->publishDate,\n  "theme": {\n    "name": target[0]->theme.name,\n    "accentColor": target[0]->theme.accentColor,\n  },\n  // heading: own string override, else the referenced doc\'s format title\n  "heading": select(\n    defined(heading) => { "title": heading },\n    defined(target[0]->heading) => {\n      "title": pt::text(target[0]->heading->title)\n    }\n  ),\n  "teaser": {\n    layout,\n    "title": coalesce(title, target[0]->title),\n    "description": coalesce(description, target[0]->description),\n    "byline": coalesce(\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n, target[0]->\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n),\n    "image": coalesce(image, target[0]->image),\n    imageCredits,\n    imagePosition,\n    imagePadding,\n    textPosition,\n    textAlignment,\n    textSize,\n    color,\n    backgroundColor,\n    // Audio always comes from the target article itself \u2014 a teaserLarge\n    // override doc has no audio of its own.\n    "audioTitle": pt::text(target[0]->title),\n    "audioSourceMp3": target[0]->audioSourceMp3,\n    "audioDurationMs": target[0]->audioDurationMs,\n  }\n}\n        },\n      }\n    }\n  }\n  ': DOCUMENT_BY_SLUG_QUERY_RESULT
+    '*[_type in ["article", "page"] && _id == $id][0]{\n    _id,\n    _type,\n    title,\n    description,\n    "slug": slug.current,\n    _updatedAt,\n    cover {\n      ...\n    },\n    heading->{\n      _id,\n      title,\n      "slug": slug.current\n    },\n    theme {\n      name,\n      accentColor,\n      darkMode\n    },\n\n    _type == "article" => {\n      repoId,\n      "plainTitle": pt::text(title),\n      audioSourceMp3,\n      audioDurationMs,\n      _updatedAt,\n      publishDate,\n      // Plain text and SEO overrides, used for the JSON-LD linked data\n      "plainTitle": pt::text(title),\n      "plainDescription": pt::text(description),\n      seo {\n        title,\n        description,\n        image,\n        useImageBuilder\n      },\n      discussion->{\n        backendDiscussionId,\n      },\n      inlineDiscussion,\n      readingAccess,\n      \n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n      newsletter->{\n        title,\n        description,\n        frequency,\n        image,\n        name,\n      },\n      \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n,\n      contributors[]{\n        _id,\n        kind,\n        // Same profile slug as the byline links\n        "slug": coalesce(contributor->slug.current, contributor->userId),\n        "name": contributor->title,\n        "description": contributor->description,\n        "portrait": contributor->portrait\n      },\n      "articleCollection": articleCollections[featured == true][0].collection->{\n        _id,\n        title,\n        description,\n        image,\n        series\n      },\n      articleRecommendations[]->{\n        \n  _id,\n  _type,\n  "title": coalesce(teaserSmall.title, title),\n  "description": coalesce(teaserSmall.description, description),\n  "byline": teaserSmall.\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n,\n  "slug": slug.current,\n  "image": teaserSmall.image,\n  publishDate,\n  "heading": select(\n    defined(teaserSmall.heading) || defined(heading) => {\n      "_id": heading->_id,\n      "title": coalesce(teaserSmall.heading, pt::text(heading->title)),\n      "slug": heading->slug.current,\n    }\n  ),\n  theme {\n    name,\n    accentColor,\n  },\n  "color": teaserSmall.color,\n  "backgroundColor": teaserSmall.backgroundColor,\n  "headingColor": teaserSmall.headingColor,\n\n      }\n    },\n\n    _type == "page" => {\n      pageBuilder[]{\n        _key,\n        _type,\n        _type == "menu" => {\n          \n  hasSeparator,\n  heading {\n    title,\n    page->{\n      _id,\n      "title": pt::text(title),\n      "slug": slug.current\n    }\n  },\n  pages[]{\n    _key,\n    _type,\n    _type == "link" => {\n      href,\n      title\n    },\n    _type == "reference" => {\n      "page": @->{\n        _id,\n        "title": pt::text(title),\n        "slug": slug.current\n      }\n    }\n  }\n\n        },\n        _type == "callToAction" => {\n          \n  target->{\n    _id,\n    _type,\n    _type == "newsletter" => {\n      name,\n      title\n    },\n    _type == "podcast" => {\n      podigeeSlug,\n      spotifyUrl,\n      appleUrl\n    },\n    _type == "articleCollection" => {\n      title,\n      description\n    }\n  }\n\n        },\n        _type == "editorBlock" => {\n          \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    },\n\n    body[] {\n      ...,\n      markDefs[]{\n        ...,\n        _type == "internalLink" => {\n          "slug": select(\n            reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n            reference->slug.current\n          )\n        }\n      }\n    }\n  }\n\n        },\n        _type == "teaserList" => {\n          \n  appearance,\n  color,\n  backgroundColor,\n  imageStyle,\n  skipDescription,\n  maxItems,\n  title,\n  "total": select(\n    source.sourceType == "MANUAL" => count(source.items),\n    source.sourceType == "COLLECTION" => count(*[\n      (\n        _type == "article" &&\n        ^.source.collection._ref in articleCollections[].collection._ref\n      ) || (\n        _type == "teaserSmall" &&\n        collection._ref == ^.source.collection._ref\n      )\n    ]),\n    0\n  ),\n  "series": source.sourceType == "COLLECTION" &&\n    source.collection->series == true,\n  "collectionId": source.collection._ref\n\n        },\n        _type == "teaserLarge" => {\n          "reference": @->{\n  _id,\n  _type,\n  "targetType": target[0]->_type,\n  // link can either be a plain link OR a referenced doc\n  "target": coalesce(target[0]->slug.current, target[0].href),\n  "targetId": target[0]->_id,\n  "publishDate": target[0]->publishDate,\n  "theme": {\n    "name": target[0]->theme.name,\n    "accentColor": target[0]->theme.accentColor,\n  },\n  // heading: own string override, else the referenced doc\'s format title\n  "heading": select(\n    defined(heading) => { "title": heading },\n    defined(target[0]->heading) => {\n      "title": pt::text(target[0]->heading->title)\n    }\n  ),\n  "teaser": {\n    layout,\n    "title": coalesce(title, target[0]->title),\n    "description": coalesce(description, target[0]->description),\n    "byline": coalesce(\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n, target[0]->\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n),\n    "image": coalesce(image, target[0]->image),\n    imageCredits,\n    imagePosition,\n    imagePadding,\n    textPosition,\n    textAlignment,\n    textSize,\n    color,\n    backgroundColor,\n    // Audio always comes from the target article itself \u2014 a teaserLarge\n    // override doc has no audio of its own.\n    "audioTitle": pt::text(target[0]->title),\n    "audioSourceMp3": target[0]->audioSourceMp3,\n    "audioDurationMs": target[0]->audioDurationMs,\n  }\n}\n        },\n      }\n    }\n  }\n  ': DOCUMENT_BY_ID_QUERY_RESULT
     '\n  *[\n    _type == "article" &&\n    defined(slug.current) &&\n    defined(publishDate) &&\n    coalesce(showInFeed, true)\n  ] | order(publishDate desc) [0...100] {\n    _id,\n    "path": slug.current,\n    "title": pt::text(title),\n    "description": pt::text(description),\n    publishDate\n  }': FEED_QUERY_RESULT
     '\n  *[\n    _type == "teaserLarge" &&\n    target[0]->_type == "article" &&\n    defined(target[0]->publishDate) &&\n    !(_id in *[_type == "front"] | order(publishDate desc)[0].pageBuilder[]._ref)\n  ] | order(target[0]->publishDate desc) [$start...$end] {\n    \n  _id,\n  _type,\n  "targetType": target[0]->_type,\n  // link can either be a plain link OR a referenced doc\n  "target": coalesce(target[0]->slug.current, target[0].href),\n  "targetId": target[0]->_id,\n  "publishDate": target[0]->publishDate,\n  "theme": {\n    "name": target[0]->theme.name,\n    "accentColor": target[0]->theme.accentColor,\n  },\n  // heading: own string override, else the referenced doc\'s format title\n  "heading": select(\n    defined(heading) => { "title": heading },\n    defined(target[0]->heading) => {\n      "title": pt::text(target[0]->heading->title)\n    }\n  ),\n  "teaser": {\n    layout,\n    "title": coalesce(title, target[0]->title),\n    "description": coalesce(description, target[0]->description),\n    "byline": coalesce(\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n, target[0]->\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n),\n    "image": coalesce(image, target[0]->image),\n    imageCredits,\n    imagePosition,\n    imagePadding,\n    textPosition,\n    textAlignment,\n    textSize,\n    color,\n    backgroundColor,\n    // Audio always comes from the target article itself \u2014 a teaserLarge\n    // override doc has no audio of its own.\n    "audioTitle": pt::text(target[0]->title),\n    "audioSourceMp3": target[0]->audioSourceMp3,\n    "audioDurationMs": target[0]->audioDurationMs,\n  }\n\n  }\n': FRONT_FEED_QUERY_RESULT
     '*[_type == "front"] | order(publishDate desc)[0]{\n    _id,\n    title,\n    pageBuilder[]{\n      _key,\n      _type,\n      _type == "teaserList" => {\n        \n  appearance,\n  color,\n  backgroundColor,\n  imageStyle,\n  skipDescription,\n  maxItems,\n  title,\n  "total": select(\n    source.sourceType == "MANUAL" => count(source.items),\n    source.sourceType == "COLLECTION" => count(*[\n      (\n        _type == "article" &&\n        ^.source.collection._ref in articleCollections[].collection._ref\n      ) || (\n        _type == "teaserSmall" &&\n        collection._ref == ^.source.collection._ref\n      )\n    ]),\n    0\n  ),\n  "series": source.sourceType == "COLLECTION" &&\n    source.collection->series == true,\n  "collectionId": source.collection._ref\n\n      },\n      _type == "teaserLarge" => {\n        "reference": @->{\n  _id,\n  _type,\n  "targetType": target[0]->_type,\n  // link can either be a plain link OR a referenced doc\n  "target": coalesce(target[0]->slug.current, target[0].href),\n  "targetId": target[0]->_id,\n  "publishDate": target[0]->publishDate,\n  "theme": {\n    "name": target[0]->theme.name,\n    "accentColor": target[0]->theme.accentColor,\n  },\n  // heading: own string override, else the referenced doc\'s format title\n  "heading": select(\n    defined(heading) => { "title": heading },\n    defined(target[0]->heading) => {\n      "title": pt::text(target[0]->heading->title)\n    }\n  ),\n  "teaser": {\n    layout,\n    "title": coalesce(title, target[0]->title),\n    "description": coalesce(description, target[0]->description),\n    "byline": coalesce(\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n, target[0]->\n  byline[] {\n    ...,\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": select(\n          reference->_type == "contributor" => "/~" + coalesce(reference->slug.current, reference->userId),\n          reference->slug.current\n        )\n      }\n    }\n  }\n),\n    "image": coalesce(image, target[0]->image),\n    imageCredits,\n    imagePosition,\n    imagePadding,\n    textPosition,\n    textAlignment,\n    textSize,\n    color,\n    backgroundColor,\n    // Audio always comes from the target article itself \u2014 a teaserLarge\n    // override doc has no audio of its own.\n    "audioTitle": pt::text(target[0]->title),\n    "audioSourceMp3": target[0]->audioSourceMp3,\n    "audioDurationMs": target[0]->audioDurationMs,\n  }\n}\n      },\n    },\n  }': FRONT_LATEST_QUERY_RESULT

--- a/yarn.lock
+++ b/yarn.lock
@@ -28250,15 +28250,6 @@ react-remove-scroll@^2.7.2:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-react-rx@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/react-rx/-/react-rx-4.2.3.tgz#c66faf1375d6e5c1e726c38b58e1853ea9b4b471"
-  integrity sha512-AzuecrOdmoIgVA/wYCCFUnWc1nFtu+6sd++uH03gYAHte/ujYApHPOPEgSlWbKDhMjiXrcYtzv9IJrxwtmurIw==
-  dependencies:
-    observable-callback "^1.0.3"
-    react-compiler-runtime "1.0.0"
-    use-effect-event "^2.0.3"
-
 react-shallow-renderer@^16.13.1:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
@@ -30629,7 +30620,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -30646,15 +30637,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@~2.1.1:
   version "2.1.1"
@@ -30795,7 +30777,7 @@ stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30815,13 +30797,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -33502,7 +33477,7 @@ wordwrapjs@5.1.1, wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.1.tgz#bfd1eb426f0f7eec73b7df32cf7df1f618bfb3a9"
   integrity sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33515,15 +33490,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Article and page slugs are derived from the publish date, which can change during planning — breaking the "/preview<slug>" route whenever a document gets rescheduled. Switch the Studio preview to resolve documents by `_id`, matching how front/teaserLarge previews already work.

- Split DOCUMENT_QUERY into DOCUMENT_BY_SLUG_QUERY (public route) and DOCUMENT_BY_ID_QUERY (preview route), sharing one DOCUMENT_FIELDS projection, with a compile-time check that their result types stay identical.
- Replace preview/[...path] with preview/[id].
- Regenerate sanity.types.ts.