### PR TITLE
use goto url instead of cdn url for calendar files

### DIFF
--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -11,6 +11,9 @@ API_GATEWAY_TOKEN=
 # Used for external refs and enforing correct protocol and hostname
 NEXT_PUBLIC_BASE_URL=http://localhost:3010
 
+# Used for links that should open *outside* of the app but redirect back to www
+NEXT_PUBLIC_GOTO_BASE_URL=http://localhost:3010
+
 # Used for links to the shop
 NEXT_PUBLIC_SHOP_BASE_URL=http://localhost:3000
 

--- a/apps/www/src/app/challenge-accepted/components/teasers/event-teaser.tsx
+++ b/apps/www/src/app/challenge-accepted/components/teasers/event-teaser.tsx
@@ -169,11 +169,9 @@ export const EventTeaser = ({ isMember, event }: EventProps) => {
             })}
             // Link to the calendar file via CDN because the app can't handle downloads. This way, the file will be opened in the OS browser.
             // To bust the CDN cache, ?v= is added with the timestamp when the event record was updated.
-            href={`${
-              process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL
-            }/veranstaltungen/${event.slug}/ics?v=${encodeURIComponent(
-              event._updatedAt,
-            )}`}
+            href={`${process.env.NEXT_PUBLIC_GOTO_BASE_URL}/veranstaltungen/${
+              event.slug
+            }/ics?v=${encodeURIComponent(event._updatedAt)}`}
           >
             <IconCalendar size={20} /> Zum Kalender hinzufügen
           </Link>

--- a/apps/www/src/app/veranstaltungen/components/event-teaser.tsx
+++ b/apps/www/src/app/veranstaltungen/components/event-teaser.tsx
@@ -217,11 +217,9 @@ export const EventTeaser = ({ isPage, isMember, event }: EventProps) => {
             })}
             // Link to the calendar file via CDN because the app can't handle downloads. This way, the file will be opened in the OS browser.
             // To bust the CDN cache, ?v= is added with the timestamp when the event record was updated.
-            href={`${
-              process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL
-            }/veranstaltungen/${event.slug}/ics?v=${encodeURIComponent(
-              event._updatedAt,
-            )}`}
+            href={`${process.env.NEXT_PUBLIC_GOTO_BASE_URL}/veranstaltungen/${
+              event.slug
+            }/ics?v=${encodeURIComponent(event._updatedAt)}`}
           >
             <IconCalendar size={20} /> Zum Kalender hinzufügen
           </Link>


### PR DESCRIPTION
This avoids ics (calendar) files being requested via CDN → asset server → CF → www. CF blocks the asset server as "verified bot traffic", so the files can't be downloaded.

Using the goto.republik.ch URL is necessary, so links to ics files don't open inside the app.