### PR TITLE
feat(assets): send custom User-Agent on outgoing asset requests

### DIFF
--- a/apps/assets/.env.example
+++ b/apps/assets/.env.example
@@ -1,6 +1,9 @@
 # Commented envs are optional
 PORT=5020
 
+# custom User-Agent sent on all outgoing asset requests (proxy, frontend, s3, render)
+#ASSETS_USER_AGENT=Republik-Assets/1.0 (+https://www.republik.ch)
+
 #############
 # auth
 #############

--- a/apps/assets/express/frontend.js
+++ b/apps/assets/express/frontend.js
@@ -1,4 +1,4 @@
-const { returnImage } = require('@orbiting/backend-modules-assets/lib')
+const { returnImage, userAgent } = require('@orbiting/backend-modules-assets/lib')
 const {
   FRONTEND_BASE_URL,
   FRONTEND_BASIC_AUTH_USER,
@@ -29,6 +29,7 @@ module.exports = (server) => {
     const result = await fetch(encodeURI(frontendUrl), {
       method: 'GET',
       headers: {
+        'User-Agent': userAgent,
         Authorization:
           FRONTEND_BASIC_AUTH_USER && FRONTEND_BASIC_AUTH_PASS
             ? `Basic ${Buffer.from(

--- a/apps/assets/express/proxy.js
+++ b/apps/assets/express/proxy.js
@@ -2,6 +2,7 @@ const debug = require('debug')('assets:proxy')
 const {
   authenticate,
   returnImage,
+  userAgent,
 } = require('@orbiting/backend-modules-assets/lib')
 
 module.exports = (server) => {
@@ -20,6 +21,9 @@ module.exports = (server) => {
     debug('GET %s', url)
     const result = await fetch(url, {
       method: 'GET',
+      headers: {
+        'User-Agent': userAgent,
+      },
     }).catch((error) => {
       console.error('proxy fetch failed', { error })
       return res.status(404).end()

--- a/packages/backend-modules/assets/lib/index.js
+++ b/packages/backend-modules/assets/lib/index.js
@@ -5,6 +5,7 @@ const returnImage = require('./returnImage')
 const urlPrefixing = require('./urlPrefixing')
 const webp = require('./webp')
 const Repo = require('./Repo')
+const userAgent = require('./userAgent')
 
 module.exports = {
   Portrait,
@@ -14,5 +15,6 @@ module.exports = {
   webp,
   Repo,
   urlPrefixing,
+  userAgent,
   ...urlPrefixing,
 }

--- a/packages/backend-modules/assets/lib/s3.js
+++ b/packages/backend-modules/assets/lib/s3.js
@@ -1,4 +1,5 @@
 const aws = require('aws-sdk')
+const userAgent = require('./userAgent')
 
 const { AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_BUCKET } =
   process.env
@@ -99,6 +100,9 @@ const del = async ({ path, bucket }) => {
 const get = ({ region = AWS_REGION, bucket, path }) => {
   return fetch(`https://s3.${region}.amazonaws.com/${bucket}/${path}`, {
     method: 'GET',
+    headers: {
+      'User-Agent': userAgent,
+    },
   }).catch((error) => {
     return {
       status: 404,

--- a/packages/backend-modules/assets/lib/screenshot/chromium.js
+++ b/packages/backend-modules/assets/lib/screenshot/chromium.js
@@ -1,3 +1,5 @@
+const userAgent = require('../userAgent')
+
 const { CHROMIUM_LAMBDA_URL } = process.env
 
 if (!CHROMIUM_LAMBDA_URL) {
@@ -18,7 +20,11 @@ const render = (params) => {
     }
   }
 
-  return fetch(url.toString()).then((res) => {
+  return fetch(url.toString(), {
+    headers: {
+      'User-Agent': userAgent,
+    },
+  }).then((res) => {
     if (!res.ok) {
       throw new Error(
         `render failed with status ${res.status} - ${res.statusText}`,

--- a/packages/backend-modules/assets/lib/userAgent.js
+++ b/packages/backend-modules/assets/lib/userAgent.js
@@ -1,0 +1,3 @@
+const { ASSETS_USER_AGENT } = process.env
+
+module.exports = ASSETS_USER_AGENT || 'Republik-Assets/1.0 (+https://www.republik.ch)'


### PR DESCRIPTION
Introduce a shared `userAgent` helper (configurable via ASSETS_USER_AGENT, falling back to a default) and apply it to all outgoing fetch calls in the asset server: /proxy, /frontend, S3 fetches, and the chromium render lambda. Previously these went out with Node's default User-Agent.