### PR TITLE
Fix static asset loading when deployed on Heroku

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -6,13 +6,17 @@ const { withPlausibleProxy } = require('next-plausible')
 
 const isProduction = process.env.NODE_ENV === 'production'
 
-const buildId =
+const deploymentId =
   // Git commit hash on Heroku
+  process.env.SOURCE_COMMIT?.substring(0, 10) ||
   process.env.SOURCE_VERSION?.substring(0, 10) ||
+  process.env.HEROKU_BUILD_COMMIT?.substring(0, 10) ||
   // ... and on Vercel
   process.env.NEXT_DEPLOYMENT_ID ||
   process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 10) ||
-  `${Date.now()}`
+  undefined
+
+console.log('Using Next.js deployment ID', deploymentId)
 
 function appendProtocol(href) {
   if (href && !href.startsWith('http')) {
@@ -38,10 +42,9 @@ const PUBLIC_CDN_URL = process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL
  */
 const nextConfig = {
   // deploymentId for Skew protection: this will trigger a hard refresh when outdated clients navigate. See https://nextjs.org/docs/app/guides/self-hosting#version-skew
-  deploymentId: buildId,
-  generateBuildId: () => buildId,
+  deploymentId,
   env: {
-    BUILD_ID: buildId,
+    BUILD_ID: deploymentId,
     PUBLIC_BASE_URL,
     PUBLIC_CDN_URL,
   },

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -16,6 +16,8 @@ const deploymentId =
   process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 10) ||
   undefined
 
+process.env.NEXT_DEPLOYMENT_ID = deploymentId
+
 console.log('Using Next.js deployment ID', deploymentId)
 
 function appendProtocol(href) {

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -16,8 +16,6 @@ const deploymentId =
   process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 10) ||
   undefined
 
-process.env.NEXT_DEPLOYMENT_ID = deploymentId
-
 console.log('Using Next.js deployment ID', deploymentId)
 
 function appendProtocol(href) {

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -33,10 +33,6 @@ const PUBLIC_BASE_URL = appendProtocol(
     `https://${process.env.HEROKU_APP_NAME}.herokuapp.com`,
 )
 
-const PUBLIC_CDN_URL = process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL
-  ? appendProtocol(process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL)
-  : ''
-
 /**
  * @type {import('next').NextConfig}
  */
@@ -44,13 +40,12 @@ const nextConfig = {
   // deploymentId for Skew protection: this will trigger a hard refresh when outdated clients navigate. See https://nextjs.org/docs/app/guides/self-hosting#version-skew
   deploymentId,
   env: {
-    BUILD_ID: deploymentId,
+    DEPLOYMENT_ID: deploymentId,
     PUBLIC_BASE_URL,
-    PUBLIC_CDN_URL,
   },
 
   poweredByHeader: false,
-  assetPrefix: isProduction ? PUBLIC_CDN_URL : undefined,
+
   // Maximum amount of time where stale content is allowed to be served from cache (CDN, browser etc.)
   expireTime: 60,
   images: {

--- a/apps/www/src/lib/apollo/index.ts
+++ b/apps/www/src/lib/apollo/index.ts
@@ -8,7 +8,7 @@ import { createAppWorkerLink } from './appWorkerLink'
 
 export const { initializeApollo, withApollo } = createApolloClientUtilities({
   name: '@orbiting/www-app',
-  version: process.env.BUILD_ID,
+  version: process.env.DEPLOYMENT_ID,
   apiUrl: isClient ? '/graphql' : API_URL,
   wsUrl: API_WS_URL,
   headers: isClient

--- a/apps/www/src/lib/constants.js
+++ b/apps/www/src/lib/constants.js
@@ -12,7 +12,8 @@ export const APP_OPTIONS =
   process.env.NEXT_PUBLIC_APP_OPTIONS !== '0'
 
 export const PUBLIC_BASE_URL = process.env.PUBLIC_BASE_URL
-export const CDN_FRONTEND_BASE_URL = process.env.PUBLIC_CDN_URL
+export const CDN_FRONTEND_BASE_URL =
+  process.env.NEXT_PUBLIC_CDN_FRONTEND_BASE_URL ?? ''
 export const RENDER_FRONTEND_BASE_URL =
   process.env.NEXT_PUBLIC_RENDER_FRONTEND_BASE_URL || PUBLIC_BASE_URL
 


### PR DESCRIPTION
This fixes a problem where an out-of-date version of the Next.js `_buildManifest.js` file could be served to the user which would lead to 404 errors when trying to load JS assets. Usually, things would still work but client-side page navigations were failing because of this.

The fix has several components:
- Part 1 of the fix is to remove the `assetPrefix` config. Using `NEXT_PUBLIC_CDN_FRONTEND_BASE_URL` resulted in unnecessary requests from KeyCDN → Asset Server → CloudFlare → www. Somewhere in that chain, a stale build manifest was cached (last modified 21 May 😬) and served. Using kcdn and the Asset Server is entirely unnecessary here, removing them solved the issue (at least initially). My suspicion is that the `?dpl` request param gets dropped by the Asset Server, leading CF to always serve a cached build manifest.
- Part 2 was that `deploymentId` was inconsistent between build and runtime which is due to some Heroku env vars not being available during runtime. Therefore the frontend never used a correct deployment ID to request fresh assets. The fix was to enable [Heroku Dyno Runtime Metadata](https://devcenter.heroku.com/articles/dyno-metadata), so the commit SHA is now available during build *and* runtime.
- Not critical but I removed the `generateBuildId` config since that does nothing when `deploymentId` is set.