### PR TITLE
feat: Add script to clean up stale unpublished document versions in ES

### DIFF
--- a/packages/backend-modules/search/jest.config.js
+++ b/packages/backend-modules/search/jest.config.js
@@ -1,0 +1,4 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+}

--- a/packages/backend-modules/search/lib/cleanupUnpublishedVersions.js
+++ b/packages/backend-modules/search/lib/cleanupUnpublishedVersions.js
@@ -1,0 +1,120 @@
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * @param {Number} weeks
+ * @param {Date} [now]
+ * @return {Date}
+ */
+const getOlderThanDate = (weeks, now = new Date()) =>
+  new Date(now.getTime() - weeks * WEEK_MS)
+
+/**
+ * Query matching document versions of a repoId which are fully unpublished
+ * (published=false AND prepublished=false, i.e. superseded by a newer
+ * version).
+ *
+ * Note: this intentionally does NOT filter by meta.publishDate. That field
+ * is content metadata (e.g. an authored/scheduled date on the "Front" type)
+ * and is often identical across hundreds of versions of the same repoId, so
+ * it cannot tell a version superseded three years ago from one superseded
+ * three weeks ago. The actual per-version age lives in Postgres, see
+ * `indexMilestonesByName`/`selectStaleVersions` below.
+ *
+ * @param  {Object} args
+ * @param  {String} args.repoId
+ * @return {Object} elasticsearch query
+ */
+const buildUnpublishedVersionsQuery = ({ repoId }) => ({
+  bool: {
+    must: [
+      { term: { __type: 'Document' } },
+      { term: { 'meta.repoId': repoId } },
+      { term: { '__state.published': false } },
+      { term: { '__state.prepublished': false } },
+    ],
+  },
+})
+
+/**
+ * Indexes publikator.milestones rows by their `name` (== ES versionName).
+ * If several milestones share a name (shouldn't happen, but scopes aren't
+ * unique per name), the most recently revoked/created one wins.
+ *
+ * @param  {Object[]} milestones rows from publikator.milestones
+ * @return {Object} map of versionName -> milestone
+ */
+const indexMilestonesByName = (milestones) => {
+  const byName = {}
+  for (const milestone of milestones) {
+    const existing = byName[milestone.name]
+    if (!existing || getMilestoneAge(milestone) > getMilestoneAge(existing)) {
+      byName[milestone.name] = milestone
+    }
+  }
+  return byName
+}
+
+/**
+ * The moment a version stopped being current: when it was revoked by a
+ * newer publish (publikator.postgres's maybeDeclareMilestonePublished sets
+ * this), falling back to when the milestone row was created for versions
+ * that were superseded before revocation was recorded, or otherwise never
+ * revoked (e.g. plain milestones).
+ *
+ * @param  {Object} milestone
+ * @return {Date|null}
+ */
+const getMilestoneAge = (milestone) => {
+  const value = milestone?.revokedAt || milestone?.createdAt
+  return value ? new Date(value) : null
+}
+
+/**
+ * Splits fully-unpublished ES hits into ones stale enough to delete
+ * (their milestone's age is older than `olderThan`) and ones to keep,
+ * annotating why. A version whose milestone can't be found is kept, not
+ * silently dropped nor silently deleted — the caller should surface it.
+ *
+ * @param  {Object} args
+ * @param  {Object[]} args.hits          ES hits (with _id, _source.versionName)
+ * @param  {Object}   args.milestonesByName from indexMilestonesByName
+ * @param  {Date}     args.olderThan
+ * @return {{stale: Object[], kept: Object[]}}
+ */
+const selectStaleVersions = ({ hits, milestonesByName, olderThan }) => {
+  const stale = []
+  const kept = []
+
+  for (const hit of hits) {
+    const versionName = hit._source?.versionName
+    const milestone = milestonesByName[versionName]
+    const age = milestone && getMilestoneAge(milestone)
+
+    if (!age) {
+      kept.push({ hit, reason: 'no milestone found for versionName' })
+    } else if (age < olderThan) {
+      stale.push({ hit, age })
+    } else {
+      kept.push({ hit, reason: 'not older than threshold', age })
+    }
+  }
+
+  return { stale, kept }
+}
+
+/**
+ * @param  {String} index
+ * @param  {String[]} ids
+ * @return {Object[]} bulk API body (delete ops)
+ */
+const toBulkDeleteBody = (index, ids) =>
+  ids.map((id) => ({ delete: { _index: index, _id: id } }))
+
+module.exports = {
+  getOlderThanDate,
+  buildUnpublishedVersionsQuery,
+  indexMilestonesByName,
+  getMilestoneAge,
+  selectStaleVersions,
+  toBulkDeleteBody,
+}

--- a/packages/backend-modules/search/lib/cleanupUnpublishedVersions.test.js
+++ b/packages/backend-modules/search/lib/cleanupUnpublishedVersions.test.js
@@ -1,0 +1,177 @@
+const {
+  getOlderThanDate,
+  buildUnpublishedVersionsQuery,
+  indexMilestonesByName,
+  getMilestoneAge,
+  selectStaleVersions,
+  toBulkDeleteBody,
+} = require('./cleanupUnpublishedVersions')
+
+describe('getOlderThanDate', () => {
+  it('subtracts the given number of weeks from now', () => {
+    const now = new Date('2026-08-10T00:00:00.000Z')
+
+    expect(getOlderThanDate(3, now)).toEqual(
+      new Date('2026-07-20T00:00:00.000Z'),
+    )
+  })
+
+  it('defaults to the current time when now is omitted', () => {
+    const before = Date.now()
+    const result = getOlderThanDate(0)
+    const after = Date.now()
+
+    expect(result.getTime()).toBeGreaterThanOrEqual(before)
+    expect(result.getTime()).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('buildUnpublishedVersionsQuery', () => {
+  it('matches only fully-unpublished versions of the repoId, without any date filter', () => {
+    expect(
+      buildUnpublishedVersionsQuery({ repoId: 'republik/magazine' }),
+    ).toEqual({
+      bool: {
+        must: [
+          { term: { __type: 'Document' } },
+          { term: { 'meta.repoId': 'republik/magazine' } },
+          { term: { '__state.published': false } },
+          { term: { '__state.prepublished': false } },
+        ],
+      },
+    })
+  })
+})
+
+describe('getMilestoneAge', () => {
+  it('prefers revokedAt over createdAt', () => {
+    expect(
+      getMilestoneAge({
+        createdAt: '2020-01-01T00:00:00.000Z',
+        revokedAt: '2022-01-01T00:00:00.000Z',
+      }),
+    ).toEqual(new Date('2022-01-01T00:00:00.000Z'))
+  })
+
+  it('falls back to createdAt when revokedAt is missing', () => {
+    expect(
+      getMilestoneAge({ createdAt: '2020-01-01T00:00:00.000Z' }),
+    ).toEqual(new Date('2020-01-01T00:00:00.000Z'))
+  })
+
+  it('returns null for a missing milestone', () => {
+    expect(getMilestoneAge(null)).toBe(null)
+    expect(getMilestoneAge(undefined)).toBe(null)
+  })
+})
+
+describe('indexMilestonesByName', () => {
+  it('indexes milestones by name', () => {
+    const m1 = { name: 'v1', createdAt: '2020-01-01T00:00:00.000Z' }
+    const m2 = { name: 'v2', createdAt: '2021-01-01T00:00:00.000Z' }
+
+    expect(indexMilestonesByName([m1, m2])).toEqual({ v1: m1, v2: m2 })
+  })
+
+  it('keeps the more recently-aged milestone when names collide', () => {
+    const older = { name: 'v1', createdAt: '2020-01-01T00:00:00.000Z' }
+    const newer = { name: 'v1', createdAt: '2021-01-01T00:00:00.000Z' }
+
+    expect(indexMilestonesByName([older, newer])).toEqual({ v1: newer })
+    expect(indexMilestonesByName([newer, older])).toEqual({ v1: newer })
+  })
+})
+
+describe('selectStaleVersions', () => {
+  const hit = (versionName, id = versionName) => ({
+    _id: id,
+    _source: { versionName },
+  })
+
+  it('marks a version stale when its milestone age is older than the threshold', () => {
+    const hits = [hit('v1')]
+    const milestonesByName = {
+      v1: { revokedAt: '2020-01-01T00:00:00.000Z' },
+    }
+
+    const { stale, kept } = selectStaleVersions({
+      hits,
+      milestonesByName,
+      olderThan: new Date('2021-01-01T00:00:00.000Z'),
+    })
+
+    expect(stale).toEqual([
+      { hit: hits[0], age: new Date('2020-01-01T00:00:00.000Z') },
+    ])
+    expect(kept).toEqual([])
+  })
+
+  it('keeps a version whose milestone age is not older than the threshold', () => {
+    const hits = [hit('v1')]
+    const milestonesByName = {
+      v1: { revokedAt: '2022-01-01T00:00:00.000Z' },
+    }
+
+    const { stale, kept } = selectStaleVersions({
+      hits,
+      milestonesByName,
+      olderThan: new Date('2021-01-01T00:00:00.000Z'),
+    })
+
+    expect(stale).toEqual([])
+    expect(kept).toEqual([
+      {
+        hit: hits[0],
+        reason: 'not older than threshold',
+        age: new Date('2022-01-01T00:00:00.000Z'),
+      },
+    ])
+  })
+
+  it('keeps (does not delete) a version with no matching milestone', () => {
+    const hits = [hit('v1')]
+
+    const { stale, kept } = selectStaleVersions({
+      hits,
+      milestonesByName: {},
+      olderThan: new Date('2021-01-01T00:00:00.000Z'),
+    })
+
+    expect(stale).toEqual([])
+    expect(kept).toEqual([
+      { hit: hits[0], reason: 'no milestone found for versionName' },
+    ])
+  })
+
+  it('partitions a mix of stale, kept, and unknown versions', () => {
+    const hits = [hit('stale'), hit('recent'), hit('unknown')]
+    const milestonesByName = {
+      stale: { revokedAt: '2020-01-01T00:00:00.000Z' },
+      recent: { revokedAt: '2022-06-01T00:00:00.000Z' },
+    }
+
+    const { stale, kept } = selectStaleVersions({
+      hits,
+      milestonesByName,
+      olderThan: new Date('2021-01-01T00:00:00.000Z'),
+    })
+
+    expect(stale.map(({ hit }) => hit._id)).toEqual(['stale'])
+    expect(kept.map(({ hit }) => hit._id)).toEqual(['recent', 'unknown'])
+  })
+})
+
+describe('toBulkDeleteBody', () => {
+  it('maps each id to a delete op against the given index, preserving order', () => {
+    expect(
+      toBulkDeleteBody('republik-document-write', ['id-1', 'id-2']),
+    ).toEqual([
+      { delete: { _index: 'republik-document-write', _id: 'id-1' } },
+      { delete: { _index: 'republik-document-write', _id: 'id-2' } },
+    ])
+  })
+
+  it('returns an empty array for no ids', () => {
+    expect(toBulkDeleteBody('republik-document-write', [])).toEqual([])
+  })
+})

--- a/packages/backend-modules/search/package.json
+++ b/packages/backend-modules/search/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "link": "yarn link"
+    "link": "yarn link",
+    "test": "jest"
   },
   "dependencies": {
     "@orbiting/graphql-list-fields": "^2.0.2",
@@ -32,5 +33,8 @@
     "snappy": "^7.1.1",
     "unist-util-visit": "^2.0.2",
     "yargs": "^17.0.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/packages/backend-modules/search/script/cleanupUnpublishedVersions.js
+++ b/packages/backend-modules/search/script/cleanupUnpublishedVersions.js
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+/**
+ * Deletes stale, fully-unpublished document versions from the
+ * republik-document-write index for a given repoId.
+ *
+ * Old versions are never deleted on publish, only marked unpublished
+ * (__state.published = false, __state.prepublished = false). For
+ * repoIds which are republished often (e.g. republik/magazine) this
+ * backlog grows without bound and eventually makes Documents.js's
+ * afterScheduled _update_by_query exceed Elasticsearch's coordinating
+ * node circuit breaker (es_rejected_execution_exception, HTTP 429).
+ *
+ * Elasticsearch itself has no reliable per-version age field: meta.publishDate
+ * is content metadata (e.g. an authored/scheduled date on a "Front" type) and
+ * is often identical across hundreds of versions of the same repoId. The
+ * actual age of a version lives in Postgres, on publikator.milestones.revokedAt
+ * (falling back to createdAt) - set by maybeDeclareMilestonePublished when a
+ * newer version supersedes it. So this script cross-references Elasticsearch
+ * (to find unpublished versions) with Postgres (to find how old they are).
+ *
+ * This script lists (and, with --delete, removes) unpublished versions
+ * of a repoId older than a given age threshold, deleting via small
+ * bulk-API batches rather than a single _delete_by_query to avoid
+ * tripping the same circuit breaker.
+ *
+ * # Usage
+ * ./cleanupUnpublishedVersions.js --repoId republik/magazine
+ * ./cleanupUnpublishedVersions.js --repoId republik/magazine --olderThan 4
+ * ./cleanupUnpublishedVersions.js --repoId republik/magazine --delete
+ */
+
+require('@orbiting/backend-modules-env').config()
+
+const yargs = require('yargs')
+const { chunk } = require('lodash')
+const readline = require('readline/promises')
+
+const Elasticsearch = require('@orbiting/backend-modules-base/lib/Elasticsearch')
+const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
+const { getIndexAlias } = require('../lib/utils')
+const {
+  getOlderThanDate,
+  buildUnpublishedVersionsQuery,
+  indexMilestonesByName,
+  selectStaleVersions,
+  toBulkDeleteBody,
+} = require('../lib/cleanupUnpublishedVersions')
+
+const DEFAULT_OLDER_THAN_WEEKS = 3
+const DEFAULT_BATCH_SIZE = 200
+// keep well under postgres' parameter/list limits for the "name IN (...)" lookup
+const MILESTONE_LOOKUP_CHUNK_SIZE = 500
+
+const argv = yargs
+  .option('repoId', {
+    alias: 'r',
+    type: 'string',
+    demandOption: true,
+    describe: 'e.g. republik/magazine',
+  })
+  .option('olderThan', {
+    alias: 'o',
+    type: 'number',
+    default: DEFAULT_OLDER_THAN_WEEKS,
+    describe:
+      'age threshold in weeks, based on publikator.milestones.revokedAt (fallback createdAt)',
+  })
+  .option('delete', {
+    type: 'boolean',
+    default: false,
+    describe: 'actually delete matches (default: list only, no side effects)',
+  })
+  .option('batchSize', {
+    type: 'number',
+    default: DEFAULT_BATCH_SIZE,
+    describe: 'number of documents deleted per bulk request',
+  })
+  .help()
+  .version(false).argv
+
+const elastic = Elasticsearch.connect()
+const index = getIndexAlias('document', 'write')
+
+const findUnpublishedVersions = async () => {
+  const params = {
+    index,
+    scroll: '1m',
+    size: 500,
+    _source: ['meta.repoId', 'versionName'],
+    body: {
+      query: buildUnpublishedVersionsQuery({ repoId: argv.repoId }),
+    },
+  }
+
+  const hits = []
+  for await (const hit of Elasticsearch.scroll(elastic, params)) {
+    hits.push(hit)
+  }
+  return hits
+}
+
+const findMilestonesByName = async (pgdb, repoId, versionNames) => {
+  const milestones = []
+  for (const namesChunk of chunk(versionNames, MILESTONE_LOOKUP_CHUNK_SIZE)) {
+    milestones.push(
+      ...(await pgdb.publikator.milestones.find({
+        repoId,
+        name: namesChunk,
+      })),
+    )
+  }
+  return indexMilestonesByName(milestones)
+}
+
+const confirm = async (message) => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+  try {
+    const answer = await rl.question(`${message} [y/N] `)
+    return answer.trim().toLowerCase() === 'y'
+  } finally {
+    rl.close()
+  }
+}
+
+const deleteInBatches = async (hits) => {
+  const batches = chunk(
+    hits.map((hit) => hit._id),
+    argv.batchSize,
+  )
+
+  const stats = { deleted: 0, errors: 0 }
+
+  for (const [batchIndex, ids] of batches.entries()) {
+    console.log(
+      `deleting batch ${batchIndex + 1}/${batches.length} (${ids.length} version(s))`,
+    )
+
+    const resp = await elastic.bulk({
+      body: toBulkDeleteBody(index, ids),
+    })
+
+    const failed = resp.errors
+      ? resp.items.filter((item) => item.delete?.error)
+      : []
+
+    if (failed.length) {
+      console.error(
+        `batch ${batchIndex + 1}: ${failed.length} error(s)`,
+        failed.map((item) => item.delete.error),
+      )
+    }
+
+    stats.errors += failed.length
+    stats.deleted += ids.length - failed.length
+  }
+
+  return stats
+}
+
+const run = async () => {
+  const olderThanDate = getOlderThanDate(argv.olderThan)
+
+  console.log('searching for unpublished document versions', {
+    index,
+    repoId: argv.repoId,
+    olderThanWeeks: argv.olderThan,
+    revokedBefore: olderThanDate.toISOString(),
+  })
+
+  const hits = await findUnpublishedVersions()
+
+  if (!hits.length) {
+    console.log('no unpublished versions found')
+    return
+  }
+
+  console.log(
+    `found ${hits.length} unpublished version(s), looking up their milestones in postgres`,
+  )
+
+  const pgdb = await PgDb.connect()
+  let stale
+  let kept
+  try {
+    const milestonesByName = await findMilestonesByName(
+      pgdb,
+      argv.repoId,
+      hits.map((hit) => hit._source.versionName),
+    )
+
+    ;({ stale, kept } = selectStaleVersions({
+      hits,
+      milestonesByName,
+      olderThan: olderThanDate,
+    }))
+  } finally {
+    await pgdb.close()
+  }
+
+  const noMilestone = kept.filter(
+    (k) => k.reason === 'no milestone found for versionName',
+  )
+  if (noMilestone.length) {
+    console.log(
+      `skipping ${noMilestone.length} version(s) with no milestone found (kept, not deleted):`,
+    )
+    for (const { hit } of noMilestone) {
+      console.log('  %s  versionName=%s', hit._id, hit._source.versionName)
+    }
+  }
+
+  console.log(
+    `${stale.length} of ${hits.length} unpublished version(s) are older than ${argv.olderThan} week(s):`,
+  )
+  for (const { hit, age } of stale) {
+    console.log(
+      '  %s  versionName=%s  revokedAt/createdAt=%s',
+      hit._id,
+      hit._source.versionName,
+      age.toISOString(),
+    )
+  }
+
+  if (!stale.length) {
+    console.log('nothing to delete')
+    return
+  }
+
+  if (!argv.delete) {
+    console.log(
+      `\n[dry run] ${stale.length} version(s) would be deleted. Re-run with --delete to remove them.`,
+    )
+    return
+  }
+
+  const confirmed = await confirm(
+    `\nDelete ${stale.length} document version(s) for repoId "${argv.repoId}"? This cannot be undone.`,
+  )
+
+  if (!confirmed) {
+    console.log('aborted, nothing was deleted')
+    return
+  }
+
+  const deleteStats = await deleteInBatches(stale.map(({ hit }) => hit))
+
+  console.log('\nsummary', {
+    repoId: argv.repoId,
+    unpublished: hits.length,
+    stale: stale.length,
+    skippedNoMilestone: noMilestone.length,
+    deleted: deleteStats.deleted,
+    errors: deleteStats.errors,
+  })
+}
+
+run()
+  .catch((e) => {
+    throw e
+  })
+  .finally(() => elastic.close())


### PR DESCRIPTION
Old, superseded document versions are never deleted from republik-document-write, only flagged unpublished. For frequently republished repoIds (e.g. republik/magazine) this backlog grows unbounded, making Documents.js's afterScheduled _update_by_query eventually exceed Elasticsearch's coordinating-node circuit breaker (es_rejected_execution_exception, HTTP 429) on every publish.

Adds a list-by-default/--delete-gated maintenance script that finds fully-unpublished versions per repoId and deletes stale ones in small bulk-API batches instead of a single _delete_by_query. Age is determined via publikator.milestones.revokedAt (fallback createdAt) rather than meta.publishDate, which turned out to be fixed content metadata identical across hundreds of versions of the same repoId.